### PR TITLE
disable help pager

### DIFF
--- a/src/nxp3/Commands/CheckpointCommand.Create.cs
+++ b/src/nxp3/Commands/CheckpointCommand.Create.cs
@@ -51,7 +51,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/CheckpointCommand.Restore.cs
+++ b/src/nxp3/Commands/CheckpointCommand.Restore.cs
@@ -42,7 +42,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/CheckpointCommand.Run.cs
+++ b/src/nxp3/Commands/CheckpointCommand.Run.cs
@@ -54,7 +54,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/CheckpointCommand.cs
+++ b/src/nxp3/Commands/CheckpointCommand.cs
@@ -9,7 +9,7 @@ namespace nxp3.Commands
         private int OnExecute(CommandLineApplication app, IConsole console)
         {
             console.WriteLine("You must specify at a subcommand.");
-            app.ShowHelp();
+            app.ShowHelp(false);
             return 1;
         }
     }

--- a/src/nxp3/Commands/ContractCommand.Deploy.cs
+++ b/src/nxp3/Commands/ContractCommand.Deploy.cs
@@ -43,7 +43,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ContractCommand.Get.cs
+++ b/src/nxp3/Commands/ContractCommand.Get.cs
@@ -35,7 +35,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ContractCommand.Invoke.cs
+++ b/src/nxp3/Commands/ContractCommand.Invoke.cs
@@ -79,7 +79,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ContractCommand.List.cs
+++ b/src/nxp3/Commands/ContractCommand.List.cs
@@ -33,7 +33,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ContractCommand.Storage.cs
+++ b/src/nxp3/Commands/ContractCommand.Storage.cs
@@ -56,7 +56,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ContractCommand.cs
+++ b/src/nxp3/Commands/ContractCommand.cs
@@ -9,7 +9,7 @@ namespace nxp3.Commands
         private int OnExecute(CommandLineApplication app, IConsole console)
         {
             console.WriteLine("You must specify at a subcommand.");
-            app.ShowHelp();
+            app.ShowHelp(false);
             return 1;
         }
     }

--- a/src/nxp3/Commands/CreateCommand.cs
+++ b/src/nxp3/Commands/CreateCommand.cs
@@ -64,7 +64,6 @@ namespace nxp3.Commands
             catch (Exception ex)
             {
                 console.WriteLine(ex.Message);
-                app.ShowHelp();
                 return 1;
             }
         }

--- a/src/nxp3/Commands/ResetCommand.cs
+++ b/src/nxp3/Commands/ResetCommand.cs
@@ -40,7 +40,6 @@ namespace nxp3.Commands
             catch (Exception ex)
             {
                 console.WriteLine(ex.Message);
-                app.ShowHelp();
                 return 1;
             }
         }

--- a/src/nxp3/Commands/RunCommand.cs
+++ b/src/nxp3/Commands/RunCommand.cs
@@ -53,7 +53,6 @@ namespace nxp3.Commands
             catch (Exception ex)
             {
                 console.WriteLine(ex.Message);
-                app.ShowHelp();
                 return 1;
             }
         }

--- a/src/nxp3/Commands/ShowCommand.Balance.cs
+++ b/src/nxp3/Commands/ShowCommand.Balance.cs
@@ -38,7 +38,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ShowCommand.Block.cs
+++ b/src/nxp3/Commands/ShowCommand.Block.cs
@@ -30,7 +30,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ShowCommand.Transaction.cs
+++ b/src/nxp3/Commands/ShowCommand.Transaction.cs
@@ -34,7 +34,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ShowCommand.cs
+++ b/src/nxp3/Commands/ShowCommand.cs
@@ -9,7 +9,7 @@ namespace nxp3.Commands
         private int OnExecute(CommandLineApplication app, IConsole console)
         {
             console.WriteLine("You must specify at a subcommand.");
-            app.ShowHelp();
+            app.ShowHelp(false);
             return 1;
         }
     }

--- a/src/nxp3/Commands/TransferCommand.cs
+++ b/src/nxp3/Commands/TransferCommand.cs
@@ -50,7 +50,6 @@ namespace nxp3.Commands
             catch (Exception ex)
             {
                 console.WriteLine(ex.Message);
-                app.ShowHelp();
                 return 1;
             }
         }

--- a/src/nxp3/Commands/WalletCommand.Create.cs
+++ b/src/nxp3/Commands/WalletCommand.Create.cs
@@ -58,7 +58,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/WalletCommand.List.cs
+++ b/src/nxp3/Commands/WalletCommand.List.cs
@@ -56,7 +56,6 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.WriteLine(ex.Message);
-                    app.ShowHelp();
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/WalletCommand.cs
+++ b/src/nxp3/Commands/WalletCommand.cs
@@ -9,7 +9,7 @@ namespace nxp3.Commands
         private int OnExecute(CommandLineApplication app, IConsole console)
         {
             console.WriteLine("You must specify at a subcommand.");
-            app.ShowHelp();
+            app.ShowHelp(false);
             return 1;
         }
     }

--- a/src/nxp3/Program.cs
+++ b/src/nxp3/Program.cs
@@ -6,7 +6,7 @@ using nxp3.Commands;
 
 namespace nxp3
 {
-    [Command("nxp3")]
+    [Command("nxp3", UsePagerForHelpText = false)]
     [Subcommand(
         typeof(CheckpointCommand),
         typeof(ContractCommand),

--- a/src/nxp3/Program.cs
+++ b/src/nxp3/Program.cs
@@ -33,7 +33,7 @@ namespace nxp3
             }
 
             console.WriteLine("You must specify a subcommand.");
-            app.ShowHelp();
+            app.ShowHelp(false);
             return 1;
         }
 


### PR DESCRIPTION
* Remove `app.ShowHelp()` calls except for commands w/o subcommands (example: `checkpoint` without `create`, `restore` or `run`)
* Explicitly disable pager (via `app.ShowHelp(false)`) when showing help
* Specify `UsePagerForHelpText = false` on root command attribute
