### PR TITLE
Add contract invoke command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,11 @@
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         },
         {
             "label": "publish",

--- a/src/neo-express/Commands/ContractCommand.Invoke.cs
+++ b/src/neo-express/Commands/ContractCommand.Invoke.cs
@@ -1,10 +1,9 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
+using NeoExpress.Neo2;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace NeoExpress.Commands
@@ -15,11 +14,8 @@ namespace NeoExpress.Commands
         private class Invoke
         {
             [Argument(0)]
-            // [Required]
-            string Contract { get; } = string.Empty;
-
-            [Argument(1)]
-            string[] Arguments { get; } = Array.Empty<string>();
+            [Required]
+            string InvocationFile { get; } = string.Empty;
 
             [Option]
             private string Input { get; } = string.Empty;
@@ -27,109 +23,34 @@ namespace NeoExpress.Commands
             [Option]
             private string Account { get; } = string.Empty;
 
-            [Option]
-            private string Function { get; } = string.Empty;
-
-            [Option]
-            private bool Overwrite { get; }
-
-            int OnExecute(CommandLineApplication app, IConsole console)
+            async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
-                console.WriteWarning("Updated contract invoke command currently not available");
-                return 1;
+                try
+                {
+                    if (!File.Exists(InvocationFile))
+                    {
+                        throw new Exception($"Invocation file {InvocationFile} couldn't be found");
+                    }
+
+                    var (chain, _) = Program.LoadExpressChain(Input);
+                    var blockchainOperations = new BlockchainOperations();
+                    var account = blockchainOperations.GetAccount(chain, Account);
+                    if (account == null)
+                    {
+                        throw new Exception("Invalid Account");
+                    }
+                    
+                    var tx = await blockchainOperations.InvokeContract(chain, InvocationFile, account);
+                    console.WriteLine($"InvocationTransaction {tx.Hash} submitted");
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    console.WriteError(ex.Message);
+                    app.ShowHelp();
+                    return 1;
+                }
             }
-
-            // static IEnumerable<JObject> ParseArguments(ExpressContract.Function function, IEnumerable<string> arguments)
-            // {
-            //     if (function.Parameters.Count != arguments.Count())
-            //     {
-            //         throw new ApplicationException($"Invalid number of arguments. Expecting {function.Parameters.Count} received {arguments.Count()}");
-            //     }
-
-            //     return function.Parameters.Zip(arguments,
-            //         (param, argValue) => new JObject()
-            //         {
-            //             ["type"] = param.Type,
-            //             ["value"] = argValue
-            //         });
-            // }
-
-            // IEnumerable<JObject> ParseArguments(ExpressContract contract)
-            // {
-            //     var arguments = Arguments ?? Enumerable.Empty<string>();
-
-            //     if (string.IsNullOrEmpty(Function))
-            //     {
-            //         var entrypoint = contract.Functions.Single(f => f.Name == contract.EntryPoint);
-            //         return ParseArguments(entrypoint, arguments);
-            //     }
-            //     else
-            //     {
-            //         var function = contract.Functions.SingleOrDefault(f => f.Name == Function);
-
-            //         if (function == null)
-            //         {
-            //             throw new Exception($"Could not find function {Function}");
-            //         }
-
-            //         return new JObject[2]
-            //         {
-            //             new JObject()
-            //             {
-            //                 ["type"] = "String",
-            //                 ["value"] = Function
-            //             },
-            //             new JObject()
-            //             {
-            //                 ["type"] = "Array",
-            //                 ["value"] = new JArray(ParseArguments(function, arguments))
-            //             }
-            //         };
-            //     }
-            // }
-
-            // async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
-            // {
-            //     try
-            //     {
-            //         var (chain, filename) = Program.LoadExpressChain(Input);
-            //         var contract = chain.GetContract(Contract);
-            //         if (contract == null)
-            //         {
-            //             throw new Exception($"Contract {Contract} not found.");
-            //         }
-
-            //         var account = chain.GetAccount(Account);
-
-            //         var args = ParseArguments(contract);
-            //         var uri = chain.GetUri();
-            //         var result = await NeoRpcClient.ExpressInvokeContract(uri, contract.Hash, args, account?.ScriptHash);
-            //         console.WriteResult(result);
-            //         if (account != null)
-            //         {
-            //             // var txid = result?["txid"];
-            //             if (txid != null)
-            //             {
-            //                 console.WriteLine("invocation complete");
-            //             }
-            //             else
-            //             {
-            //                 var signatures = account.Sign(chain.ConsensusNodes, result);
-            //                 var result2 = await NeoRpcClient.ExpressSubmitSignatures(uri, result?["contract-context"], signatures);
-            //                 console.WriteResult(result2);
-            //             }
-            //         }
-
-            //         chain.SaveContract(contract, filename, console, Overwrite);
-            //         return 0;
-            //     }
-            //     catch (Exception ex)
-            //     {
-            //         console.WriteError(ex.Message);
-            //         app.ShowHelp();
-            //         return 1;
-            //     }
-            // }
         }
     }
 }

--- a/src/neo-express/default.neo-express.json
+++ b/src/neo-express/default.neo-express.json
@@ -1,0 +1,41 @@
+{
+  "magic": 1453394355,
+  "consensus-nodes": [
+    {
+      "tcp-port": 49333,
+      "ws-port": 49334,
+      "rpc-port": 49332,
+      "wallet": {
+        "name": "node1",
+        "accounts": [
+          {
+            "private-key": "9232255cd489052d39bbdf3cac33084bf2f2ca577e4bbf70147c5ff8fec65258",
+            "script-hash": "AUHLGQEN9KwWMPqTdWKKoicPEqCypihHL3",
+            "label": null,
+            "is-default": true,
+            "contract": {
+              "script": "2103dac5420b9296afdd087f5cfb351cf69ecd6eb36a560c7efeebfde5c824aaa1f3ac",
+              "parameters": [
+                "Signature"
+              ]
+            }
+          },
+          {
+            "private-key": "9232255cd489052d39bbdf3cac33084bf2f2ca577e4bbf70147c5ff8fec65258",
+            "script-hash": "AKdZd1dfBvfswEM6V4CmjerqkjJH7LCnK4",
+            "label": "MultiSigContract",
+            "is-default": false,
+            "contract": {
+              "script": "512103dac5420b9296afdd087f5cfb351cf69ecd6eb36a560c7efeebfde5c824aaa1f351ae",
+              "parameters": [
+                "Signature"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "wallets": [],
+  "contracts": []
+}

--- a/src/neo-express/neo-express.csproj
+++ b/src/neo-express/neo-express.csproj
@@ -22,6 +22,13 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <!-- https://stackoverflow.com/a/48714896 to detect platform -->
+  <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
+    <!-- UseAppHost to enable loading librocksdb.dylib dependencies on MacOS
+         https://docs.microsoft.com/en-us/dotnet/core/install/macos-notarization-issues#apphost-is-disabled-by-default  -->
+    <UseAppHost>true</UseAppHost>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="neo-logo-72.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>

--- a/src/neo2/Extensions.cs
+++ b/src/neo2/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using NeoExpress.Abstractions;
 using NeoExpress.Abstractions.Models;
+using NeoExpress.Neo2.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -66,5 +67,8 @@ namespace NeoExpress.Neo2
 
         public static bool IsMultiSigContract(this Neo.Wallets.WalletAccount account)
             => Neo.SmartContract.Helper.IsMultiSigContract(account.Contract.Script);
+
+        public static AbiContract.Function GetEntrypoint(this AbiContract abiContract) 
+            => abiContract.Functions.Single(f => f.Name == abiContract.Entrypoint);
     }
 }

--- a/src/neo2/Models/InvokeResponse.cs
+++ b/src/neo2/Models/InvokeResponse.cs
@@ -1,0 +1,32 @@
+using Newtonsoft.Json;
+using System;
+
+namespace NeoExpress.Neo2.Models
+{
+    public class InvokeResponse
+    {
+        public class Stack
+        {
+            [JsonProperty("type")]
+            public string Type { get; set; } = string.Empty;
+
+            [JsonProperty("value")]
+            public string Value { get; set; } = string.Empty;
+        }
+
+        [JsonProperty("script")]
+        public string Script { get; set; } = string.Empty;
+
+        [JsonProperty("state")]
+        public string State { get; set; } = string.Empty;
+
+        [JsonProperty("gas_consumed")]
+        public decimal GasConsumed { get; set; }
+
+        [JsonProperty("stack")]
+        public Stack[] ReturnStack { get; set; } = Array.Empty<Stack>();
+
+        [JsonProperty("tx")]
+        public string Tx { get; set; } = string.Empty;
+    }
+}

--- a/src/neo2/NeoRpcClient.cs
+++ b/src/neo2/NeoRpcClient.cs
@@ -141,5 +141,10 @@ namespace NeoExpress.Neo2
         {
             return RpcCall(uri, "express-list-contract-metadata", new JArray());
         } 
+
+        public static Task<JToken?> InvokeScript(Uri uri, byte[] script)
+        {
+            return RpcCall(uri, "invokescript", new JArray(script.ToHexString()));
+        }
     }
 }


### PR DESCRIPTION
This PR adds `contract invoke` command to master. Unlike the contact invoke command implementation from the 1.0 release, this implementation has the contract invocation details (hash code + contract parameters) in a json file instead of passed on the command line. This json file can be checked into source control, supports arbitrarily complex contract parameters (including arrays and maps) and eventualy be generated by Visual DevTracker

Fixes #52