### PR TITLE
--stack-trace + WriteException

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ may not exactly match a publicly released version.
 * `policy` command (#173)
 * `contract hash` command (#170)
 * `chain.SecondsPerBlock` setting (#171)
+* `--stack-trace` option (#174)
 
 ## [3.0.5] 2021-08-10
 

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -37,7 +37,7 @@ namespace NeoExpress.Commands
         [Option(Description = "Path to neo-express data file")]
         internal string Input { get; init; } = string.Empty;
 
-        internal async Task<int> OnExecuteAsync(IConsole console, CancellationToken token)
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
         {
             try
             {
@@ -48,7 +48,7 @@ namespace NeoExpress.Commands
             }
             catch (Exception ex)
             {
-                await console.Error.WriteLineAsync(ex.Message).ConfigureAwait(false);
+                app.WriteException(ex);
                 return 1;
             }
         }

--- a/src/neoxp/Commands/CheckpointCommand.Create.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Create.cs
@@ -27,7 +27,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Overwrite existing data")]
             internal bool Force { get; }
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -38,7 +38,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/CheckpointCommand.Restore.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Restore.cs
@@ -26,7 +26,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Overwrite existing data")]
             internal bool Force { get; }
 
-            internal int OnExecute(IConsole console)
+            internal int OnExecute(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -37,7 +37,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    console.Error.WriteLine(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/CheckpointCommand.Run.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Run.cs
@@ -45,7 +45,7 @@ namespace NeoExpress.Commands
                 await chainManager.RunAsync(storageProvider, chain.ConsensusNodes[0], Trace, console.Out, token);
             }
 
-            internal async Task<int> OnExecuteAsync(IConsole console, CancellationToken token)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
             {
                 try
                 {
@@ -54,7 +54,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.Deploy.cs
+++ b/src/neoxp/Commands/ContractCommand.Deploy.cs
@@ -47,7 +47,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -59,7 +59,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.Get.cs
+++ b/src/neoxp/Commands/ContractCommand.Get.cs
@@ -35,7 +35,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.Hash.cs
+++ b/src/neoxp/Commands/ContractCommand.Hash.cs
@@ -32,7 +32,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -51,7 +51,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.Invoke.cs
+++ b/src/neoxp/Commands/ContractCommand.Invoke.cs
@@ -49,7 +49,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -76,12 +76,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync($"{ex.Message} [{ex.GetType().Name}]").ConfigureAwait(false);
-                    while (ex.InnerException != null)
-                    {
-                        await console.Error.WriteLineAsync($"  Contract Exception: {ex.InnerException.Message} [{ex.InnerException.GetType().Name}]").ConfigureAwait(false);
-                        ex = ex.InnerException;
-                    }
+                    app.WriteException(ex, showInnerExceptions: true);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.List.cs
+++ b/src/neoxp/Commands/ContractCommand.List.cs
@@ -63,7 +63,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message).ConfigureAwait(false);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.Run.cs
+++ b/src/neoxp/Commands/ContractCommand.Run.cs
@@ -56,7 +56,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -79,17 +79,11 @@ namespace NeoExpress.Commands
                         await txExec.ContractInvokeAsync(script, Account, password, WitnessScope, AdditionalGas);
                     }
 
-
                     return 0;
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync($"{ex.Message} [{ex.GetType().Name}]").ConfigureAwait(false);
-                    while (ex.InnerException != null)
-                    {
-                        await console.Error.WriteLineAsync($"  Contract Exception: {ex.InnerException.Message} [{ex.InnerException.GetType().Name}]").ConfigureAwait(false);
-                        ex = ex.InnerException;
-                    }
+                    app.WriteException(ex, showInnerExceptions: true);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -105,7 +105,7 @@ namespace NeoExpress.Commands
                 }
             }
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -114,7 +114,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -27,7 +27,7 @@ namespace NeoExpress.Commands
         [Option(Description = "Overwrite existing data")]
         internal bool Force { get; set; }
 
-        internal int OnExecute(IConsole console)
+        internal int OnExecute(CommandLineApplication app, IConsole console)
         {
             try
             {
@@ -42,7 +42,7 @@ namespace NeoExpress.Commands
             }
             catch (Exception ex)
             {
-                console.Error.WriteLine(ex.Message);
+                app.WriteException(ex);
                 return 1;
             }
         }

--- a/src/neoxp/Commands/ExportCommand.cs
+++ b/src/neoxp/Commands/ExportCommand.cs
@@ -50,7 +50,7 @@ namespace NeoExpress.Commands
             }
             catch (Exception ex)
             {
-                console.Error.WriteLine(ex.Message);
+                app.WriteException(ex);
                 return 1;
             }
         }

--- a/src/neoxp/Commands/OracleCommand.Enable.cs
+++ b/src/neoxp/Commands/OracleCommand.Enable.cs
@@ -35,7 +35,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -47,7 +47,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/OracleCommand.List.cs
+++ b/src/neoxp/Commands/OracleCommand.List.cs
@@ -33,7 +33,7 @@ namespace NeoExpress.Commands
                 }
             }
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -42,7 +42,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/OracleCommand.Requests.cs
+++ b/src/neoxp/Commands/OracleCommand.Requests.cs
@@ -34,7 +34,7 @@ namespace NeoExpress.Commands
                 }
             }
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -43,7 +43,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/OracleCommand.Response.cs
+++ b/src/neoxp/Commands/OracleCommand.Response.cs
@@ -36,7 +36,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -47,7 +47,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/PolicyCommand.Block.cs
+++ b/src/neoxp/Commands/PolicyCommand.Block.cs
@@ -39,7 +39,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -51,7 +51,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/PolicyCommand.Get.cs
+++ b/src/neoxp/Commands/PolicyCommand.Get.cs
@@ -39,7 +39,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
+++ b/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
@@ -43,7 +43,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/PolicyCommand.Set.cs
+++ b/src/neoxp/Commands/PolicyCommand.Set.cs
@@ -45,7 +45,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -56,7 +56,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/PolicyCommand.Unblock.cs
+++ b/src/neoxp/Commands/PolicyCommand.Unblock.cs
@@ -39,7 +39,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Output as JSON")]
             internal bool Json { get; init; } = false;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -51,7 +51,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ResetCommand.cs
+++ b/src/neoxp/Commands/ResetCommand.cs
@@ -56,7 +56,7 @@ namespace NeoExpress.Commands
             }
         }
 
-        internal int OnExecute(IConsole console)
+        internal int OnExecute(CommandLineApplication app, IConsole console)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace NeoExpress.Commands
             }
             catch (Exception ex)
             {
-                console.Error.WriteLine(ex.Message);
+                app.WriteException(ex);
                 return 1;
             }
         }

--- a/src/neoxp/Commands/RunCommand.cs
+++ b/src/neoxp/Commands/RunCommand.cs
@@ -42,7 +42,7 @@ namespace NeoExpress.Commands
             await chainManager.RunAsync(storageProvider, node, Trace, console.Out, token);
         }
 
-        internal async Task<int> OnExecuteAsync(IConsole console, CancellationToken token)
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
         {
             try
             {
@@ -51,7 +51,7 @@ namespace NeoExpress.Commands
             }
             catch (Exception ex)
             {
-                await console.Error.WriteLineAsync(ex.Message);
+                app.WriteException(ex);
                 return 1;
             }
         }

--- a/src/neoxp/Commands/ShowCommand.Balance.cs
+++ b/src/neoxp/Commands/ShowCommand.Balance.cs
@@ -28,7 +28,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -45,7 +45,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ShowCommand.Balances.cs
+++ b/src/neoxp/Commands/ShowCommand.Balances.cs
@@ -24,7 +24,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
-            internal async Task<int> OnExecuteAsync(IConsole console)
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -52,7 +52,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ShowCommand.Block.cs
+++ b/src/neoxp/Commands/ShowCommand.Block.cs
@@ -34,7 +34,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/ShowCommand.Transaction.cs
+++ b/src/neoxp/Commands/ShowCommand.Transaction.cs
@@ -37,7 +37,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    await console.Error.WriteLineAsync(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/StopCommand.cs
+++ b/src/neoxp/Commands/StopCommand.cs
@@ -56,7 +56,7 @@ namespace NeoExpress.Commands
             }
         }
 
-        internal async Task<int> OnExecuteAsync(IConsole console)
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace NeoExpress.Commands
             }
             catch (Exception ex)
             {
-                await console.Error.WriteLineAsync(ex.Message).ConfigureAwait(false);
+                app.WriteException(ex);
                 return 1;
             }
         }

--- a/src/neoxp/Commands/TransferCommand.cs
+++ b/src/neoxp/Commands/TransferCommand.cs
@@ -45,7 +45,7 @@ namespace NeoExpress.Commands
         [Option(Description = "Output as JSON")]
         internal bool Json { get; init; } = false;
 
-        internal async Task<int> OnExecuteAsync(IConsole console)
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
         {
             try
             {

--- a/src/neoxp/Commands/WalletCommand.Create.cs
+++ b/src/neoxp/Commands/WalletCommand.Create.cs
@@ -61,7 +61,7 @@ namespace NeoExpress.Commands
                 return expressWallet;
             }
 
-            internal int OnExecute(IConsole console)
+            internal int OnExecute(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -77,7 +77,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    console.Error.WriteLine(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/WalletCommand.Delete.cs
+++ b/src/neoxp/Commands/WalletCommand.Delete.cs
@@ -48,7 +48,7 @@ namespace NeoExpress.Commands
                 }
             }
 
-            internal int OnExecute(IConsole console)
+            internal int OnExecute(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -58,7 +58,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    console.Error.WriteLine(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/WalletCommand.Export.cs
+++ b/src/neoxp/Commands/WalletCommand.Export.cs
@@ -65,7 +65,7 @@ namespace NeoExpress.Commands
                 return output;
             }
 
-            private int OnExecute(IConsole console)
+            private int OnExecute(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -75,7 +75,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    console.Error.WriteLine(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Commands/WalletCommand.List.cs
+++ b/src/neoxp/Commands/WalletCommand.List.cs
@@ -55,7 +55,7 @@ namespace NeoExpress.Commands
                 }
             }
 
-            internal int OnExecute(IConsole console)
+            internal int OnExecute(CommandLineApplication app, IConsole console)
             {
                 try
                 {
@@ -64,7 +64,7 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    console.Error.WriteLine(ex.Message);
+                    app.WriteException(ex);
                     return 1;
                 }
             }

--- a/src/neoxp/Program.cs
+++ b/src/neoxp/Program.cs
@@ -37,6 +37,7 @@ namespace NeoExpress
                 .BuildServiceProvider();
 
             var app = new CommandLineApplication<Program>();
+            app.Option<bool>("--stack-trace", "", CommandOptionType.NoValue, o => o.ShowInHelpText = false, inherited: true);
             app.Conventions
                 .UseDefaultConventions()
                 .UseConstructorInjection(services);


### PR DESCRIPTION
add global --stack-trace option to assist in remote troubleshooting.

Standardize command catch blocks to call WriteException extension method