### PR TITLE
Add contract run command

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -51,7 +51,7 @@ namespace NeoExpress.Commands
             }
 
             [Command("contract")]
-            [Subcommand(typeof(Deploy), typeof(Invoke))]
+            [Subcommand(typeof(Deploy), typeof(Invoke), typeof(Run))]
             internal class Contract
             {
                 [Command("deploy")]
@@ -84,6 +84,32 @@ namespace NeoExpress.Commands
                     internal string InvocationFile { get; init; } = string.Empty;
 
                     [Argument(1, Description = "Account to pay contract invocation GAS fee")]
+                    [Required]
+                    internal string Account { get; init; } = string.Empty;
+
+                    [Option(Description = "password to use for NEP-2/NEP-6 account")]
+                    internal string Password { get; init; } = string.Empty;
+
+                    [Option(Description = "Witness Scope to use for transaction signer (Default: CalledByEntry)")]
+                    [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
+                    internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
+                }
+
+                [Command("run")]
+                internal class Run
+                {
+                    [Argument(0, Description = "Contract name or invocation hash")]
+                    [Required]
+                    internal string Contract { get; init; } = string.Empty;
+
+                    [Argument(1, Description = "Contract method to invoke")]
+                    [Required]
+                    internal string Method { get; init; } = string.Empty;
+
+                    [Argument(2, Description = "Arguments to pass to contract")]
+                    internal string[] Arguments { get; init; } = Array.Empty<string>();
+
+                    [Option(Description = "Account to pay contract invocation GAS fee")]
                     [Required]
                     internal string Account { get; init; } = string.Empty;
 

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -121,6 +121,19 @@ namespace NeoExpress.Commands
                                 cmd.Model.WitnessScope).ConfigureAwait(false);
                             break;
                         }
+                    case CommandLineApplication<BatchFileCommands.Contract.Run> cmd:
+                        {
+                            var script = await txExec.BuildInvocationScriptAsync(
+                                cmd.Model.Contract, 
+                                cmd.Model.Method, 
+                                cmd.Model.Arguments).ConfigureAwait(false);
+                            await txExec.ContractInvokeAsync(
+                                script,
+                                cmd.Model.Account,
+                                cmd.Model.Password,
+                                cmd.Model.WitnessScope).ConfigureAwait(false);
+                            break;
+                        }
                     case CommandLineApplication<BatchFileCommands.Oracle.Enable> cmd:
                         {
                             await txExec.OracleEnableAsync(

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -112,8 +112,10 @@ namespace NeoExpress.Commands
                         }
                     case CommandLineApplication<BatchFileCommands.Contract.Invoke> cmd:
                         {
+                            var script = await txExec.LoadInvocationScriptAsync(
+                                cmd.Model.InvocationFile).ConfigureAwait(false);
                             await txExec.ContractInvokeAsync(
-                                cmd.Model.InvocationFile,
+                                script,
                                 cmd.Model.Account,
                                 cmd.Model.Password,
                                 cmd.Model.WitnessScope).ConfigureAwait(false);

--- a/src/neoxp/Commands/ContractCommand.Invoke.cs
+++ b/src/neoxp/Commands/ContractCommand.Invoke.cs
@@ -8,7 +8,8 @@ namespace NeoExpress.Commands
 {
     partial class ContractCommand
     {
-        [Command(Name = "invoke")]
+
+        [Command(Name = "invoke", Description = "Invoke a contract using parameters from .neo-invoke.json file")]
         internal class Invoke
         {
             readonly IExpressChainManagerFactory chainManagerFactory;
@@ -59,17 +60,17 @@ namespace NeoExpress.Commands
                     }
 
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+                    using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
+                    var script = await txExec.LoadInvocationScriptAsync(InvocationFile).ConfigureAwait(false);
 
                     if (Results)
                     {
-                        using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                        await txExec.InvokeForResultsAsync(InvocationFile, Account, WitnessScope);
+                        await txExec.InvokeForResultsAsync(script, Account, WitnessScope);
                     }
                     else
                     {
                         var password = chainManager.Chain.ResolvePassword(Account, Password);
-                        using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                        await txExec.ContractInvokeAsync(InvocationFile, Account, password, WitnessScope);
+                        await txExec.ContractInvokeAsync(script, Account, password, WitnessScope);
                     }
 
                     return 0;

--- a/src/neoxp/Commands/ContractCommand.Run.cs
+++ b/src/neoxp/Commands/ContractCommand.Run.cs
@@ -1,0 +1,98 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Neo.Network.P2P.Payloads;
+
+namespace NeoExpress.Commands
+{
+    partial class ContractCommand
+    {
+        [Command(Name = "run", Description = "Invoke a contract using parameters passed on command line")]
+        internal class Run
+        {
+            readonly IExpressChainManagerFactory chainManagerFactory;
+            readonly ITransactionExecutorFactory txExecutorFactory;
+
+            public Run(IExpressChainManagerFactory chainManagerFactory, ITransactionExecutorFactory txExecutorFactory)
+            {
+                this.chainManagerFactory = chainManagerFactory;
+                this.txExecutorFactory = txExecutorFactory;
+            }
+
+            [Argument(0, Description = "Contract name or invocation hash")]
+            [Required]
+            internal string Contract { get; init; } = string.Empty;
+
+            [Argument(1, Description = "Contract method to invoke")]
+            [Required]
+            internal string Method { get; init; } = string.Empty;
+
+            [Argument(2, Description = "Contract method to invoke")]
+            internal string[] Arguments { get; init; } = Array.Empty<string>();
+
+            [Option(Description = "Account to pay contract invocation GAS fee")]
+            internal string Account { get; init; } = string.Empty;
+
+            [Option(Description = "Witness Scope to use for transaction signer (Default: CalledByEntry)")]
+            [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
+            internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
+
+            [Option(Description = "Invoke contract for results (does not cost GAS)")]
+            internal bool Results { get; init; } = false;
+
+            [Option("--gas|-g", CommandOptionType.SingleValue, Description = "Additional GAS to apply to the contract invocation")]
+            internal decimal AdditionalGas { get; init; } = 0;
+
+            [Option(Description = "password to use for NEP-2/NEP-6 account")]
+            internal string Password { get; init; } = string.Empty;
+
+            [Option(Description = "Enable contract execution tracing")]
+            internal bool Trace { get; init; } = false;
+
+            [Option(Description = "Output as JSON")]
+            internal bool Json { get; init; } = false;
+
+            [Option(Description = "Path to neo-express data file")]
+            internal string Input { get; init; } = string.Empty;
+
+            internal async Task<int> OnExecuteAsync(IConsole console)
+            {
+                try
+                {
+                    if (string.IsNullOrEmpty(Account) && !Results)
+                    {
+                        throw new Exception("Either --account or --results must be specified");
+                    }
+
+                    var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+                    using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
+                    var script = await txExec.BuildInvocationScriptAsync(Contract, Method, Arguments).ConfigureAwait(false);
+
+                    if (Results)
+                    {
+                        await txExec.InvokeForResultsAsync(script, Account, WitnessScope);
+                    }
+                    else
+                    {
+                        var password = chainManager.Chain.ResolvePassword(Account, Password);
+                        await txExec.ContractInvokeAsync(script, Account, password, WitnessScope);
+                    }
+
+
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    await console.Error.WriteLineAsync($"{ex.Message} [{ex.GetType().Name}]").ConfigureAwait(false);
+                    while (ex.InnerException != null)
+                    {
+                        await console.Error.WriteLineAsync($"  Contract Exception: {ex.InnerException.Message} [{ex.InnerException.GetType().Name}]").ConfigureAwait(false);
+                        ex = ex.InnerException;
+                    }
+                    return 1;
+                }
+            }
+        }
+    }
+}

--- a/src/neoxp/Commands/ContractCommand.cs
+++ b/src/neoxp/Commands/ContractCommand.cs
@@ -3,7 +3,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace NeoExpress.Commands
 {
     [Command("contract", Description = "Manage smart contracts")]
-    [Subcommand(typeof(Deploy), typeof(Get), typeof(Invoke), typeof(List), typeof(Storage))]
+    [Subcommand(typeof(Deploy), typeof(Get), typeof(Invoke), typeof(List), typeof(Run), typeof(Storage))]
     partial class ContractCommand
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)

--- a/src/neoxp/ITransactionExecutor.cs
+++ b/src/neoxp/ITransactionExecutor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Neo.Network.P2P.Payloads;
+using Neo.VM;
 
 namespace NeoExpress
 {
@@ -8,8 +9,9 @@ namespace NeoExpress
     {
         IExpressNode ExpressNode { get; }
         Task ContractDeployAsync(string contract, string account, string password, WitnessScope witnessScope, bool force);
-        Task ContractInvokeAsync(string invocationFile, string account, string password, WitnessScope witnessScope);
-        Task InvokeForResultsAsync(string invocationFile, string account, WitnessScope witnessScope);
+        Task<Script> LoadInvocationScriptAsync(string invocationFile);
+        Task ContractInvokeAsync(Script script, string account, string password, WitnessScope witnessScope);
+        Task InvokeForResultsAsync(Script script, string account, WitnessScope witnessScope);
         Task TransferAsync(string quantity, string asset, string sender, string password, string receiver);
         Task OracleEnableAsync(string account, string password);
         Task OracleResponseAsync(string url, string responsePath, ulong? requestId = null);

--- a/src/neoxp/ITransactionExecutor.cs
+++ b/src/neoxp/ITransactionExecutor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neo.Network.P2P.Payloads;
 using Neo.VM;
@@ -10,6 +11,7 @@ namespace NeoExpress
         IExpressNode ExpressNode { get; }
         Task ContractDeployAsync(string contract, string account, string password, WitnessScope witnessScope, bool force);
         Task<Script> LoadInvocationScriptAsync(string invocationFile);
+        Task<Script> BuildInvocationScriptAsync(string contract, string operation, IReadOnlyList<string>? arguments = null);
         Task ContractInvokeAsync(Script script, string account, string password, WitnessScope witnessScope);
         Task InvokeForResultsAsync(Script script, string account, WitnessScope witnessScope);
         Task TransferAsync(string quantity, string asset, string sender, string password, string receiver);


### PR DESCRIPTION
adds new `contract run` command that accepts contract id (name or hash), method and arguments on the command line.  `contract run` also supported for batch command

fixes #150