### PR TITLE
mark debug port as DefaultValueHandling.Ignore 

### DIFF
--- a/src/abstractions/Models/ExpressConsensusNode.cs
+++ b/src/abstractions/Models/ExpressConsensusNode.cs
@@ -13,7 +13,7 @@ namespace NeoExpress.Abstractions.Models
         [JsonProperty("rpc-port")]
         public ushort RpcPort { get; set; }
 
-        [JsonProperty("debug-port")]
+        [JsonProperty("debug-port", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ushort DebugPort { get; set; }
 
         [JsonProperty("wallet")]

--- a/src/neo2/BlockchainOperations.cs
+++ b/src/neo2/BlockchainOperations.cs
@@ -54,7 +54,6 @@ namespace Neo2Express
                         TcpPort = GetPortNumber(i, 333),
                         WebSocketPort = GetPortNumber(i, 334),
                         RpcPort = GetPortNumber(i, 332),
-                        DebugPort = GetPortNumber(i, 335),
                         Wallet = wallets[i].wallet.ToExpressWallet()
                     });
                 }


### PR DESCRIPTION
fixes #7 

With this change:
* new neo-express instances will not write out a debug-port value for their consensus nodes
* existing neo-express instances will maintain a non-zero debug-port value in their consensus nodes when updating the json file in any way (for example, creating a new wallet)
* existing neo-express instances with a zero debug-port value in their consensus nodes will remove the debug-port property entirely when updating the json file in any way (for example, creating a new wallet)
