### PR TITLE
Adapt to Script Hash Identification Change

### DIFF
--- a/src/neo3/BlockchainOperations.cs
+++ b/src/neo3/BlockchainOperations.cs
@@ -418,7 +418,7 @@ namespace NeoExpress.Neo3
                 return uint160;
             }
 
-            var contracts = await expressNode.ListNep5ContractsAsync().ConfigureAwait(false);
+            var contracts = await expressNode.ListNep17ContractsAsync().ConfigureAwait(false);
             for (int i = 0; i < contracts.Count; i++)
             {
                 if (contracts[i].Symbol.Equals(asset, StringComparison.CurrentCultureIgnoreCase))
@@ -556,7 +556,7 @@ namespace NeoExpress.Neo3
             return null;
         }
 
-        public async Task<(BigDecimal balance, Nep5Contract contract)> ShowBalance(ExpressChain chain, ExpressWalletAccount account, string asset)
+        public async Task<(BigDecimal balance, Nep17Contract contract)> ShowBalance(ExpressChain chain, ExpressWalletAccount account, string asset)
         {
             if (!NodeUtility.InitializeProtocolSettings(chain))
             {
@@ -582,13 +582,13 @@ namespace NeoExpress.Neo3
                 var symbol = Encoding.UTF8.GetString(stack[2].GetSpan());
                 var decimals = (byte)(stack[3].GetInteger());
 
-                return (new BigDecimal(balance, decimals), new Nep5Contract(name, symbol, decimals, assetHash));
+                return (new BigDecimal(balance, decimals), new Nep17Contract(name, symbol, decimals, assetHash));
             }
 
             throw new Exception("invalid script results");
         }
 
-        public async Task<(RpcNep5Balance balance, Nep5Contract contract)[]> GetBalances(ExpressChain chain, ExpressWalletAccount account)
+        public async Task<(RpcNep17Balance balance, Nep17Contract contract)[]> GetBalances(ExpressChain chain, ExpressWalletAccount account)
         {
             if (!NodeUtility.InitializeProtocolSettings(chain))
             {

--- a/src/neo3/Models/Nep17Contract.cs
+++ b/src/neo3/Models/Nep17Contract.cs
@@ -6,14 +6,14 @@ using Neo.VM;
 
 namespace NeoExpress.Neo3.Models
 {
-    public struct Nep5Contract
+    public struct Nep17Contract
     {
         public readonly string Name;
         public readonly string Symbol;
         public readonly byte Decimals;
         public readonly UInt160 ScriptHash;
 
-        public Nep5Contract(string name, string symbol, byte decimals, UInt160 scriptHash)
+        public Nep17Contract(string name, string symbol, byte decimals, UInt160 scriptHash)
         {
             Name = name;
             Symbol = symbol;
@@ -21,9 +21,9 @@ namespace NeoExpress.Neo3.Models
             ScriptHash = scriptHash;
         }
 
-        public static Nep5Contract Unknown(UInt160 scriptHash) => new Nep5Contract("unknown", "unknown", 0, scriptHash);
+        public static Nep17Contract Unknown(UInt160 scriptHash) => new Nep17Contract("unknown", "unknown", 0, scriptHash);
 
-        public static bool TryLoad(IReadOnlyStore store, UInt160 scriptHash, out Nep5Contract contract)
+        public static bool TryLoad(IReadOnlyStore store, UInt160 scriptHash, out Nep17Contract contract)
         {
             using var sb = new ScriptBuilder();
             sb.EmitAppCall(scriptHash, "name");
@@ -36,7 +36,7 @@ namespace NeoExpress.Neo3.Models
                 var decimals = (byte)engine.ResultStack.Pop<Neo.VM.Types.Integer>().GetInteger();
                 var symbol = Encoding.UTF8.GetString(engine.ResultStack.Pop().GetSpan());
                 var name = Encoding.UTF8.GetString(engine.ResultStack.Pop().GetSpan());
-                contract = new Nep5Contract(name, symbol, decimals, scriptHash);
+                contract = new Nep17Contract(name, symbol, decimals, scriptHash);
                 return true;
             }
 
@@ -54,13 +54,13 @@ namespace NeoExpress.Neo3.Models
             return json;
         }
 
-        public static Nep5Contract FromJson(JObject json)
+        public static Nep17Contract FromJson(JObject json)
         {
             var name = json["name"].AsString();
             var symbol = json["symbol"].AsString();
             var scriptHash = UInt160.Parse(json["scriptHash"].AsString());
             var decimals = (byte)json["decimals"].AsNumber();
-            return new Nep5Contract(name, symbol, decimals, scriptHash);
+            return new Nep17Contract(name, symbol, decimals, scriptHash);
         }
     }
 }

--- a/src/neo3/Node/ExpressApplicationEngineProvider.cs
+++ b/src/neo3/Node/ExpressApplicationEngineProvider.cs
@@ -10,6 +10,7 @@ using Neo.VM;
 
 namespace NeoExpress.Neo3.Node
 {
+    // Note: namespace alias needed to avoid conflict with Plugin.System property
     using SysIO = System.IO;
 
     class ExpressApplicationEngineProvider : Plugin, IApplicationEngineProvider

--- a/src/neo3/Node/ExpressOracle.cs
+++ b/src/neo3/Node/ExpressOracle.cs
@@ -75,7 +75,7 @@ namespace NeoExpress.Neo3.Node
             // Calculate network fee
 
             var engine = ApplicationEngine.Create(TriggerType.Verification, tx, snapshot.Clone());
-            engine.LoadScript(NativeContract.Oracle.Script, CallFlags.None, 0);
+            engine.LoadScript(NativeContract.Oracle.Script, CallFlags.None);
             engine.LoadScript(new ScriptBuilder().Emit(OpCode.DEPTH, OpCode.PACK).EmitPush("verify").ToArray(), CallFlags.None);
             if (engine.Execute() != VMState.HALT) return null;
             tx.NetworkFee += engine.GasConsumed;

--- a/src/neo3/Node/ExpressRpcServer.cs
+++ b/src/neo3/Node/ExpressRpcServer.cs
@@ -174,6 +174,7 @@ namespace NeoExpress.Neo3.Node
             var jsonContracts = new JArray();
             foreach (var contract in GetNep5Contracts(snapshot))
             {
+                var jsonContract = new JObject();
                 jsonContracts.Add(contract.ToJson());
             }
             return jsonContracts;
@@ -289,7 +290,10 @@ namespace NeoExpress.Neo3.Node
             var json = new JArray();
             foreach (var (key, value) in contracts)
             {
-                json.Add(value.Manifest.ToJson());
+                var jsonContract = new JObject();
+                jsonContract["hash"] = value.Hash.ToString();
+                jsonContract["manifest"] = value.Manifest.ToJson();
+                json.Add(jsonContract);
             }
             return json;
         }

--- a/src/neo3/Node/IExpressNode.cs
+++ b/src/neo3/Node/IExpressNode.cs
@@ -26,7 +26,7 @@ namespace NeoExpress.Neo3.Node
         Task<uint> GetTransactionHeight(UInt256 txHash);
         Task<IReadOnlyList<ExpressStorage>> GetStoragesAsync(UInt160 scriptHash);
         Task<ContractManifest> GetContractAsync(UInt160 scriptHash);
-        Task<IReadOnlyList<ContractManifest>> ListContractsAsync();
+        Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync();
         Task<IReadOnlyList<Nep5Contract>> ListNep5ContractsAsync();
         Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync();
         Task<UInt256> SubmitOracleResponseAsync(ExpressChain chain, OracleResponse response, ECPoint[] oracleNodes);

--- a/src/neo3/Node/IExpressNode.cs
+++ b/src/neo3/Node/IExpressNode.cs
@@ -18,7 +18,7 @@ namespace NeoExpress.Neo3.Node
         Task<UInt256> ExecuteAsync(ExpressChain chain, ExpressWalletAccount account, Script script, decimal additionalGas = 0);
         Task<UInt256> SubmitTransactionAsync(Transaction tx);
         Task<InvokeResult> InvokeAsync(Script script);
-        Task<(RpcNep5Balance balance, Nep5Contract contract)[]> GetBalancesAsync(UInt160 address);
+        Task<(RpcNep17Balance balance, Nep17Contract contract)[]> GetBalancesAsync(UInt160 address);
         Task<(Transaction tx, RpcApplicationLog? appLog)> GetTransactionAsync(UInt256 txHash);
         Task<Block> GetBlockAsync(UInt256 blockHash);
         Task<Block> GetBlockAsync(uint blockIndex);
@@ -27,7 +27,7 @@ namespace NeoExpress.Neo3.Node
         Task<IReadOnlyList<ExpressStorage>> GetStoragesAsync(UInt160 scriptHash);
         Task<ContractManifest> GetContractAsync(UInt160 scriptHash);
         Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync();
-        Task<IReadOnlyList<Nep5Contract>> ListNep5ContractsAsync();
+        Task<IReadOnlyList<Nep17Contract>> ListNep17ContractsAsync();
         Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync();
         Task<UInt256> SubmitOracleResponseAsync(ExpressChain chain, OracleResponse response, ECPoint[] oracleNodes);
     }

--- a/src/neo3/Node/ITraceDebugSink.cs
+++ b/src/neo3/Node/ITraceDebugSink.cs
@@ -10,8 +10,8 @@ namespace NeoExpress.Neo3.Node
     public interface ITraceDebugSink : IDisposable
     {
         void Trace(VMState vmState, IReadOnlyCollection<ExecutionContext> executionContexts);
-        void Log(LogEventArgs args);
-        void Notify(NotifyEventArgs args);
+        void Log(LogEventArgs args, string scriptName);
+        void Notify(NotifyEventArgs args, string scriptName);
         void Results(VMState vmState, long gasConsumed, IReadOnlyCollection<Neo.VM.Types.StackItem> results);
         void Fault(Exception exception);
         void Script(byte[] script);

--- a/src/neo3/Node/LogPlugin.cs
+++ b/src/neo3/Node/LogPlugin.cs
@@ -18,8 +18,9 @@ namespace NeoExpress.Neo3.Node
 
         private void OnLog(object sender, LogEventArgs args)
         {
-            var name = args.ScriptHash.ToString();
-            writer.WriteLine($"{name} Log \"{args.Message}\" [{args.ScriptContainer.GetType().Name}]");
+            var contract = Neo.Ledger.Blockchain.Singleton.View.Contracts.TryGet(args.ScriptHash);
+            var name = contract == null ? args.ScriptHash.ToString() : contract.Manifest.Name;
+            writer.WriteLine($"\x1b[35m{name}\x1b[0m Log: \x1b[96m\"{args.Message}\"\x1b[0m [{args.ScriptContainer.GetType().Name}]");
         }
 
         void ILogPlugin.Log(string source, LogLevel level, object message)

--- a/src/neo3/Node/OfflineNode.cs
+++ b/src/neo3/Node/OfflineNode.cs
@@ -377,14 +377,14 @@ namespace NeoExpress.Neo3.Node
             GC.SuppressFinalize(this);
         }
 
-        public Task<(RpcNep5Balance balance, Nep5Contract contract)[]> GetBalancesAsync(UInt160 address)
+        public Task<(RpcNep17Balance balance, Nep17Contract contract)[]> GetBalancesAsync(UInt160 address)
         {
             if (disposedValue) throw new ObjectDisposedException(nameof(OfflineNode));
 
-            var contracts = ExpressRpcServer.GetNep5Contracts(Blockchain.Singleton.Store).ToDictionary(c => c.ScriptHash);
-            var balances = ExpressRpcServer.GetNep5Balances(Blockchain.Singleton.Store, address)
+            var contracts = ExpressRpcServer.GetNep17Contracts(Blockchain.Singleton.Store).ToDictionary(c => c.ScriptHash);
+            var balances = ExpressRpcServer.GetNep17Balances(Blockchain.Singleton.Store, address)
                 .Select(b => (
-                    balance: new RpcNep5Balance
+                    balance: new RpcNep17Balance
                     {
                         Amount = b.balance,
                         AssetHash = b.contract.ScriptHash,
@@ -392,7 +392,7 @@ namespace NeoExpress.Neo3.Node
                     },
                     contract: contracts.TryGetValue(b.contract.ScriptHash, out var value)
                         ? value
-                        : Nep5Contract.Unknown(b.contract.ScriptHash)))
+                        : Nep17Contract.Unknown(b.contract.ScriptHash)))
                 .ToArray();
             return Task.FromResult(balances);
         }
@@ -482,10 +482,10 @@ namespace NeoExpress.Neo3.Node
             return Task.FromResult<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>>(contracts);
         }
 
-        public Task<IReadOnlyList<Nep5Contract>> ListNep5ContractsAsync()
+        public Task<IReadOnlyList<Nep17Contract>> ListNep17ContractsAsync()
         {
-            return Task.FromResult<IReadOnlyList<Nep5Contract>>(
-                ExpressRpcServer.GetNep5Contracts(Blockchain.Singleton.Store).ToList());
+            return Task.FromResult<IReadOnlyList<Nep17Contract>>(
+                ExpressRpcServer.GetNep17Contracts(Blockchain.Singleton.Store).ToList());
         }
 
         public Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync()

--- a/src/neo3/Node/OfflineNode.cs
+++ b/src/neo3/Node/OfflineNode.cs
@@ -60,11 +60,10 @@ namespace NeoExpress.Neo3.Node
         {
             var engine = sender as ApplicationEngine;
             var tx = engine?.ScriptContainer as Transaction;
-            if (tx?.Witnesses?.Any() ?? false)
-            {
-                var name = args.ScriptHash.ToString();
-                Console.WriteLine($"{name} Log \x1b[36m\"{args.Message}\"\x1b[0m [{args.ScriptContainer.GetType().Name}]");
-            }
+            var colorCode = tx?.Witnesses?.Any() ?? false ? "96" : "93";
+            var contract = Blockchain.Singleton.View.Contracts.TryGet(args.ScriptHash);
+            var name = contract == null ? args.ScriptHash.ToString() : contract.Manifest.Name;
+            Console.WriteLine($"\x1b[35m{name}\x1b[0m Log: \x1b[{colorCode}m\"{args.Message}\"\x1b[0m [{args.ScriptContainer.GetType().Name}]");
         }
 
         public Task<InvokeResult> InvokeAsync(Neo.VM.Script script)

--- a/src/neo3/Node/OfflineNode.cs
+++ b/src/neo3/Node/OfflineNode.cs
@@ -472,15 +472,15 @@ namespace NeoExpress.Neo3.Node
             return Task.FromResult(contractState.Manifest);
         }
 
-        public Task<IReadOnlyList<ContractManifest>> ListContractsAsync()
+        public Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync()
         {
             if (disposedValue) throw new ObjectDisposedException(nameof(OfflineNode));
 
             var contracts = Blockchain.Singleton.View.Contracts.Find()
                     .OrderBy(t => t.Value.Id)
-                    .Select(t => t.Value.Manifest)
+                    .Select(t => (t.Value.Hash, t.Value.Manifest))
                     .ToList();
-            return Task.FromResult<IReadOnlyList<ContractManifest>>(contracts);
+            return Task.FromResult<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>>(contracts);
         }
 
         public Task<IReadOnlyList<Nep5Contract>> ListNep5ContractsAsync()

--- a/src/neo3/Node/OnlineNode.cs
+++ b/src/neo3/Node/OnlineNode.cs
@@ -52,18 +52,18 @@ namespace NeoExpress.Neo3.Node
             return rpcClient.SendRawTransactionAsync(tx);
         }
 
-        public async Task<(Neo.Network.RPC.Models.RpcNep5Balance balance, Nep5Contract contract)[]> GetBalancesAsync(UInt160 address)
+        public async Task<(Neo.Network.RPC.Models.RpcNep17Balance balance, Nep17Contract contract)[]> GetBalancesAsync(UInt160 address)
         {
-            var contracts = ((Neo.IO.Json.JArray)await rpcClient.RpcSendAsync("expressgetnep5contracts"))
-                .Select(json => Nep5Contract.FromJson(json))
+            var contracts = ((Neo.IO.Json.JArray)await rpcClient.RpcSendAsync("expressgetnep17contracts"))
+                .Select(json => Nep17Contract.FromJson(json))
                 .ToDictionary(c => c.ScriptHash);
-            var balances = await rpcClient.GetNep5BalancesAsync(address.ToAddress()).ConfigureAwait(false);
+            var balances = await rpcClient.GetNep17BalancesAsync(address.ToAddress()).ConfigureAwait(false);
             return balances.Balances
                 .Select(b => (
                     balance: b,
                     contract: contracts.TryGetValue(b.AssetHash, out var value)
                         ? value
-                        : Nep5Contract.Unknown(b.AssetHash)))
+                        : Nep17Contract.Unknown(b.AssetHash)))
                 .ToArray();
         }
 
@@ -148,16 +148,16 @@ namespace NeoExpress.Neo3.Node
             return Array.Empty<(UInt160 hash, ContractManifest manifest)>();
         }
 
-        public async Task<IReadOnlyList<Nep5Contract>> ListNep5ContractsAsync()
+        public async Task<IReadOnlyList<Nep17Contract>> ListNep17ContractsAsync()
         {
-            var json = await rpcClient.RpcSendAsync("expressgetnep5contracts").ConfigureAwait(false);
+            var json = await rpcClient.RpcSendAsync("expressgetnep17contracts").ConfigureAwait(false);
 
             if (json != null && json is Neo.IO.Json.JArray array)
             {
-                return array.Select(Nep5Contract.FromJson).ToList();
+                return array.Select(Nep17Contract.FromJson).ToList();
             }
 
-            return Array.Empty<Nep5Contract>();
+            return Array.Empty<Nep17Contract>();
         }
 
         public async Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync()

--- a/src/neo3/Node/OnlineNode.cs
+++ b/src/neo3/Node/OnlineNode.cs
@@ -132,16 +132,20 @@ namespace NeoExpress.Neo3.Node
             return InvokeResult.FromRpcInvokeResult(invokeResult);
         }
 
-        public async Task<IReadOnlyList<ContractManifest>> ListContractsAsync()
+        public async Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync()
         {
             var json = await rpcClient.RpcSendAsync("expresslistcontracts").ConfigureAwait(false);
 
             if (json != null && json is Neo.IO.Json.JArray array)
             {
-                return array.Select(ContractManifest.FromJson).ToList();
+                return array
+                    .Select(j => (
+                        UInt160.Parse(j["hash"].AsString()),
+                        ContractManifest.FromJson(j["manifest"])))
+                    .ToList();
             }
 
-            return Array.Empty<ContractManifest>();
+            return Array.Empty<(UInt160 hash, ContractManifest manifest)>();
         }
 
         public async Task<IReadOnlyList<Nep5Contract>> ListNep5ContractsAsync()

--- a/src/neo3/Node/TraceDebugSink.cs
+++ b/src/neo3/Node/TraceDebugSink.cs
@@ -22,6 +22,7 @@ namespace NeoExpress.Neo3.Node
     internal class TraceDebugSink : ITraceDebugSink
     {
         private readonly static MessagePackSerializerOptions options;
+        private readonly IDictionary<UInt160, UInt160> scriptIdMap = new Dictionary<UInt160, UInt160>();
 
         static TraceDebugSink()
         {
@@ -61,17 +62,17 @@ namespace NeoExpress.Neo3.Node
 
         public void Trace(VMState vmState, IReadOnlyCollection<ExecutionContext> executionContexts)
         {
-            Write((seq, opt) => TraceRecord.Write(seq, opt, vmState, executionContexts));
+            Write((seq, opt) => TraceRecord.Write(seq, opt, scriptIdMap, vmState, executionContexts));
         }
 
-        public void Notify(NotifyEventArgs args)
+        public void Notify(NotifyEventArgs args, string scriptName)
         {
-            Write((seq, opt) => NotifyRecord.Write(seq, opt, args.ScriptHash, args.EventName, args.State));
+            Write((seq, opt) => NotifyRecord.Write(seq, opt, args.ScriptHash, scriptName, args.EventName, args.State));
         }
 
-        public void Log(LogEventArgs args)
+        public void Log(LogEventArgs args, string scriptName)
         {
-            Write((seq, opt) => LogRecord.Write(seq, opt, args.ScriptHash, args.Message));
+            Write((seq, opt) => LogRecord.Write(seq, opt, args.ScriptHash, scriptName, args.Message));
         }
 
         public void Results(VMState vmState, long gasConsumed, IReadOnlyCollection<StackItem> results)

--- a/src/neo3/neo3.csproj
+++ b/src/neo3/neo3.csproj
@@ -10,14 +10,14 @@
   <ItemGroup>
     <PackageReference Include="Neo.Network.RPC.RpcClient" Version="3.0.0-mono-master-00349" />
     <PackageReference Include="Neo.Plugins.RpcServer" Version="3.0.0-mono-master-00349" />
-    <!-- <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.52-preview" /> -->
+    <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.56-preview" />
     <PackageReference Include="Nerdbank.Streams" Version="2.6.81" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.Disposables" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\abstractions\abstractions.csproj" />
-    <ProjectReference Include="..\..\..\lib-bctk\src\bctklib-3\bctklib-3.csproj" />
+    <!-- <ProjectReference Include="..\..\..\lib-bctk\src\bctklib-3\bctklib-3.csproj" /> -->
     <!-- <ProjectReference Include="..\..\..\..\official\modules\src\RpcClient\RpcClient.csproj" /> -->
     <!-- <ProjectReference Include="..\..\..\..\official\modules\src\RpcServer\RpcServer.csproj" /> -->
   </ItemGroup>

--- a/src/neo3/neo3.csproj
+++ b/src/neo3/neo3.csproj
@@ -8,15 +8,17 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-mono-master-00328" />
-    <PackageReference Include="Neo.Network.RPC.RpcClient" Version="3.0.0-mono-master-00328" />
-    <PackageReference Include="Neo.Plugins.RpcServer" Version="3.0.0-mono-master-00328" />
-    <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.52-preview" />
+    <PackageReference Include="Neo.Network.RPC.RpcClient" Version="3.0.0-mono-master-00349" />
+    <PackageReference Include="Neo.Plugins.RpcServer" Version="3.0.0-mono-master-00349" />
+    <!-- <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.52-preview" /> -->
     <PackageReference Include="Nerdbank.Streams" Version="2.6.81" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.Disposables" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\abstractions\abstractions.csproj" />
+    <ProjectReference Include="..\..\..\lib-bctk\src\bctklib-3\bctklib-3.csproj" />
+    <!-- <ProjectReference Include="..\..\..\..\official\modules\src\RpcClient\RpcClient.csproj" /> -->
+    <!-- <ProjectReference Include="..\..\..\..\official\modules\src\RpcServer\RpcServer.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/src/nxp3/Commands/ContractCommand.Deploy.cs
+++ b/src/nxp3/Commands/ContractCommand.Deploy.cs
@@ -22,6 +22,9 @@ namespace nxp3.Commands
             [Option]
             string Input { get; } = string.Empty;
 
+            [Option()]
+            bool Json { get; } = false;
+
             internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
@@ -36,7 +39,14 @@ namespace nxp3.Commands
                     }
 
                     var txHash = await blockchainOperations.DeployContract(chain, Contract, account);
-                    console.WriteLine($"Deployment Transaction {txHash} submitted");
+                    if (Json)
+                    {
+                        console.WriteLine($"{txHash}");
+                    }
+                    else
+                    {
+                        console.WriteLine($"Deployment Transaction {txHash} submitted");
+                    }
 
                     return 0;
                 }

--- a/src/nxp3/Commands/ContractCommand.Invoke.cs
+++ b/src/nxp3/Commands/ContractCommand.Invoke.cs
@@ -128,10 +128,11 @@ namespace nxp3.Commands
                 }
                 catch (Exception ex)
                 {
-                    console.Error.WriteLine(ex.Message);
-                    if (ex.InnerException != null && ex.InnerException is Neo.VM.VMUnhandledException)
+                    console.Error.WriteLine($"{ex.Message} [{ex.GetType().Name}]");
+                    while (ex.InnerException != null)
                     {
-                        console.Error.WriteLine($"  Contract Exception: {ex.InnerException.Message}");
+                        console.Error.WriteLine($"  Contract Exception: {ex.InnerException.Message} [{ex.InnerException.GetType().Name}]");
+                        ex = ex.InnerException;
                     }
                     return 1;
                 }

--- a/src/nxp3/Commands/ContractCommand.Invoke.cs
+++ b/src/nxp3/Commands/ContractCommand.Invoke.cs
@@ -129,6 +129,10 @@ namespace nxp3.Commands
                 catch (Exception ex)
                 {
                     console.Error.WriteLine(ex.Message);
+                    if (ex.InnerException != null && ex.InnerException is Neo.VM.VMUnhandledException)
+                    {
+                        console.Error.WriteLine($"  Contract Exception: {ex.InnerException.Message}");
+                    }
                     return 1;
                 }
             }

--- a/src/nxp3/Commands/ContractCommand.Invoke.cs
+++ b/src/nxp3/Commands/ContractCommand.Invoke.cs
@@ -31,6 +31,9 @@ namespace nxp3.Commands
             [Option("--trace")]
             bool Trace { get; } = false;
 
+            [Option()]
+            bool Json { get; } = false;
+
             static void WriteStackItem(IConsole console, Neo.VM.Types.StackItem item, int indent = 1, string prefix = "")
             {
                 switch (item)
@@ -122,7 +125,14 @@ namespace nxp3.Commands
                             throw new Exception($"{Account} account not found.");
                         }
                         var txHash = await blockchainOperations.InvokeContract(chain, InvocationFile, account, Trace, AdditionalGas);
-                        console.WriteLine($"Invocation Transaction {txHash} submitted");
+                        if (Json)
+                        {
+                            console.WriteLine($"{txHash}");
+                        }
+                        else
+                        {
+                            console.WriteLine($"Invocation Transaction {txHash} submitted");
+                        }
                     }
                     return 0;
                 }

--- a/src/nxp3/Commands/ContractCommand.List.cs
+++ b/src/nxp3/Commands/ContractCommand.List.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using NeoExpress.Neo3;
 using System;
+using System.Linq;
 
 namespace nxp3.Commands
 {
@@ -23,9 +24,9 @@ namespace nxp3.Commands
                     var contracts = await blockchainOperations.ListContracts(chain)
                         .ConfigureAwait(false);
 
-                    for (int i = 0; i < contracts.Count; i++)
+                    foreach (var (hash, manifest) in contracts)
                     {
-                        console.WriteLine(contracts[i].ToJson().ToString(true));
+                        console.WriteLine($"{manifest.Name} ({hash})");
                     }
 
                     return 0;

--- a/src/nxp3/Commands/ContractCommand.List.cs
+++ b/src/nxp3/Commands/ContractCommand.List.cs
@@ -14,6 +14,9 @@ namespace nxp3.Commands
             [Option]
             string Input { get; } = string.Empty;
 
+            [Option()]
+            bool Json { get; } = false;
+
             internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
@@ -24,9 +27,27 @@ namespace nxp3.Commands
                     var contracts = await blockchainOperations.ListContracts(chain)
                         .ConfigureAwait(false);
 
-                    foreach (var (hash, manifest) in contracts)
+                    if (Json)
                     {
-                        console.WriteLine($"{manifest.Name} ({hash})");
+                        using var writer = new Newtonsoft.Json.JsonTextWriter(console.Out);
+                        writer.WriteStartArray();
+                        foreach (var (hash, manifest) in contracts)
+                        {
+                            writer.WriteStartObject();
+                            writer.WritePropertyName("name");
+                            writer.WriteValue(manifest.Name);
+                            writer.WritePropertyName("hash");
+                            writer.WriteValue(hash.ToString());
+                            writer.WriteEndObject();
+                        }
+                        writer.WriteEndArray();
+                    }
+                    else
+                    {
+                        foreach (var (hash, manifest) in contracts)
+                        {
+                            console.WriteLine($"{manifest.Name} ({hash})");
+                        }
                     }
 
                     return 0;

--- a/src/nxp3/Commands/OracleCommand.Enable.cs
+++ b/src/nxp3/Commands/OracleCommand.Enable.cs
@@ -13,6 +13,9 @@ namespace nxp3.Commands
             [Option]
             string Input { get; } = string.Empty;
 
+            [Option()]
+            bool Json { get; } = false;
+
             internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
@@ -23,6 +26,15 @@ namespace nxp3.Commands
                         .DesignateOracleRoles(chain, chain.ConsensusNodes.Select(n => n.Wallet.DefaultAccount))
                         .ConfigureAwait(false);
                     console.WriteLine($"Oracle Enable Transaction {txHash} submitted");
+
+                    if (Json)
+                    {
+                        console.WriteLine($"{txHash}");
+                    }
+                    else
+                    {
+                        console.WriteLine($"Transfer Transaction {txHash} submitted");
+                    }
 
                     return 0;
                 }

--- a/src/nxp3/Commands/TransferCommand.cs
+++ b/src/nxp3/Commands/TransferCommand.cs
@@ -23,6 +23,9 @@ namespace nxp3.Commands
         [Option]
         string Input { get; } = string.Empty;
 
+        [Option()]
+        bool Json { get; } = false;
+
         internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
         {
             try
@@ -43,7 +46,14 @@ namespace nxp3.Commands
 
                 var txHash = await blockchainOperations.Transfer(chain, Asset, Quantity, senderAccount, receiverAccount)
                     .ConfigureAwait(false);
-                console.WriteLine($"Transfer Transaction {txHash} submitted");
+                if (Json)
+                {
+                    console.WriteLine($"{txHash}");
+                }
+                else
+                {
+                    console.WriteLine($"Transfer Transaction {txHash} submitted");
+                }
 
                 return 0;
             }


### PR DESCRIPTION
This PR adapts Neo Express to changes introduced by https://github.com/neo-project/neo/pull/2044 (plus a few other recent changes)

* include script hash identification in `ListContractsAsync` and `ExpressListContracts` response
* include contract name (if available) in notify/log records + script hash and script identification in trace records
* Rename Nep5 operations/type to Nep17
* add `--json` option to several commands to produce machine readable output
