### PR TITLE
Update for Neo RC4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.4.205</Version>
+      <Version>3.4.220</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -46,8 +46,7 @@ namespace NeoExpress.Models
             ScriptHash = reader.ReadSerializable<UInt160>();
             State = (Neo.VM.Types.Array)BinarySerializer.Deserialize(
                 reader,
-                ExecutionEngineLimits.Default.MaxStackSize,
-                ExecutionEngineLimits.Default.MaxItemSize,
+                ExecutionEngineLimits.Default,
                 null);
             EventName = reader.ReadVarString();
             InventoryHash = reader.ReadSerializable<UInt256>();

--- a/src/neoxp/neoxp.csproj
+++ b/src/neoxp/neoxp.csproj
@@ -6,7 +6,7 @@
     <Copyright>2015-2021 The Neo Project</Copyright>
     <Description>neo-express is a Neo developer blockchain tool</Description>
     <LangVersion>9</LangVersion>
-    <NeoVersion>3.0.0-rc3</NeoVersion>
+    <NeoVersion>3.0.0-rc4</NeoVersion>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <PackageIcon>neo-logo-72.png</PackageIcon>
@@ -35,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Neo.BlockchainToolkit3" Version="1.0.54-preview"/>
+    <PackageReference Include="Neo.BlockchainToolkit3" Version="1.0.56-preview"/>
     <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoVersion)"/>
     <PackageReference Include="Neo.Network.RPC.RpcClient" Version="$(NeoVersion)"/>
     <PackageReference Include="Neo.Plugins.RpcServer" Version="$(NeoVersion)"/>


### PR DESCRIPTION
* Update to Neo RC4 version of bctk-lib
* adapted to minor breaking change in BinarySerializer.Deserialize