### PR TITLE
add NeoExpress fast forward command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fix releases, but
 may not exactly match a publicly released version.
 
+## Unreleased
+
+* Added NeoExpress fast forward command (#182)
+
 ## [3.0.19] 2021-10-12
 
 ### Added

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -567,6 +567,23 @@ The commands supported in a batch file include:
 * `policy unblock`
 * `transfer`
 
+## neoxp fastfwd
+
+```
+Usage: neoxp fastfwd [options] <Count>
+
+Arguments:
+  Count               Number of blocks to mint     
+
+Options:
+  -i|--input <INPUT>  Path to neo-express data file
+  -?|-h|--help        Show help information.   
+```
+
+The `fastfwd` command generates the specified number of empty blocks. This is useful for testing scenarios
+such as voting on a proposal where some amount of time (measured in minted blocks) must pass between
+operations.
+
 ## neoxp oracle
 
 The `oracle` command has a series of subcommands for configuring Neo-express' oracle subsystem as well

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -9,7 +9,7 @@ namespace NeoExpress.Commands
     partial class BatchCommand
     {
         [Command]
-        [Subcommand(typeof(Checkpoint), typeof(Contract), typeof(Oracle), typeof(Policy), typeof(Transfer))]
+        [Subcommand(typeof(Checkpoint), typeof(Contract), typeof(FastForward), typeof(Oracle), typeof(Policy), typeof(Transfer))]
         internal class BatchFileCommands
         {
             [Command("checkpoint")]
@@ -98,6 +98,14 @@ namespace NeoExpress.Commands
                     [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
                     internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
                 }
+            }
+
+            [Command("fastfwd")]
+            internal class FastForward
+            {
+                [Argument(0, Description = "Number of blocks to mint")]
+                [Required]
+                internal uint Count { get; init; } = 1;
             }
 
             [Command("oracle")]

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -139,8 +139,7 @@ namespace NeoExpress.Commands
                         }
                     case CommandLineApplication<BatchFileCommands.FastForward> cmd:
                         {
-                            var offlineNode = (Node.OfflineNode)txExec.ExpressNode;
-                            await offlineNode.MintEmptyBlocksAsync(cmd.Model.Count).ConfigureAwait(false);
+                            await txExec.ExpressNode.FastForwardAsync(cmd.Model.Count).ConfigureAwait(false);
                             await writer.WriteLineAsync($"{cmd.Model.Count} empty blocks minted").ConfigureAwait(false);
                             break;
                         }

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -137,6 +137,13 @@ namespace NeoExpress.Commands
                                 cmd.Model.WitnessScope).ConfigureAwait(false);
                             break;
                         }
+                    case CommandLineApplication<BatchFileCommands.FastForward> cmd:
+                        {
+                            var offlineNode = (Node.OfflineNode)txExec.ExpressNode;
+                            await offlineNode.MintEmptyBlocksAsync(cmd.Model.Count).ConfigureAwait(false);
+                            await writer.WriteLineAsync($"{cmd.Model.Count} empty blocks minted").ConfigureAwait(false);
+                            break;
+                        }
                     case CommandLineApplication<BatchFileCommands.Oracle.Enable> cmd:
                         {
                             await txExec.OracleEnableAsync(

--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -27,7 +27,8 @@ namespace NeoExpress.Commands
             try
             {
                 var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                await chainManager.FastForwardAsync(Count).ConfigureAwait(false);
+                using var expressNode = chainManager.GetExpressNode();
+                await expressNode.FastForwardAsync(Count).ConfigureAwait(false);
                 await console.Out.WriteLineAsync($"{Count} empty blocks minted").ConfigureAwait(false);
                 return 0;
             }

--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -1,0 +1,41 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace NeoExpress.Commands
+{
+    [Command("fastfwd", Description = "")]
+    class FastForwardCommand
+    {
+        readonly IExpressChainManagerFactory chainManagerFactory;
+
+        public FastForwardCommand(IExpressChainManagerFactory chainManagerFactory)
+        {
+            this.chainManagerFactory = chainManagerFactory;
+        }
+
+        [Argument(0, Description = "Number of blocks to mint")]
+        [Required]
+        internal uint Count { get; init; } = 1;
+
+        [Option(Description = "Path to neo-express data file")]
+        internal string Input { get; init; } = string.Empty;
+
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
+        {
+            try
+            {
+                var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+                await chainManager.FastForwardAsync(Count).ConfigureAwait(false);
+                await console.Out.WriteLineAsync($"{Count} empty blocks minted").ConfigureAwait(false);
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                await console.Error.WriteLineAsync(ex.Message);
+                return 1;
+            }
+        }
+    }
+}

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -387,19 +387,5 @@ namespace NeoExpress
 
             return GetOfflineNode(offlineTrace);
         }
-
-        public async Task FastForwardAsync(uint blockCount)
-        {
-            for (int i = 0; i < chain.ConsensusNodes.Count; i++)
-            {
-                if (IsNodeRunning(chain.ConsensusNodes[i]))
-                {
-                    throw new InvalidOperationException("cannot fast forward while node is running");
-                }
-            }
-
-            var offlineNode = GetOfflineNode();
-            await offlineNode.MintEmptyBlocksAsync(blockCount).ConfigureAwait(false);
-        }
     }
 }

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -358,6 +358,19 @@ namespace NeoExpress
             return new CheckpointStorageProvider(rocksDbStorageProvider, checkpointCleanup: folderCleanup);
         }
 
+        OfflineNode GetOfflineNode(bool offlineTrace = false)
+        {
+            var node = chain.ConsensusNodes[0];
+            var nodePath = fileSystem.GetNodePath(node);
+            if (!fileSystem.Directory.Exists(nodePath)) fileSystem.Directory.CreateDirectory(nodePath);
+
+            return new Node.OfflineNode(ProtocolSettings,
+                RocksDbStorageProvider.Open(nodePath),
+                node.Wallet,
+                chain,
+                offlineTrace);
+        }
+
         public IExpressNode GetExpressNode(bool offlineTrace = false)
         {
             // Check to see if there's a neo-express blockchain currently running by
@@ -372,15 +385,21 @@ namespace NeoExpress
                 }
             }
 
-            var node = chain.ConsensusNodes[0];
-            var nodePath = fileSystem.GetNodePath(node);
-            if (!fileSystem.Directory.Exists(nodePath)) fileSystem.Directory.CreateDirectory(nodePath);
+            return GetOfflineNode(offlineTrace);
+        }
 
-            return new Node.OfflineNode(ProtocolSettings,
-                RocksDbStorageProvider.Open(nodePath),
-                node.Wallet,
-                chain,
-                offlineTrace);
+        public async Task FastForwardAsync(uint blockCount)
+        {
+            for (int i = 0; i < chain.ConsensusNodes.Count; i++)
+            {
+                if (IsNodeRunning(chain.ConsensusNodes[i]))
+                {
+                    throw new InvalidOperationException("cannot fast forward while node is running");
+                }
+            }
+
+            var offlineNode = GetOfflineNode();
+            await offlineNode.MintEmptyBlocksAsync(blockCount).ConfigureAwait(false);
         }
     }
 }

--- a/src/neoxp/IExpressChainManager.cs
+++ b/src/neoxp/IExpressChainManager.cs
@@ -15,7 +15,6 @@ namespace NeoExpress
 
         Task<(string path, IExpressNode.CheckpointMode checkpointMode)> CreateCheckpointAsync(IExpressNode expressNode, string checkPointPath, bool force, System.IO.TextWriter? writer = null);
         IDisposableStorageProvider GetCheckpointStorageProvider(string checkPointPath);
-        Task FastForwardAsync(uint blockCount);
         IExpressNode GetExpressNode(bool offlineTrace = false);
         IDisposableStorageProvider GetNodeStorageProvider(ExpressConsensusNode node, bool discard);
         bool IsRunning(ExpressConsensusNode? node = null);

--- a/src/neoxp/IExpressChainManager.cs
+++ b/src/neoxp/IExpressChainManager.cs
@@ -15,6 +15,7 @@ namespace NeoExpress
 
         Task<(string path, IExpressNode.CheckpointMode checkpointMode)> CreateCheckpointAsync(IExpressNode expressNode, string checkPointPath, bool force, System.IO.TextWriter? writer = null);
         IDisposableStorageProvider GetCheckpointStorageProvider(string checkPointPath);
+        Task FastForwardAsync(uint blockCount);
         IExpressNode GetExpressNode(bool offlineTrace = false);
         IDisposableStorageProvider GetNodeStorageProvider(ExpressConsensusNode node, bool discard);
         bool IsRunning(ExpressConsensusNode? node = null);

--- a/src/neoxp/IExpressChainManagerFactory.cs
+++ b/src/neoxp/IExpressChainManagerFactory.cs
@@ -2,7 +2,6 @@ namespace NeoExpress
 {
     internal interface IExpressChainManagerFactory
     {
-        (IExpressChainManager manager, string path) CreateChain(int nodeCount, string outputPath, bool force, uint secondsPerBlock = 0) => CreateChain(nodeCount, null, outputPath, force, secondsPerBlock);
         (IExpressChainManager manager, string path) CreateChain(int nodeCount, byte? addressVersion, string outputPath, bool force, uint secondsPerBlock = 0);
         (IExpressChainManager manager, string path) LoadChain(string path, uint? secondsPerBlock = null);
     }

--- a/src/neoxp/IExpressNode.cs
+++ b/src/neoxp/IExpressNode.cs
@@ -24,6 +24,7 @@ namespace NeoExpress
         Task<RpcInvokeResult> InvokeAsync(Script script, Signer? signer = null);
         Task<UInt256> ExecuteAsync(Wallet wallet, UInt160 accountHash, WitnessScope witnessScope, Script script, decimal additionalGas = 0);
         Task<UInt256> SubmitOracleResponseAsync(OracleResponse response, IReadOnlyList<ECPoint> oracleNodes);
+        Task FastForwardAsync(uint blockCount);
 
         Task<Block> GetBlockAsync(UInt256 blockHash);
         Task<Block> GetBlockAsync(uint blockIndex);

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -181,7 +181,7 @@ namespace NeoExpress.Node
             return tx.Hash;
         }
 
-        public async Task MintEmptyBlocksAsync(uint blockCount)
+        public async Task FastForwardAsync(uint blockCount)
         {
             if (disposedValue) throw new ObjectDisposedException(nameof(OfflineNode));
 
@@ -196,75 +196,74 @@ namespace NeoExpress.Node
             if (disposedValue) throw new ObjectDisposedException(nameof(OfflineNode));
 
             var transactions = tx == null ? Array.Empty<Transaction>() : new[] { tx };
-            var block = CreateSignedBlock(transactions);
+            var block = CreateSignedBlock(neoSystem, consensusNodesKeys.Value, transactions);
             var blockRelay = await neoSystem.Blockchain.Ask<RelayResult>(block);
             if (blockRelay.Result != VerifyResult.Succeed)
             {
                 throw new Exception($"Block relay failed {blockRelay.Result}");
             }
             return block.Hash;
-        }
 
-        Block CreateSignedBlock(Transaction[] transactions)
-        {
-            // The logic in this method is distilled from ConsensusService/ConsensusContext + MemPool tx verification logic
-
-            var snapshot = neoSystem.StoreView;
-
-            // Verify the provided transactions. When running, Blockchain class does verification in two steps: VerifyStateIndependent and VerifyStateDependent.
-            // However, Verify does both parts and there's no point in verifying dependent/independent in separate steps here
-            var verificationContext = new TransactionVerificationContext();
-            for (int i = 0; i < transactions.Length; i++)
+            static Block CreateSignedBlock(NeoSystem neoSystem, KeyPair[] consensusNodesKeys, Transaction[] transactions)
             {
-                var q = transactions[i].Size * NativeContract.Policy.GetFeePerByte(snapshot);
-                if (transactions[i].Verify(ProtocolSettings, snapshot, verificationContext) != VerifyResult.Succeed)
+                // The logic in this method is distilled from ConsensusService/ConsensusContext + MemPool tx verification logic
+
+                var snapshot = neoSystem.StoreView;
+
+                // Verify the provided transactions. When running, Blockchain class does verification in two steps: VerifyStateIndependent and VerifyStateDependent.
+                // However, Verify does both parts and there's no point in verifying dependent/independent in separate steps here
+                var verificationContext = new TransactionVerificationContext();
+                for (int i = 0; i < transactions.Length; i++)
                 {
-                    throw new Exception("Verification failed");
+                    if (transactions[i].Verify(neoSystem.Settings, snapshot, verificationContext) != VerifyResult.Succeed)
+                    {
+                        throw new Exception("Verification failed");
+                    }
                 }
-            }
 
-            // create the block instance
-            var prevHash = NativeContract.Ledger.CurrentHash(snapshot);
-            var prevBlock = NativeContract.Ledger.GetHeader(snapshot, prevHash);
-            var blockHeight = prevBlock.Index + 1;
-            var block = new Block
-            {
-                Header = new Header
+                // create the block instance
+                var prevHash = NativeContract.Ledger.CurrentHash(snapshot);
+                var prevBlock = NativeContract.Ledger.GetHeader(snapshot, prevHash);
+                var blockHeight = prevBlock.Index + 1;
+                var block = new Block
                 {
-                    Version = 0,
-                    PrevHash = prevHash,
-                    MerkleRoot = MerkleTree.ComputeRoot(transactions.Select(t => t.Hash).ToArray()),
-                    Timestamp = Math.Max(Neo.Helper.ToTimestampMS(DateTime.UtcNow), prevBlock.Timestamp + 1),
-                    Index = blockHeight,
-                    PrimaryIndex = 0,
-                    NextConsensus = Contract.GetBFTAddress(
-                        NeoToken.ShouldRefreshCommittee(blockHeight, ProtocolSettings.CommitteeMembersCount)
-                            ? NativeContract.NEO.ComputeNextBlockValidators(snapshot, ProtocolSettings)
-                            : NativeContract.NEO.GetNextBlockValidators(snapshot, ProtocolSettings.ValidatorsCount)),
-                },
-                Transactions = transactions
-            };
+                    Header = new Header
+                    {
+                        Version = 0,
+                        PrevHash = prevHash,
+                        MerkleRoot = MerkleTree.ComputeRoot(transactions.Select(t => t.Hash).ToArray()),
+                        Timestamp = Math.Max(Neo.Helper.ToTimestampMS(DateTime.UtcNow), prevBlock.Timestamp + 1),
+                        Index = blockHeight,
+                        PrimaryIndex = 0,
+                        NextConsensus = Contract.GetBFTAddress(
+                            NeoToken.ShouldRefreshCommittee(blockHeight, neoSystem.Settings.CommitteeMembersCount)
+                                ? NativeContract.NEO.ComputeNextBlockValidators(snapshot, neoSystem.Settings)
+                                : NativeContract.NEO.GetNextBlockValidators(snapshot, neoSystem.Settings.ValidatorsCount)),
+                    },
+                    Transactions = transactions
+                };
 
-            // retrieve the validators for the next block. Logic lifted from ConsensusContext.Reset
-            var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, ProtocolSettings.ValidatorsCount);
-            var m = validators.Length - (validators.Length - 1) / 3;
+                // retrieve the validators for the next block. Logic lifted from ConsensusContext.Reset
+                var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, neoSystem.Settings.ValidatorsCount);
+                var m = validators.Length - (validators.Length - 1) / 3;
 
-            // generate the block header witness. Logic lifted from ConsensusContext.CreateBlock
-            var contract = Contract.CreateMultiSigContract(m, validators);
-            var signingContext = new ContractParametersContext(snapshot, block.Header, ProtocolSettings.Network);
-            for (int i = 0, j = 0; i < validators.Length && j < m; i++)
-            {
-                var key = consensusNodesKeys.Value.SingleOrDefault(k => k.PublicKey.Equals(validators[i]));
-                if (key == null) continue;
+                // generate the block header witness. Logic lifted from ConsensusContext.CreateBlock
+                var contract = Contract.CreateMultiSigContract(m, validators);
+                var signingContext = new ContractParametersContext(snapshot, block.Header, neoSystem.Settings.Network);
+                for (int i = 0, j = 0; i < validators.Length && j < m; i++)
+                {
+                    var key = consensusNodesKeys.SingleOrDefault(k => k.PublicKey.Equals(validators[i]));
+                    if (key == null) continue;
 
-                var signature = block.Header.Sign(key, ProtocolSettings.Network);
-                signingContext.AddSignature(contract, validators[i], signature);
-                j++;
+                    var signature = block.Header.Sign(key, neoSystem.Settings.Network);
+                    signingContext.AddSignature(contract, validators[i], signature);
+                    j++;
+                }
+                if (!signingContext.Completed) throw new Exception("block signing incomplete");
+                block.Header.Witness = signingContext.GetWitnesses()[0];
+
+                return block;
             }
-            if (!signingContext.Completed) throw new Exception("block signing incomplete");
-            block.Header.Witness = signingContext.GetWitnesses()[0];
-
-            return block;
         }
 
         public Task<Block> GetBlockAsync(UInt256 blockHash)

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -1,14 +1,17 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Neo;
 using Neo.BlockchainToolkit.Models;
 using Neo.Cryptography.ECC;
 using Neo.IO;
+using Neo.IO.Json;
 using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC;
 using Neo.Network.RPC.Models;
+using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Native;
@@ -48,6 +51,106 @@ namespace NeoExpress.Node
             return signer == null
                 ? rpcClient.InvokeScriptAsync(script)
                 : rpcClient.InvokeScriptAsync(script, signer);
+        }
+
+        // Need an IVerifiable.GetScriptHashesForVerifying implementation that doesn't
+        // depend on the DataCache snapshot parameter since the ContractParametersContext
+        // we are creating here does not have direct access to node data.
+
+        class BlockScriptHashes : IVerifiable
+        {
+            readonly UInt160[] hashes;
+
+            public BlockScriptHashes(UInt160 scriptHash)
+            {
+                hashes = new[] { scriptHash };
+            }
+
+            public UInt160[] GetScriptHashesForVerifying(DataCache snapshot) => hashes;
+
+            Witness[] IVerifiable.Witnesses 
+            { 
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
+            }
+
+            int ISerializable.Size => throw new NotImplementedException();
+
+            void ISerializable.Deserialize(BinaryReader reader)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IVerifiable.DeserializeUnsigned(BinaryReader reader)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ISerializable.Serialize(BinaryWriter writer)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IVerifiable.SerializeUnsigned(BinaryWriter writer)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public async Task FastForwardAsync(uint blockCount)
+        {
+            var keyPairs = chain.ConsensusNodes
+                .Select(n => 
+                {
+                    var account = n.Wallet.DefaultAccount 
+                        ?? throw new InvalidOperationException($"Invalid default account for {n.Wallet.Name}");
+                    return new KeyPair(account.PrivateKey.HexToBytes());
+                })
+                .ToArray();
+
+            for (var i = 0u; i < blockCount; i++)
+            {
+                await SubmitEmptyBlockAsync(rpcClient, keyPairs, ProtocolSettings.Network).ConfigureAwait(false);
+            }
+
+            static async Task SubmitEmptyBlockAsync(RpcClient rpcClient, IReadOnlyList<KeyPair> keyPairs, uint network)
+            {
+                var hash = await rpcClient.GetBestBlockHashAsync().ConfigureAwait(false);
+                var header = Convert.FromBase64String(await rpcClient.GetBlockHeaderHexAsync($"{hash}"))
+                    .AsSerializable<Header>();
+
+                var block = new Block
+                {
+                    Header = new Header
+                    {
+                        Version = 0,
+                        PrevHash = header.Hash,
+                        MerkleRoot = UInt256.Zero,
+                        Timestamp = Math.Max(Neo.Helper.ToTimestampMS(DateTime.UtcNow), header.Timestamp + 1),
+                        Index = header.Index + 1,
+                        PrimaryIndex = 0,
+                        NextConsensus = header.NextConsensus,
+                    },
+                    Transactions = Array.Empty<Transaction>()
+                };
+
+                var validators = (await rpcClient.GetNextBlockValidatorsAsync().ConfigureAwait(false))
+                        .Select(v => ECPoint.Parse(v.PublicKey, ECCurve.Secp256r1)).ToArray();
+                var signatureCount = validators.Length - (validators.Length - 1) / 3;
+                var contract = Contract.CreateMultiSigContract(signatureCount, validators);
+
+                var context = new ContractParametersContext(null, new BlockScriptHashes(header.NextConsensus), network);
+                for (int i = 0; i < keyPairs.Count; i++)
+                {
+                    var signature = block.Sign(keyPairs[i], network);
+                    context.AddSignature(contract, keyPairs[i].PublicKey, signature);
+                    if (context.Completed) break;
+                }
+                if (!context.Completed) throw new InvalidOperationException("Invalid block signature");
+                block.Header.Witness = context.GetWitnesses().Single();
+
+                await rpcClient.SubmitBlockAsync(block.ToArray()).ConfigureAwait(false);
+            }
         }
 
         public async Task<UInt256> ExecuteAsync(Wallet wallet, UInt160 accountHash, WitnessScope witnessScope, Script script, decimal additionalGas = 0)

--- a/src/neoxp/Program.cs
+++ b/src/neoxp/Program.cs
@@ -15,6 +15,7 @@ namespace NeoExpress
         typeof(ContractCommand),
         typeof(CreateCommand),
         typeof(ExportCommand),
+        typeof(FastForwardCommand),
         typeof(OracleCommand),
         typeof(PolicyCommand),
         typeof(ResetCommand),


### PR DESCRIPTION
Add fastfwd command to neo express. Allows user to specify a number of empty blocks to mint. Useful for scenarios where a set amount of time must occur between contract operations. Only works when node is *not* running

Fixes #181