### PR TITLE
devhawk/more-rc1

### DIFF
--- a/src/neoxp/Commands/ContractCommand.Deploy.cs
+++ b/src/neoxp/Commands/ContractCommand.Deploy.cs
@@ -33,6 +33,9 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
+            [Option(Description = "Enable contract execution tracing")]
+            internal bool Trace { get; init; } = false;
+
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
@@ -53,7 +56,7 @@ namespace NeoExpress.Commands
                 try
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                    using var expressNode = chainManager.GetExpressNode();
+                    using var expressNode = chainManager.GetExpressNode(Trace);
                     await ExecuteAsync(chainManager, expressNode, fileSystem, Contract, Account, console.Out, Json).ConfigureAwait(false);
                     return 0;
                 }

--- a/src/neoxp/Commands/ContractCommand.Invoke.cs
+++ b/src/neoxp/Commands/ContractCommand.Invoke.cs
@@ -27,8 +27,8 @@ namespace NeoExpress.Commands
             [Argument(1, Description = "Account to pay contract invocation GAS fee")]
             internal string Account { get; init; } = string.Empty;
 
-            [Option("--test", Description = "Test invocation (does not cost GAS)")]
-            internal bool Test { get; init; } = false;
+            [Option(Description = "Invoke contract for results (does not cost GAS)")]
+            internal bool Results { get; init; } = false;
 
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
@@ -60,7 +60,7 @@ namespace NeoExpress.Commands
                 await writer.WriteTxHashAsync(txHash, "Deployment", json).ConfigureAwait(false);
             }
 
-            internal static async Task ExecuteTestAsync(IExpressChainManager chainManager, IExpressNode expressNode, string invocationFile, IFileSystem fileSystem, System.IO.TextWriter writer, bool json = false)
+            internal static async Task InvokeForResultsAsync(IExpressChainManager chainManager, IExpressNode expressNode, string invocationFile, IFileSystem fileSystem, System.IO.TextWriter writer, bool json = false)
             {
                 if (!fileSystem.File.Exists(invocationFile))
                 {
@@ -100,11 +100,11 @@ namespace NeoExpress.Commands
                 try
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                    using var expressNode = chainManager.GetExpressNode();
+                    using var expressNode = chainManager.GetExpressNode(Trace);
 
-                    if (Test)
+                    if (Results)
                     {
-                        await ExecuteTestAsync(chainManager, expressNode, InvocationFile, fileSystem, console.Out, Json);
+                        await InvokeForResultsAsync(chainManager, expressNode, InvocationFile, fileSystem, console.Out, Json);
                     }
                     else
                     {

--- a/src/neoxp/Commands/OracleCommand.Enable.cs
+++ b/src/neoxp/Commands/OracleCommand.Enable.cs
@@ -27,6 +27,9 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
+            [Option(Description = "Enable contract execution tracing")]
+            internal bool Trace { get; init; } = false;
+
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
@@ -35,7 +38,7 @@ namespace NeoExpress.Commands
                 try
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                    using var expressNode = chainManager.GetExpressNode();
+                    using var expressNode = chainManager.GetExpressNode(Trace);
                     await ExecuteAsync(chainManager, expressNode, Account, console.Out, Json);
                     return 0;
                 }

--- a/src/neoxp/Commands/TransferCommand.cs
+++ b/src/neoxp/Commands/TransferCommand.cs
@@ -37,6 +37,9 @@ namespace NeoExpress.Commands
         [Option(Description = "Path to neo-express data file")]
         internal string Input { get; init; } = string.Empty;
 
+        [Option(Description = "Enable contract execution tracing")]
+        internal bool Trace { get; init; } = false;
+
         [Option(Description = "Output as JSON")]
         internal bool Json { get; init; } = false;
 
@@ -77,7 +80,7 @@ namespace NeoExpress.Commands
             try
             {
                 var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                using var expressNode = chainManager.GetExpressNode();
+                using var expressNode = chainManager.GetExpressNode(Trace);
                 await ExecuteAsync(chainManager, expressNode, Quantity, Asset, Sender, Receiver, console.Out, Json).ConfigureAwait(false);
                 return 0;
             }

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -30,7 +30,7 @@ namespace NeoExpress.Node
         {
             this.ProtocolSettings = settings;
             this.chain = chain;
-            rpcClient = new RpcClient(new Uri($"http://localhost:{node.RpcPort}"));
+            rpcClient = new RpcClient(new Uri($"http://localhost:{node.RpcPort}"), protocolSettings: settings);
         }
 
         public void Dispose()


### PR DESCRIPTION
* Enabled offline `--trace` option for contract deploy, contract invoke, oracle enable and transfer commands
* changed contract invoke `--test` option to `--results` to avoid short name collision with `--trace` option 
* fixed rpc client settings issue
