### PR TITLE
add --gas option to contract invoke

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "IANA",
         "Nito",
+        "Secp",
         "Unspents"
     ],
 }

--- a/src/neo3/BlockchainOperations.cs
+++ b/src/neo3/BlockchainOperations.cs
@@ -444,7 +444,7 @@ namespace NeoExpress.Neo3
             }
         }
 
-        public async Task<UInt256> InvokeContract(ExpressChain chain, string invocationFilePath, ExpressWalletAccount account)
+        public async Task<UInt256> InvokeContract(ExpressChain chain, string invocationFilePath, ExpressWalletAccount account, decimal additionalGas = 0m)
         {
             if (!NodeUtility.InitializeProtocolSettings(chain))
             {
@@ -460,6 +460,7 @@ namespace NeoExpress.Neo3
 
             var tm = new TransactionManager(rpcClient)
                 .MakeTransaction(script, signers)
+                .AddGas(additionalGas)
                 .AddSignatures(chain, account)
                 .Sign();
 

--- a/src/neo3/Extensions.cs
+++ b/src/neo3/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using Neo;
 using Neo.Network.RPC;
+using Neo.SmartContract.Native;
 using Neo.Wallets;
 using NeoExpress.Abstractions;
 using NeoExpress.Abstractions.Models;
@@ -121,6 +122,15 @@ namespace NeoExpress.Neo3
                     .Where(a => a != null)
                     .Select(Models.DevWalletAccount.FromExpressWalletAccount);
             }
+        }
+
+        public static TransactionManager AddGas(this TransactionManager transactionManager, decimal gas)
+        {
+            if (transactionManager.Tx != null && gas > 0.0m)
+            {
+                transactionManager.Tx.SystemFee += (long)gas.ToBigInteger(NativeContract.GAS.Decimals);
+            }
+            return transactionManager;
         }
     }
 }

--- a/src/nxp3/Commands/ContractCommand.Invoke.cs
+++ b/src/nxp3/Commands/ContractCommand.Invoke.cs
@@ -25,6 +25,9 @@ namespace nxp3.Commands
             [Option]
             string Input { get; } = string.Empty;
 
+            [Option("--gas|-g", CommandOptionType.SingleValue, Description = "Additional GAS to apply to the contract invocation")]
+            decimal AdditionalGas { get; } = 0;
+
             static string AsString(Neo.VM.Types.StackItem item) => item switch
             {
                 Neo.VM.Types.Boolean _ => $"{item.GetBoolean()}",
@@ -69,7 +72,7 @@ namespace nxp3.Commands
                         {
                             throw new Exception($"{Account} account not found.");
                         }
-                        var txHash = await blockchainOperations.InvokeContract(chain, InvocationFile, account);
+                        var txHash = await blockchainOperations.InvokeContract(chain, InvocationFile, account, AdditionalGas);
                         console.WriteLine($"InvocationTransaction {txHash} submitted");
                     }
                     return 0;

--- a/src/nxp3/nxp3.csproj
+++ b/src/nxp3/nxp3.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
In some cases, `invokescript` RPC endpoint [reports an incorrect GAS amount](https://github.com/neo-project/neo/issues/1882). This leads to a scenario where neo express can't invoke a contract.

This PR adds a new `--gas` (or `-g`) command option to `contract invoke` to add the specified amount of gas to the SystemFee calculated by `invokescript`