### PR TITLE
Multi Contract call support in .neo-invoke.json files

### DIFF
--- a/src/neo3/BlockchainOperations.cs
+++ b/src/neo3/BlockchainOperations.cs
@@ -251,7 +251,7 @@ namespace NeoExpress.Neo3
             static bool NodeRunning(ExpressConsensusNode node)
             {
                 // Check to see if there's a neo-express blockchain currently running
-                // by attempting to open a mutex with the multisig account address for 
+                // by attempting to open a mutex with the multisig account address for
                 // a name. If so, do an online checkpoint instead of offline.
 
                 var multiSigAccount = node.Wallet.Accounts.Single(a => a.IsMultiSigContract());
@@ -444,50 +444,6 @@ namespace NeoExpress.Neo3
             }
         }
 
-        private static async Task<byte[]> LoadInvocationFileScript(string invocationFilePath)
-        {
-            JObject json;
-            {
-                using var fileStream = File.OpenRead(invocationFilePath);
-                using var textReader = new StreamReader(fileStream);
-                using var jsonReader = new JsonTextReader(textReader);
-                json = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
-            }
-
-            var scriptHash = GetScriptHash(json["contract"], invocationFilePath);
-            var operation = json.Value<string>("operation");
-            var args = ContractParameterParser.ParseParams(json.GetValue("args")).ToArray();
-
-            using var sb = new ScriptBuilder();
-            sb.EmitAppCall(scriptHash, operation, args);
-            return sb.ToArray();
-
-            static UInt160 GetScriptHash(JToken? json, string invocationFilePath)
-            {
-                if (json != null && json is JObject jObject)
-                {
-                    if (jObject.TryGetValue("hash", out var jsonHash))
-                    {
-                        return UInt160.Parse(jsonHash.Value<string>());
-                    }
-
-                    if (jObject.TryGetValue("path", out var jsonPath))
-                    {
-                        var path = jsonPath.Value<string>();
-                        path = Path.IsPathFullyQualified(path)
-                            ? path
-                            : Path.Combine(Path.GetDirectoryName(invocationFilePath), path);
-
-                        using var stream = File.OpenRead(path);
-                        using var reader = new BinaryReader(stream, Encoding.UTF8, false);
-                        return reader.ReadSerializable<NefFile>().ScriptHash;
-                    }
-                }
-
-                throw new InvalidDataException("invalid contract property");
-            }
-        }
-
         public async Task<UInt256> InvokeContract(ExpressChain chain, string invocationFilePath, ExpressWalletAccount account)
         {
             if (!NodeUtility.InitializeProtocolSettings(chain))
@@ -497,7 +453,7 @@ namespace NeoExpress.Neo3
 
             var uri = chain.GetUri();
             var rpcClient = new RpcClient(uri.ToString());
-            var script = await LoadInvocationFileScript(invocationFilePath).ConfigureAwait(false);
+            var script = await ContractParameterParser.LoadInvocationScript(invocationFilePath).ConfigureAwait(false);
 
             var devAccount = DevWalletAccount.FromExpressWalletAccount(account);
             var signers = new[] { new Signer { Scopes = WitnessScope.CalledByEntry, Account = devAccount.ScriptHash } };

--- a/src/neo3/BlockchainOperations.cs
+++ b/src/neo3/BlockchainOperations.cs
@@ -475,7 +475,7 @@ namespace NeoExpress.Neo3
 
             var uri = chain.GetUri();
             var rpcClient = new RpcClient(uri.ToString());
-            var script = await LoadInvocationFileScript(invocationFilePath).ConfigureAwait(false);
+            var script = await ContractParameterParser.LoadInvocationScript(invocationFilePath).ConfigureAwait(false);
             return rpcClient.InvokeScript(script);
         }
 

--- a/src/neo3/ContractParameterParser.cs
+++ b/src/neo3/ContractParameterParser.cs
@@ -1,12 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
 using Neo;
 using Neo.Cryptography.ECC;
+using Neo.IO;
 using Neo.SmartContract;
+using Neo.VM;
 using Neo.Wallets;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace NeoExpress.Neo3
@@ -14,6 +20,74 @@ namespace NeoExpress.Neo3
     // https://gist.github.com/devhawk/4394bb9be2af0b0ff54211b41574b65b
     public static class ContractParameterParser
     {
+        public static async Task<Script> LoadInvocationScript(string invocationFilePath)
+        {
+            JToken invokeFileJson;
+            {
+                using var fileStream = File.OpenRead(invocationFilePath);
+                using var textReader = new StreamReader(fileStream);
+                using var jsonReader = new JsonTextReader(textReader);
+                invokeFileJson = await JToken.LoadAsync(jsonReader).ConfigureAwait(false);
+            }
+
+            using var sb = new ScriptBuilder();
+            switch (invokeFileJson.Type)
+            {
+                case JTokenType.Object:
+                    EmitAppCall(sb, (JObject)invokeFileJson);
+                    break;
+                case JTokenType.Array:
+                    {
+                        JArray array = (JArray)invokeFileJson;
+                        for (int i = 0; i < array.Count; i++)
+                        {
+                            if (array[i].Type != JTokenType.Object) 
+                            {
+                                throw new InvalidDataException("invalid invocation file");
+                            }
+                            EmitAppCall(sb, (JObject)array[i]);
+                        }
+                    }
+                    break;
+                default:
+                    throw new InvalidDataException("invalid invocation file");
+            }
+            return sb.ToArray();
+
+            void EmitAppCall(ScriptBuilder scriptBuilder, JObject json)
+            {
+                var scriptHash = GetScriptHash(json["contract"]);
+                var operation = json.Value<string>("operation");
+                var args = ContractParameterParser.ParseParams(json.GetValue("args")).ToArray();
+                scriptBuilder.EmitAppCall(scriptHash, operation, args);
+            }
+
+            UInt160 GetScriptHash(JToken? json)
+            {
+                if (json != null && json is JObject jObject)
+                {
+                    if (jObject.TryGetValue("hash", out var jsonHash))
+                    {
+                        return UInt160.Parse(jsonHash.Value<string>());
+                    }
+
+                    if (jObject.TryGetValue("path", out var jsonPath))
+                    {
+                        var path = jsonPath.Value<string>();
+                        path = Path.IsPathFullyQualified(path)
+                            ? path
+                            : Path.Combine(Path.GetDirectoryName(invocationFilePath), path);
+
+                        using var stream = File.OpenRead(path);
+                        using var reader = new BinaryReader(stream, Encoding.UTF8, false);
+                        return reader.ReadSerializable<NefFile>().ScriptHash;
+                    }
+                }
+
+                throw new InvalidDataException("invalid contract property");
+            }
+        }
+
         public static IEnumerable<ContractParameter> ParseParams(JToken? @params)
         {
             if (@params == null)
@@ -56,17 +130,37 @@ namespace NeoExpress.Neo3
 
         private static ContractParameter ParseStringParam(string param)
         {
-            if (param.StartsWith("@N"))
+            if (TryParseScriptHash(out var scriptHash))
             {
                 return new ContractParameter()
                 {
                     Type = ContractParameterType.Hash160,
-                    Value = param.Substring(1).ToScriptHash()
+                    Value = scriptHash
+                };
+            }
+
+            if (param[0] == '#'
+                && UInt160.TryParse(param[1..], out var uint160))
+            {
+                return new ContractParameter()
+                {
+                    Type = ContractParameterType.Hash160,
+                    Value = uint160
+                };
+            }
+
+            if (param[0] == '#'
+                && UInt256.TryParse(param[1..], out var uint256))
+            {
+                return new ContractParameter()
+                {
+                    Type = ContractParameterType.Hash256,
+                    Value = uint256
                 };
             }
 
             if (param.StartsWith("0x")
-                && BigInteger.TryParse(param.AsSpan().Slice(2), NumberStyles.HexNumber, null, out var bigInteger))
+                && BigInteger.TryParse(param.AsSpan()[2..], NumberStyles.HexNumber, null, out var bigInteger))
             {
                 return new ContractParameter()
                 {
@@ -80,6 +174,24 @@ namespace NeoExpress.Neo3
                 Type = ContractParameterType.String,
                 Value = param
             };
+
+            bool TryParseScriptHash(out UInt160 value)
+            {
+                try
+                {
+                    if (param[0] == '@')
+                    {
+                        value = param[1..].ToScriptHash();
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+
+                value = default!;
+                return false;
+            }
         }
 
         private static ContractParameter ParseObjectParam(JObject param)
@@ -112,7 +224,7 @@ namespace NeoExpress.Neo3
             {
                 var value = json.Value<string>();
                 return value.StartsWith("0x")
-                    ? value.Substring(2).HexToBytes()
+                    ? value[2..].HexToBytes()
                     : Convert.FromBase64String(value);
             }
 


### PR DESCRIPTION
This PR adds support for multi call invoke files. Template NEP-5 contract `mint` operation expects tx to invoke one or more NEO or GAS transfers before invoking the `mint` operation. This change allows contract neo-invoke file to have either a single contract call object or an array of contract call objects.

PR also adds support for `#` strings to be treated as Hash160/256 parameters  