### PR TITLE
Use sendRawTransaction RPC endpoint for transfer, claim and contract deployment

### DIFF
--- a/src/neo-express/BlockchainOperations.cs
+++ b/src/neo-express/BlockchainOperations.cs
@@ -334,6 +334,5 @@ namespace NeoExpress
             return NodeUtility.RunAsync(new CheckpointStore(directory), node, writer, cancellationToken);
 #pragma warning restore IDE0067 // Dispose objects before losing scope
         }
-
     }
 }

--- a/src/neo-express/Commands/ClaimCommand.cs
+++ b/src/neo-express/Commands/ClaimCommand.cs
@@ -41,8 +41,8 @@ namespace NeoExpress.Commands
                     throw new Exception($"could not retrieve claimable for {Account}");
                 }
 
-                var (_, gasHash) = await NeoRpcClient.GetStandardAssetHashes(uri);
-                var tx = RpcTransactionManager.CreateClaimTransaction(account, claimable, Neo.UInt256.Parse(gasHash));
+                var gasHash = Neo.Ledger.Blockchain.UtilityToken.Hash;
+                var tx = RpcTransactionManager.CreateClaimTransaction(account, claimable, gasHash);
                 tx.Witnesses = new[] { RpcTransactionManager.GetWitness(tx, chain, account) };
                 var sendResult = await NeoRpcClient.SendRawTransaction(uri, tx);
                 if (sendResult == null || !sendResult.Value<bool>())

--- a/src/neo-express/Commands/ClaimCommand.cs
+++ b/src/neo-express/Commands/ClaimCommand.cs
@@ -41,7 +41,8 @@ namespace NeoExpress.Commands
                     throw new Exception($"could not retrieve claimable for {Account}");
                 }
 
-                var tx = RpcTransactionManager.CreateClaimTransaction(account, claimable);
+                var (_, gasHash) = await NeoRpcClient.GetStandardAssetHashes(uri);
+                var tx = RpcTransactionManager.CreateClaimTransaction(account, claimable, Neo.UInt256.Parse(gasHash));
                 tx.Witnesses = new[] { RpcTransactionManager.GetWitness(tx, chain, account) };
                 var sendResult = await NeoRpcClient.SendRawTransaction(uri, tx);
                 if (sendResult == null || !sendResult.Value<bool>())

--- a/src/neo-express/Commands/ContractCommand.Deploy.cs
+++ b/src/neo-express/Commands/ContractCommand.Deploy.cs
@@ -80,7 +80,6 @@ namespace NeoExpress.Commands
                     contract.Properties.Add("has-dynamic-invoke", hasStorage.ToString());
                 }
 
-                var (_, gasHash) = await NeoRpcClient.GetStandardAssetHashes(uri);
                 var unspents = (await NeoRpcClient.GetUnspents(uri, account.ScriptHash)
                     .ConfigureAwait(false))?.ToObject<UnspentsResponse>();
                 if (unspents == null)
@@ -89,7 +88,7 @@ namespace NeoExpress.Commands
                 }
 
                 var tx = RpcTransactionManager.CreateDeploymentTransaction(contract, 
-                    account, unspents, Neo.UInt256.Parse(gasHash));
+                    account, unspents);
                 tx.Witnesses = new[] { RpcTransactionManager.GetWitness(tx, chain, account) };
                 var sendResult = await NeoRpcClient.SendRawTransaction(uri, tx);
                 if (sendResult == null || !sendResult.Value<bool>())

--- a/src/neo-express/Commands/ShowCommand.Transaction.cs
+++ b/src/neo-express/Commands/ShowCommand.Transaction.cs
@@ -1,0 +1,45 @@
+using McMaster.Extensions.CommandLineUtils;
+using System;
+using System.Threading.Tasks;
+
+namespace NeoExpress.Commands
+{
+    partial class ShowCommand
+    {
+        [Command("transaction", "tx")]
+        private class Transaction
+        {
+            [Option]
+            private string Input { get; } = string.Empty;
+
+            [Argument(0)]
+            private string TransactionId { get; } = string.Empty;
+
+            private async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
+            {
+                try
+                {
+                    var (chain, _) = Program.LoadExpressChain(Input);
+                    var uri = chain.GetUri();
+
+                    var response = await NeoRpcClient.GetRawTransaction(uri, TransactionId);
+                    if (response == null)
+                    {
+                        console.WriteWarning("Requested transaction does not exist or has not been processed.");
+                    }
+                    else
+                    {
+                        console.WriteResult(response);
+                    }
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    console.WriteError(ex.Message);
+                    app.ShowHelp();
+                    return 1;
+                }
+            }
+        }
+    }
+}

--- a/src/neo-express/Commands/ShowCommand.cs
+++ b/src/neo-express/Commands/ShowCommand.cs
@@ -9,8 +9,13 @@ using System.Threading.Tasks;
 namespace NeoExpress.Commands
 {
     [Command("show")]
-    [Subcommand(typeof(Account), typeof(Claimable), typeof(Coins), typeof(Gas), typeof(Unspents))]
-    class ShowCommand
+    [Subcommand(typeof(Account), 
+        typeof(Claimable), 
+        typeof(Coins), 
+        typeof(Gas), 
+        typeof(Transaction), 
+        typeof(Unspents))]
+    partial class ShowCommand
     {
         private int OnExecute(CommandLineApplication app, IConsole console)
         {

--- a/src/neo-express/Commands/TransferCommand.cs
+++ b/src/neo-express/Commands/TransferCommand.cs
@@ -51,7 +51,7 @@ namespace NeoExpress.Commands
                     .ConfigureAwait(false))?.ToObject<UnspentsResponse>();
                 if (unspents == null)
                 {
-                    throw new Exception("could not retrieve unspents");
+                    throw new Exception($"could not retrieve unspents for {Sender}");
                 }
 
                 var assetId = NodeUtility.GetAssetId(Asset);

--- a/src/neo-express/Commands/TransferCommand.cs
+++ b/src/neo-express/Commands/TransferCommand.cs
@@ -54,12 +54,8 @@ namespace NeoExpress.Commands
                 }
 
                 var assetId = await NeoRpcClient.GetAssetId(uri, Asset);
-                var balance = unspents.Balance.SingleOrDefault(b => Neo.UInt256.Parse(b.AssetHash) == assetId);
-                if (balance == null)
-                    throw new Exception($"{Sender} does not have any {Asset}");
-
                 var tx = RpcTransactionManager.CreateContractTransaction(
-                        assetId, Quantity, balance.Transactions, senderAccount, receiverAccount);
+                        assetId, Quantity, unspents, senderAccount, receiverAccount);
 
                 tx.Witnesses = new[] { RpcTransactionManager.GetWitness(tx, chain, senderAccount) };
                 var sendResult = await NeoRpcClient.SendRawTransaction(uri, tx);

--- a/src/neo-express/Commands/TransferCommand.cs
+++ b/src/neo-express/Commands/TransferCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using NeoExpress.Models;
+using NeoExpress.Node;
 
 namespace NeoExpress.Commands
 {
@@ -53,7 +54,7 @@ namespace NeoExpress.Commands
                     throw new Exception($"could not retrieve unspents for {Sender}");
                 }
 
-                var assetId = await NeoRpcClient.GetAssetId(uri, Asset);
+                var assetId = NodeUtility.GetAssetId(Asset);
                 var tx = RpcTransactionManager.CreateContractTransaction(
                         assetId, Quantity, unspents, senderAccount, receiverAccount);
 

--- a/src/neo-express/Commands/TransferCommand.cs
+++ b/src/neo-express/Commands/TransferCommand.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using NeoExpress.Models;
-using NeoExpress.Node;
 
 namespace NeoExpress.Commands
 {
@@ -54,7 +53,7 @@ namespace NeoExpress.Commands
                     throw new Exception($"could not retrieve unspents for {Sender}");
                 }
 
-                var assetId = NodeUtility.GetAssetId(Asset);
+                var assetId = await NeoRpcClient.GetAssetId(uri, Asset);
                 var balance = unspents.Balance.SingleOrDefault(b => Neo.UInt256.Parse(b.AssetHash) == assetId);
                 if (balance == null)
                     throw new Exception($"{Sender} does not have any {Asset}");

--- a/src/neo-express/Models/ClaimableTransaction.cs
+++ b/src/neo-express/Models/ClaimableTransaction.cs
@@ -9,24 +9,24 @@ namespace NeoExpress.Models
         public string TransactionId { get; set; } = string.Empty;
 
         [JsonProperty("n")]
-        public long Index { get; set; }
+        public ushort Index { get; set; }
 
         [JsonProperty("value")]
         public decimal Value { get; set; }
 
         [JsonProperty("start_height")]
-        public long StartHeight { get; set; }
+        public uint StartHeight { get; set; }
 
         [JsonProperty("end_height")]
-        public long EndHeight { get; set; }
+        public uint EndHeight { get; set; }
 
         [JsonProperty("generated")]
-        public double Generated { get; set; }
+        public decimal Generated { get; set; }
 
         [JsonProperty("sys_fee")]
-        public double SystemFee { get; set; }
+        public decimal SystemFee { get; set; }
 
         [JsonProperty("unclaimed")]
-        public double Unclaimed { get; set; }
+        public decimal Unclaimed { get; set; }
     }
 }

--- a/src/neo-express/Models/UnspentTransaction.cs
+++ b/src/neo-express/Models/UnspentTransaction.cs
@@ -9,7 +9,7 @@ namespace NeoExpress.Models
         public string TransactionId { get; set; } = string.Empty;
 
         [JsonProperty("n")]
-        public long Index { get; set; }
+        public ushort Index { get; set; }
 
         [JsonProperty("value")]
         public decimal Value { get; set; }

--- a/src/neo-express/NeoRpcClient.cs
+++ b/src/neo-express/NeoRpcClient.cs
@@ -150,9 +150,9 @@ namespace NeoExpress
             return RpcCall(uri, "sendrawtransaction", new JArray(txData));
         }
 
-        public static Task<JToken?> GetRawTransaction(Uri uri, string txid)
+        public static Task<JToken?> GetRawTransaction(Uri uri, string txid, bool verbose = true)
         {
-            return RpcCall(uri, "getrawtransaction", new JArray(txid));            
+            return RpcCall(uri, "getrawtransaction", new JArray(txid, verbose ? 1 : 0));            
         }
     }
 }

--- a/src/neo-express/NeoRpcClient.cs
+++ b/src/neo-express/NeoRpcClient.cs
@@ -154,51 +154,5 @@ namespace NeoExpress
         {
             return RpcCall(uri, "getrawtransaction", new JArray(txid, verbose ? 1 : 0));            
         }
-
-        public static async Task<Neo.UInt256> GetAssetId(Uri uri, string asset)
-        {
-            var (neo, gas) = await GetStandardAssetHashes(uri);
-            if (string.Compare("neo", asset, true) == 0)
-                return Neo.UInt256.Parse(neo);
-
-            if (string.Compare("gas", asset, true) == 0)
-                return Neo.UInt256.Parse(gas);
-
-            return Neo.UInt256.Parse(asset);
-        }
-
-        public static async Task<(string, string)> GetStandardAssetHashes(Uri uri)
-        {
-            var genesisBlock = await RpcCall(uri, "getblock", new JArray(0, 1));
-            if (genesisBlock == null)
-            {
-                throw new Exception("genesis block could not be retrieved");
-            }
-
-            string neoHash = string.Empty, gasHash = string.Empty;
-            foreach (var tx in genesisBlock["tx"] ?? Enumerable.Empty<JToken>())
-            {
-                if (tx.Value<string>("type") == "RegisterTransaction")
-                {
-                    var asset = tx["asset"]?.Value<string>("type") ?? string.Empty;
-                    if (asset == "GoverningToken")
-                    {
-                        neoHash = tx.Value<string>("txid");
-                    }
-                    else if (asset == "UtilityToken")
-                    {
-                        gasHash = tx.Value<string>("txid");
-                    }
-                }
-            }
-
-            if (string.IsNullOrEmpty(neoHash) 
-                || string.IsNullOrEmpty(gasHash))
-            {
-                throw new Exception("Genesis block was missing NEO or GAS RegisterTransaction");
-            }
-
-            return (neoHash, gasHash);
-        }
     }
 }

--- a/src/neo-express/NeoRpcClient.cs
+++ b/src/neo-express/NeoRpcClient.cs
@@ -143,5 +143,16 @@ namespace NeoExpress
         {
             return RpcCall(uri, "getunspents", new JArray(address));
         }
+
+        public static Task<JToken?> SendRawTransaction(Uri uri, Neo.Network.P2P.Payloads.Transaction tx)
+        {
+            var txData = Neo.Helper.ToHexString(Neo.IO.Helper.ToArray(tx));
+            return RpcCall(uri, "sendrawtransaction", new JArray(txData));
+        }
+
+        public static Task<JToken?> GetRawTransaction(Uri uri, string txid)
+        {
+            return RpcCall(uri, "getrawtransaction", new JArray(txid));            
+        }
     }
 }

--- a/src/neo-express/Node/ExpressNodeRpcPlugin.cs
+++ b/src/neo-express/Node/ExpressNodeRpcPlugin.cs
@@ -313,7 +313,13 @@ namespace NeoExpress.Node
                 return JObject.Parse(json);
             }
 
-            return JObject.Null;
+            // I'd rather be returning JObject.Null here, but Neo's RPC plugin
+            // infrastructure can't distingish between null return meaning 
+            // "this plugin doesn't support this method" and JObject.Null return
+            // meaning "this plugin does support this method, but there was a null
+            // return value". So I'm using an empty string as the null response. 
+
+            return string.Empty;
         }
 
         public JObject OnGetUnspents(JArray @params)

--- a/src/neo-express/RpcTransactionManager.cs
+++ b/src/neo-express/RpcTransactionManager.cs
@@ -231,8 +231,10 @@ namespace NeoExpress
             throw new ArgumentException(nameof(quantity));
         }
 
-        public static InvocationTransaction CreateDeploymentTransaction(ExpressContract contract, ExpressWalletAccount sender, UnspentsResponse unspents, UInt256 gasAssetId)
+        public static InvocationTransaction CreateDeploymentTransaction(ExpressContract contract, ExpressWalletAccount sender, UnspentsResponse unspents)
         {
+            var gasAssetId = Neo.Ledger.Blockchain.UtilityToken.Hash;
+            
             using var builder = BuildContractCreateScript(contract);
             var contractPropertyState = GetContractPropertyState(contract);
 

--- a/src/neo-express/RpcTransactionManager.cs
+++ b/src/neo-express/RpcTransactionManager.cs
@@ -92,10 +92,7 @@ namespace NeoExpress
             }
         }
 
-        // TODO: retrieve token hash from genesis block
-        const string GAS_TOKEN_HASH = "602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7";
-
-        public static ClaimTransaction CreateClaimTransaction(ExpressWalletAccount account, ClaimableResponse claimable)
+        public static ClaimTransaction CreateClaimTransaction(ExpressWalletAccount account, ClaimableResponse claimable, UInt256 assetId)
         {
             const int MAX_CLAIMS_AMOUNT = 50;
 
@@ -117,7 +114,7 @@ namespace NeoExpress
                 {
                     new TransactionOutput
                     {
-                        AssetId = Neo.UInt256.Parse(GAS_TOKEN_HASH),
+                        AssetId = assetId,
                         Value = Neo.Fixed8.FromDecimal(claimable.Unclaimed),
                         ScriptHash = Neo.Wallets.Helper.ToScriptHash(account.ScriptHash)
                     }

--- a/src/neo-express/RpcTransactionManager.cs
+++ b/src/neo-express/RpcTransactionManager.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Neo;
+using Neo.Network.P2P.Payloads;
+using NeoExpress.Models;
+using Newtonsoft.Json.Linq;
+
+namespace NeoExpress
+{
+    static class RpcTransactionManager
+    {
+        private static bool IsMultiSigContract(ExpressWalletAccount account) =>
+            Neo.SmartContract.Helper.IsMultiSigContract(account.Contract.Script.ToByteArray());
+
+        static byte[] Sign(byte[] hashData, DevWalletAccount account)
+        {
+            var key = account.GetKey();
+            if (key == null)
+            {
+                throw new Exception("DevWalletAccount missing key");
+            }
+
+            var publicKey = key.PublicKey.EncodePoint(false).AsSpan().Slice(1).ToArray();
+            return Neo.Cryptography.Crypto.Default.Sign(hashData, key.PrivateKey, publicKey);
+        }
+
+
+        public static Witness GetWitness(Transaction tx, ExpressChain chain, ExpressWalletAccount account)
+        {
+            var txHashData = Neo.Network.P2P.Helper.GetHashData(tx);
+            var devAccount = DevWalletAccount.FromExpressWalletAccount(account);
+
+            if (IsMultiSigContract(account))
+            {
+                // neo-express only uses multi sig contracts for consensus nodes
+                var verification = devAccount.Contract.Script;
+                var signatureCount = devAccount.Contract.ParameterList.Length;
+
+                var signatures = chain.ConsensusNodes
+                    .Take(signatureCount)
+                    .Select(node =>
+                    {
+                        var account = DevWalletAccount.FromExpressWalletAccount(node.Wallet.DefaultAccount);
+                        return Sign(txHashData, account);
+                    })
+                    .ToList();
+
+                var invocation = new byte[signatures.Aggregate(0, (a, sig) => a + sig.Length + 1)];
+
+                var curPos = 0;
+                for (int i = 0; i < signatures.Count; i++)
+                {
+                    invocation[curPos] = 0x40;
+                    signatures[i].AsSpan().CopyTo(invocation.AsSpan().Slice(curPos + 1, signatures[i].Length));
+                    curPos += 1 + signatures[i].Length;
+                }
+
+                return new Witness()
+                {
+                    InvocationScript = invocation,
+                    VerificationScript = verification,
+                };
+            }
+            else
+            {
+                static byte[] CreateSignatureRedeemScript(DevWalletAccount account)
+                {
+                    var key = account.GetKey();
+                    if (key == null)
+                    {
+                        throw new Exception("DevWalletAccount missing key");
+                    }
+
+                    using var sb = new Neo.VM.ScriptBuilder();
+                    sb.EmitPush(key.PublicKey.EncodePoint(true));
+                    sb.Emit(Neo.VM.OpCode.CHECKSIG);
+                    return sb.ToArray();
+                }
+
+                var signature = Sign(txHashData, devAccount);
+
+                var invocation = new byte[signature.Length + 1];
+                invocation[0] = 0x40;
+                signature.AsSpan().CopyTo(invocation.AsSpan().Slice(1, signature.Length));
+                var verification = CreateSignatureRedeemScript(devAccount);
+                return new Witness()
+                {
+                    InvocationScript = invocation,
+                    VerificationScript = verification,
+                };
+            }
+        }
+
+        public static ContractTransaction CreateContractTransaction(UInt256 assetId, string quantity, UnspentTransaction[] transactions, ExpressWalletAccount sender, ExpressWalletAccount receiver)
+        {
+            static CoinReference ConvertUnspentTransaction(UnspentTransaction t) => new CoinReference()
+            {
+                PrevHash = UInt256.Parse(t.TransactionId),
+                PrevIndex = t.Index
+            };
+
+            IEnumerable<UnspentTransaction> GetInputs(decimal amount)
+            {
+                foreach (var tx in transactions.OrderByDescending(t => t.Value))
+                {
+                    if (amount < tx.Value)
+                    {
+                        yield return tx;
+                    }
+                    else
+                    {
+                        yield return tx;
+                    }
+
+                    amount -= tx.Value;
+                    if (amount <= decimal.Zero)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            var sum = transactions.Sum(t => t.Value);
+
+            if (quantity.Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ContractTransaction()
+                {
+                    Attributes = Array.Empty<TransactionAttribute>(),
+                    Inputs = transactions.Select(ConvertUnspentTransaction).ToArray(),
+                    Outputs = new TransactionOutput[] {
+                        new TransactionOutput
+                        {
+                            AssetId = assetId,
+                            Value = Neo.Fixed8.FromDecimal(sum),
+                            ScriptHash = Neo.Wallets.Helper.ToScriptHash(receiver.ScriptHash)
+                        }
+                    }
+                };
+            }
+
+            if (decimal.TryParse(quantity, out var result))
+            {
+                if (sum < result)
+                    throw new ApplicationException("Insufficient funds for transfer");
+
+                var inputs = GetInputs(result);
+                sum = inputs.Sum(t => t.Value);
+
+                return new ContractTransaction()
+                {
+                    Attributes = Array.Empty<TransactionAttribute>(),
+                    Inputs = inputs.Select(ConvertUnspentTransaction).ToArray(),
+                    Outputs = new TransactionOutput[] {
+                        new TransactionOutput
+                        {
+                            AssetId = assetId,
+                            Value = Neo.Fixed8.FromDecimal(sum - result),
+                            ScriptHash = Neo.Wallets.Helper.ToScriptHash(sender.ScriptHash)
+                        },
+                        new TransactionOutput
+                        {
+                            AssetId = assetId,
+                            Value = Neo.Fixed8.FromDecimal(result),
+                            ScriptHash = Neo.Wallets.Helper.ToScriptHash(receiver.ScriptHash)
+                        },
+                    }
+                };
+            }
+
+            throw new ArgumentException(nameof(quantity));
+        }
+    }
+}

--- a/src/neo-express/launch.ps1
+++ b/src/neo-express/launch.ps1
@@ -1,4 +1,4 @@
-param([int]$secondsPerBlock = 1, [switch]$debug, [switch]$reset, [string]$checkpoint)
+param([int]$secondsPerBlock = 5, [switch]$debug, [switch]$reset, [string]$checkpoint)
 
 dotnet publish -o .\bin\launch
 


### PR DESCRIPTION
When I originally built neo-express, I used neo-cli as a guide. However, since neo-express is split into separate processes, I built [custom RPC endpoints](https://github.com/neo-project/neo-express/blob/80c500f2aad7da9651b53fafea6f34e027d08646/src/neo-express/Node/ExpressNodeRpcPlugin.cs#L477) to allow the CLI to invoke transfer/claim/deploy/invoke. However, the more common way to accomplish these tasks is to build the transaction on the client side (including signing) and submitting via [`sendrawtransaction`](https://docs.neo.org/docs/en-us/reference/rpc/latest-version/api/sendrawtransaction.html).

This PR updates `transfer`, `claim` and `contract deploy` commands to use `sendrawtransaction` RPC endpoints rather than the neo-express custom endpoints described above. Support for using `sendrawtransaction` for `contract invoke` will come as part of #28.

Additionally, this PR adds a `show transaction` command that dumps the verbose JSON output of [`getrawtransaction`](https://docs.neo.org/docs/en-us/reference/rpc/latest-version/api/getrawtransaction.html) to the console. Additionally, this command dumps the JSON output of [`getapplicationlog`](https://docs.neo.org/docs/en-us/reference/rpc/latest-version/api/getapplicationlog.html) if available.

fixes #32 
fixes #47 
fixes #9