### PR TITLE
Add GAS preload support

### DIFF
--- a/src/neo-express/BlockchainOperations.cs
+++ b/src/neo-express/BlockchainOperations.cs
@@ -296,14 +296,14 @@ namespace NeoExpress
             }
         }
 
-        public static Task RunBlockchainAsync(string directory, ExpressChain chain, int index, uint secondsPerBlock, TextWriter writer, CancellationToken cancellationToken)
+        public static Task RunBlockchainAsync(string directory, ExpressChain chain, int index, uint secondsPerBlock, uint preloadGas, TextWriter writer, CancellationToken cancellationToken)
         {
             chain.InitializeProtocolSettings(secondsPerBlock);
 
             var node = chain.ConsensusNodes[index];
 
 #pragma warning disable IDE0067 // NodeUtility.RunAsync disposes the store when it's done
-            return NodeUtility.RunAsync(new RocksDbStore(directory), node, writer, cancellationToken);
+            return NodeUtility.RunAsync(new RocksDbStore(directory), node, writer, preloadGas, cancellationToken);
 #pragma warning restore IDE0067 // Dispose objects before losing scope
         }
 
@@ -315,7 +315,7 @@ namespace NeoExpress
             ValidateCheckpoint(directory, chain.Magic, node.Wallet.DefaultAccount);
 
 #pragma warning disable IDE0067 // NodeUtility.RunAsync disposes the store when it's done
-            return NodeUtility.RunAsync(new CheckpointStore(directory), node, writer, cancellationToken);
+            return NodeUtility.RunAsync(new CheckpointStore(directory), node, writer, 0, cancellationToken);
 #pragma warning restore IDE0067 // Dispose objects before losing scope
         }
 

--- a/src/neo-express/Commands/RunCommand.cs
+++ b/src/neo-express/Commands/RunCommand.cs
@@ -19,6 +19,9 @@ namespace NeoExpress.Commands
         private uint SecondsPerBlock { get; }
 
         [Option]
+        private uint PreloadGas { get; }
+
+        [Option]
         private bool Reset { get; }
 
         private async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
@@ -55,8 +58,8 @@ namespace NeoExpress.Commands
                 {
                     console.CancelKeyPress += (sender, args) => cts.Cancel();
 
-                    await BlockchainOperations.RunBlockchainAsync(folder, chain, index, SecondsPerBlock, console.Out,
-                                                                  cts.Token)
+                    await BlockchainOperations.RunBlockchainAsync(folder, chain, index, SecondsPerBlock, PreloadGas, 
+                                                                  console.Out, cts.Token)
                         .ConfigureAwait(false);
                 }
 

--- a/src/neo-express/Node/ExpressNodeRpcPlugin.cs
+++ b/src/neo-express/Node/ExpressNodeRpcPlugin.cs
@@ -313,7 +313,7 @@ namespace NeoExpress.Node
                 return JObject.Parse(json);
             }
 
-            throw new Exception("Unknown transaction");
+            return JObject.Null;
         }
 
         public JObject OnGetUnspents(JArray @params)

--- a/src/neo-express/Node/NodeUtility.cs
+++ b/src/neo-express/Node/NodeUtility.cs
@@ -149,12 +149,11 @@ namespace NeoExpress.Node
 
                         using (var snapshot = Blockchain.Singleton.GetSnapshot())
                         {
-                            var lastBlock = Blockchain.Singleton.GetBlock(snapshot.CurrentBlockHash);
-                            var validators = snapshot.GetValidators();
-                            if (lastBlock.Index == 0 && validators.Length == 1)
+                            if (PreloadValid())
                             {
-                                Plugin.Log("neo-express", LogLevel.Info, "Creating 1000 empty blocks to preload GAS");
-                                for (int i = 0; i < 125; i++)
+                                var preloadCount = 125;
+                                Plugin.Log("neo-express", LogLevel.Info, $"Creating {preloadCount} empty blocks to preload GAS");
+                                for (int i = 0; i < preloadCount; i++)
                                 {
                                     var block = CreatePreloadBlock(wallet);
                                     var reason = system.Blockchain.Ask<RelayResultReason>(block).Result;

--- a/src/neo-express/Node/NodeUtility.cs
+++ b/src/neo-express/Node/NodeUtility.cs
@@ -134,7 +134,7 @@ namespace NeoExpress.Node
                     throw new InvalidOperationException("Preload only supported for single-node blockchains");
                 }
 
-                var account = wallet.GetAccounts().Single(a => a.Label == "MultiSigContract");
+                var account = wallet.GetAccounts().Single(a => a.Contract.Script.IsMultiSigContract());
 
                 var tx = factory(snapshot, account);
                 if (tx == null)


### PR DESCRIPTION
This PR adds a --preload-gas support that will add enough blocks after the genesis block to give the genesis account the specified amount of gas. Note, the gas will be unavailable to start - the user will still needs to execute a transfer to release the GAS for claiming. 

Question for reviewers: Should we cap the amount of gas / blocks the user can specify? On my dev box, it takes about a second to add 200 blocks, which creates 1600 GAS. If we cap at 10 seconds (on my machine) that's around 2,000 blocks / 16,000 GAS

fixes #40 