### PR TITLE
Add express-get-populated-blocks RPC endpoint

### DIFF
--- a/src/neo2/ExpressNodeRpcPlugin.cs
+++ b/src/neo2/ExpressNodeRpcPlugin.cs
@@ -426,6 +426,23 @@ namespace Neo2Express
             }
         }
 
+        private JObject OnGetPopulatedBlocks(JArray @params)
+        {
+            var populatedBlocks = new JArray();
+            using (var snapshot = Blockchain.Singleton.GetSnapshot())
+            {
+                foreach (var kvp in snapshot.Blocks.Find())
+                {
+                    var block = kvp.Value.TrimmedBlock;
+                    if (block.Hashes.Length > 1)
+                    {
+                        populatedBlocks.Add(block.Index);
+                    }
+                }
+            }
+            return populatedBlocks;
+        }
+
         JObject? IRpcPlugin.OnProcess(HttpContext context, string method, JArray @params)
         {
             switch (method)
@@ -459,6 +476,8 @@ namespace Neo2Express
                     return OnGetContractStorage(@params);
                 case "express-create-checkpoint":
                     return OnCheckpointCreate(@params);
+                case "express-get-populated-blocks":
+                    return OnGetPopulatedBlocks(@params);
             }
 
             return null;

--- a/src/neo2/ExpressNodeRpcPlugin.cs
+++ b/src/neo2/ExpressNodeRpcPlugin.cs
@@ -441,25 +441,6 @@ namespace Neo2Express
             return populatedBlocks;
         }
 
-        private JObject OnListContracts(JArray @params)
-        {
-            var contracts = new JArray();
-            using var snapshot = Blockchain.Singleton.GetSnapshot();
-            foreach (var kvp in snapshot.Contracts.Find())
-            {
-                var json = new JObject();
-                foreach (var prop in kvp.Value.ToJson().Properties)
-                {
-                    if (prop.Key != "script")
-                    {
-                        json[prop.Key] = prop.Value;
-                    }
-                }
-                contracts.Add(json);
-            }
-            return contracts;
-        }
-
         JObject? IRpcPlugin.OnProcess(HttpContext context, string method, JArray @params)
         {
             switch (method)
@@ -495,8 +476,6 @@ namespace Neo2Express
                     return OnCheckpointCreate(@params);
                 case "express-get-populated-blocks":
                     return OnGetPopulatedBlocks(@params);
-                case "express-list-contracts":
-                    return OnListContracts(@params);
             }
 
             return null;


### PR DESCRIPTION
Adds a custom RPC endpoint for neo-express to enable [visual devtracker](https://github.com/neo-project/neo-visual-tracker/) to retrieve a list of non-empty blocks quickly. Needed for [visual devtracker bug 16](https://github.com/neo-project/neo-visual-tracker/issues/16)

Fixes #16 