### PR TITLE
contract invoke --results needs a mechanism to specify signers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         dotnet-version: '5.0.x'
     - name: Install nbgv
-      run: dotnet tool install nbgv --tool-path ./tools --version 3.3.37
+      run: dotnet tool install nbgv --tool-path ./tools
     - name: Run nbgv
       run: echo "NUGET_PACKAGE_VERSION=$(./tools/nbgv get-version -v NuGetPackageVersion)" >> $GITHUB_ENV
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
         fetch-depth: 0
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: Install nbgv
       run: dotnet tool install nbgv --tool-path ./tools --version 3.3.37
     - name: Run nbgv

--- a/eng/azure-ci.yml
+++ b/eng/azure-ci.yml
@@ -29,7 +29,7 @@ steps:
   displayName: 'use .NET Core SDK from global.json'
   inputs:
     packageType: 'sdk'
-    useGlobalJson: true
+    version: '5.0.x'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet pack'

--- a/src/neoxp/Commands/ContractCommand.Invoke.cs
+++ b/src/neoxp/Commands/ContractCommand.Invoke.cs
@@ -63,7 +63,7 @@ namespace NeoExpress.Commands
                     if (Results)
                     {
                         using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                        await txExec.InvokeForResultsAsync(InvocationFile);
+                        await txExec.InvokeForResultsAsync(InvocationFile, Account, WitnessScope);
                     }
                     else
                     {

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Neo;
+using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC;
 using Neo.Network.RPC.Models;
 using Neo.Persistence;
@@ -18,12 +19,15 @@ namespace NeoExpress
 
         public static IEnumerable<WalletAccount> GetMultiSigAccounts(this Wallet wallet) => wallet.GetAccounts().Where(IsMultiSigContract);
 
-        public static ApplicationEngine Invoke(this Neo.VM.ScriptBuilder builder, ProtocolSettings settings, DataCache snapshot) => Invoke(builder.ToArray(), settings, snapshot);
+        public static ApplicationEngine Invoke(this Neo.VM.ScriptBuilder builder, ProtocolSettings settings, DataCache snapshot, IVerifiable? container = null)
+            => Invoke(builder.ToArray(), settings, snapshot, container);
 
-        public static ApplicationEngine Invoke(this Neo.VM.Script script, ProtocolSettings settings, DataCache snapshot) => ApplicationEngine.Run(
-            script: script,
-            snapshot: snapshot,
-            settings: settings);
+        public static ApplicationEngine Invoke(this Neo.VM.Script script, ProtocolSettings settings, DataCache snapshot, IVerifiable? container = null)
+            => ApplicationEngine.Run(
+                script: script,
+                snapshot: snapshot,
+                settings: settings,
+                container: container);
 
         public static async Task WriteTxHashAsync(this TextWriter writer, UInt256 txHash, string txType = "", bool json = false)
         {

--- a/src/neoxp/IExpressNode.cs
+++ b/src/neoxp/IExpressNode.cs
@@ -21,7 +21,7 @@ namespace NeoExpress
 
         Task<CheckpointMode> CreateCheckpointAsync(string checkPointPath);
 
-        Task<RpcInvokeResult> InvokeAsync(Script script);
+        Task<RpcInvokeResult> InvokeAsync(Script script, Signer? signer = null);
         Task<UInt256> ExecuteAsync(Wallet wallet, UInt160 accountHash, WitnessScope witnessScope, Script script, decimal additionalGas = 0);
         Task<UInt256> SubmitOracleResponseAsync(OracleResponse response, IReadOnlyList<ECPoint> oracleNodes);
 

--- a/src/neoxp/ITransactionExecutor.cs
+++ b/src/neoxp/ITransactionExecutor.cs
@@ -9,7 +9,7 @@ namespace NeoExpress
         IExpressNode ExpressNode { get; }
         Task ContractDeployAsync(string contract, string account, string password, WitnessScope witnessScope, bool force);
         Task ContractInvokeAsync(string invocationFile, string account, string password, WitnessScope witnessScope);
-        Task InvokeForResultsAsync(string invocationFile);
+        Task InvokeForResultsAsync(string invocationFile, string account, WitnessScope witnessScope);
         Task TransferAsync(string quantity, string asset, string sender, string password, string receiver);
         Task OracleEnableAsync(string account, string password);
         Task OracleResponseAsync(string url, string responsePath, ulong? requestId = null);

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -6,6 +6,7 @@ using Akka.Actor;
 using Neo;
 using Neo.BlockchainToolkit.Models;
 using Neo.BlockchainToolkit.Persistence;
+using Neo.BlockchainToolkit.SmartContract;
 using Neo.Cryptography;
 using Neo.Cryptography.ECC;
 using Neo.IO;
@@ -110,15 +111,7 @@ namespace NeoExpress.Node
             {
                 if (disposedValue) return Task.FromException<RpcInvokeResult>(new ObjectDisposedException(nameof(OfflineNode)));
 
-                Transaction? tx = signer != null
-                    ? new Transaction
-                        {
-                            Signers = new[] { signer },
-                            Attributes = Array.Empty<TransactionAttribute>(),
-                            Witnesses = Array.Empty<Witness>(),
-                        }
-                    : null;
-
+                Transaction tx = TestApplicationEngine.CreateTestTransaction(signer);
                 using ApplicationEngine engine = script.Invoke(neoSystem.Settings, neoSystem.StoreView, tx);
                 return Task.FromResult(new RpcInvokeResult()
                 {

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -104,13 +104,22 @@ namespace NeoExpress.Node
             }
         }
 
-        public Task<RpcInvokeResult> InvokeAsync(Neo.VM.Script script)
+        public Task<RpcInvokeResult> InvokeAsync(Neo.VM.Script script, Signer? signer = null)
         {
             try
             {
                 if (disposedValue) return Task.FromException<RpcInvokeResult>(new ObjectDisposedException(nameof(OfflineNode)));
 
-                using ApplicationEngine engine = script.Invoke(neoSystem.Settings, neoSystem.StoreView);
+                Transaction? tx = signer != null
+                    ? new Transaction
+                        {
+                            Signers = new[] { signer },
+                            Attributes = Array.Empty<TransactionAttribute>(),
+                            Witnesses = Array.Empty<Witness>(),
+                        }
+                    : null;
+
+                using ApplicationEngine engine = script.Invoke(neoSystem.Settings, neoSystem.StoreView, tx);
                 return Task.FromResult(new RpcInvokeResult()
                 {
                     State = engine.State,

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -43,9 +43,11 @@ namespace NeoExpress.Node
             return IExpressNode.CheckpointMode.Online;
         }
 
-        public Task<RpcInvokeResult> InvokeAsync(Script script)
+        public Task<RpcInvokeResult> InvokeAsync(Script script, Signer? signer = null)
         {
-            return rpcClient.InvokeScriptAsync(script);
+            return signer == null
+                ? rpcClient.InvokeScriptAsync(script)
+                : rpcClient.InvokeScriptAsync(script, signer);
         }
 
         public async Task<UInt256> ExecuteAsync(Wallet wallet, UInt160 accountHash, WitnessScope witnessScope, Script script,  decimal additionalGas = 0)

--- a/src/neoxp/neoxp.csproj
+++ b/src/neoxp/neoxp.csproj
@@ -35,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Neo.BlockchainToolkit3" Version="1.0.47-preview"/>
+    <PackageReference Include="Neo.BlockchainToolkit3" Version="1.0.50-preview"/>
     <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoVersion)"/>
     <PackageReference Include="Neo.Network.RPC.RpcClient" Version="$(NeoVersion)"/>
     <PackageReference Include="Neo.Plugins.RpcServer" Version="$(NeoVersion)"/>

--- a/src/neoxp/neoxp.csproj
+++ b/src/neoxp/neoxp.csproj
@@ -35,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Neo.BlockchainToolkit3" Version="1.0.50-preview"/>
+    <PackageReference Include="Neo.BlockchainToolkit3" Version="1.0.51-preview"/>
     <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoVersion)"/>
     <PackageReference Include="Neo.Network.RPC.RpcClient" Version="$(NeoVersion)"/>
     <PackageReference Include="Neo.Plugins.RpcServer" Version="$(NeoVersion)"/>


### PR DESCRIPTION
Fixes #146

This PR plumbs `contract invoke` Account and WitnessScope arguments thru when using `--results`. 

This enables contracts that use `(Transaction)Runtime.ScriptContainer` to be supported in `--results` operations