### PR TITLE
add count and start parameters to get-populated-blocks

### DIFF
--- a/src/neo-express/Node/ExpressNodeRpcPlugin.cs
+++ b/src/neo-express/Node/ExpressNodeRpcPlugin.cs
@@ -428,14 +428,30 @@ namespace NeoExpress.Node
 
         private JObject OnGetPopulatedBlocks(JArray @params)
         {
-            var populatedBlocks = new JArray();
             using var snapshot = Blockchain.Singleton.GetSnapshot();
-            foreach (var kvp in snapshot.Blocks.Find())
+
+            var count = @params.Count >= 1 ? uint.Parse(@params[0].AsString()) : 20;
+            count = count > 100 ? 100 : count;
+
+            var start = @params.Count >= 2 ? uint.Parse(@params[1].AsString()) : snapshot.Height;
+            start = start > snapshot.Height ? snapshot.Height : start;
+
+            var populatedBlocks = new JArray();
+            while (populatedBlocks.Count < count)
             {
-                var block = kvp.Value.TrimmedBlock;
-                if (block.Hashes.Length > 1)
+                var block = snapshot.GetBlock(start);
+                if (block.Transactions.Length > 1)
                 {
                     populatedBlocks.Add(block.Index);
+                }
+
+                if (start == 0)
+                {
+                    break;
+                }
+                else
+                {
+                    start--;
                 }
             }
             return populatedBlocks;


### PR DESCRIPTION
instead of getting all the populated blocks in a single call, modify get-populated-blocks to take count and start parameters to specify how the maximum number of blocks to retrieve and what block index to start from 

fixes #35 