### PR TITLE
read metadata from .abi.json

### DIFF
--- a/src/neo-express/Extensions.cs
+++ b/src/neo-express/Extensions.cs
@@ -313,6 +313,22 @@ namespace NeoExpress
                         }).ToList()
                     };
 
+                    static Dictionary<string, string> ToExpressContractProperties(AbiContract.ContractMetadata? metadata)
+                    {
+                        return metadata == null
+                            ? new Dictionary<string, string>()
+                            : new Dictionary<string, string>()
+                            {
+                                { "title", metadata.Title },
+                                { "description", metadata.Description },
+                                { "version", metadata.Version },
+                                { "email", metadata.Email },
+                                { "author", metadata.Author },
+                                { "has-storage", metadata.HasStorage.ToString() },
+                                { "has-dynamic-invoke", metadata.HasDynamicInvoke.ToString() },
+                            };
+                    }
+
                     string abiFile = Path.ChangeExtension(avmFile, ".abi.json");
                     if (!File.Exists(abiFile))
                     {
@@ -336,7 +352,7 @@ namespace NeoExpress
                         ContractData = File.ReadAllBytes(avmFile).ToHexString(),
                         Functions = abiContract.Functions.Select(ToExpressContractFunction).ToList(),
                         Events = abiContract.Events.Select(ToExpressContractFunction).ToList(),
-                        Properties = new Dictionary<string, string>()
+                        Properties = ToExpressContractProperties(abiContract.Metadata),
                     };
                 },
                 error =>

--- a/src/neo-express/Models/AbiContract.cs
+++ b/src/neo-express/Models/AbiContract.cs
@@ -5,6 +5,33 @@ namespace NeoExpress.Models
 {
     public class AbiContract
     {
+        public class ContractMetadata
+        {
+            [JsonProperty("title")]
+            public string Title { get; set; } = string.Empty;
+
+            [JsonProperty("description")]
+            public string Description { get; set; } = string.Empty;
+
+            [JsonProperty("version")]
+            public string Version { get; set; } = string.Empty;
+
+            [JsonProperty("author")]
+            public string Author { get; set; } = string.Empty;
+
+            [JsonProperty("email")]
+            public string Email { get; set; } = string.Empty;
+
+            [JsonProperty("has-storage")]
+            public bool HasStorage { get; set; }
+
+            [JsonProperty("has-dynamic-invoke")]
+            public bool HasDynamicInvoke { get; set; }
+
+            [JsonProperty("is-payable")]
+            public bool IsPayable { get; set; }
+        }
+
         public class Parameter
         {
             [JsonProperty("name")]
@@ -28,6 +55,9 @@ namespace NeoExpress.Models
 
         [JsonProperty("hash")]
         public string Hash { get; set; } = string.Empty;
+
+        [JsonProperty("metadata")]
+        public ContractMetadata? Metadata { get; set; }
 
         [JsonProperty("entrypoint")]
         public string Entrypoint { get; set; } = string.Empty;


### PR DESCRIPTION
This PR updates neo-express to read the contract metadata that has [recently been added](https://github.com/neo-project/neo-devpack-dotnet/pull/148) to neon. Will still query user if storage and/or dynamic invoke info is missing from abi.json file (for example, if the user is using an earlier version of neon or neon-de). 

Also adds an --overwrite flag to avoid prompting the user when when deploying a contract that has previously been deployed with the same name but different contract hash