### PR TITLE
Generate Contract from keypair in DevWallet/DevWalletAccount

### DIFF
--- a/src/neoxp/Models/DevWallet.cs
+++ b/src/neoxp/Models/DevWallet.cs
@@ -87,7 +87,7 @@ namespace NeoExpress.Models
 
         public override WalletAccount CreateAccount(UInt160 scriptHash)
         {
-            var account = new DevWalletAccount(ProtocolSettings, null, null, scriptHash);
+            var account = new DevWalletAccount(ProtocolSettings, scriptHash);
             return AddAccount(account);
         }
 

--- a/src/neoxp/Models/DevWallet.cs
+++ b/src/neoxp/Models/DevWallet.cs
@@ -75,9 +75,7 @@ namespace NeoExpress.Models
         public override WalletAccount CreateAccount(byte[] privateKey)
         {
             var key = new KeyPair(privateKey);
-            var contract = Contract.CreateSignatureContract(key.PublicKey);
-
-            var account = new DevWalletAccount(ProtocolSettings, key, contract);
+            var account = new DevWalletAccount(ProtocolSettings, key);
             return AddAccount(account);
         }
 

--- a/src/neoxp/Models/DevWallet.cs
+++ b/src/neoxp/Models/DevWallet.cs
@@ -74,14 +74,14 @@ namespace NeoExpress.Models
 
         public override WalletAccount CreateAccount(byte[] privateKey)
         {
-            var key = new KeyPair(privateKey);
-            var account = new DevWalletAccount(ProtocolSettings, key);
+            var keyPair = new KeyPair(privateKey);
+            var account = new DevWalletAccount(ProtocolSettings, keyPair);
             return AddAccount(account);
         }
 
-        public override WalletAccount CreateAccount(Contract contract, KeyPair? key = null)
+        public override WalletAccount CreateAccount(Contract contract, KeyPair? keyPair = null)
         {
-            var account = new DevWalletAccount(ProtocolSettings, key, contract);
+            var account = new DevWalletAccount(ProtocolSettings, contract, keyPair);
             return AddAccount(account);
         }
 

--- a/src/neoxp/Models/DevWalletAccount.cs
+++ b/src/neoxp/Models/DevWalletAccount.cs
@@ -9,32 +9,32 @@ namespace NeoExpress.Models
 {
     class DevWalletAccount : WalletAccount
     {
-        private readonly KeyPair? key;
+        private readonly KeyPair? keyPair;
 
         public DevWalletAccount(ProtocolSettings settings, KeyPair keyPair)
-            : this(settings, keyPair, Contract.CreateSignatureContract(keyPair.PublicKey))
+            : this(settings, Contract.CreateSignatureContract(keyPair.PublicKey), keyPair)
         {
         }
 
-        public DevWalletAccount(ProtocolSettings settings, KeyPair? key, Contract contract) : base(contract.ScriptHash, settings)
+        public DevWalletAccount(ProtocolSettings settings, Contract contract, KeyPair? keyPair) : base(contract.ScriptHash, settings)
         {
-            this.key = key;
+            this.keyPair = keyPair;
             Contract = contract;
         }
 
         public DevWalletAccount(ProtocolSettings settings, UInt160 scriptHash) : base(scriptHash, settings)
         {
-            this.key = null;
+            this.keyPair = null;
             Contract = null;
         }
 
-        public override bool HasKey => key != null;
+        public override bool HasKey => keyPair != null;
 
-        public override KeyPair? GetKey() => key;
+        public override KeyPair? GetKey() => keyPair;
 
         public ExpressWalletAccount ToExpressWalletAccount() => new ExpressWalletAccount()
         {
-            PrivateKey = key?.PrivateKey.ToHexString() ?? string.Empty,
+            PrivateKey = keyPair?.PrivateKey.ToHexString() ?? string.Empty,
             ScriptHash = ScriptHash.ToAddress(ProtocolSettings.AddressVersion),
             Label = Label,
             IsDefault = IsDefault,

--- a/src/neoxp/Models/DevWalletAccount.cs
+++ b/src/neoxp/Models/DevWalletAccount.cs
@@ -11,13 +11,18 @@ namespace NeoExpress.Models
     {
         private readonly KeyPair? key;
 
-        public DevWalletAccount(ProtocolSettings settings, KeyPair? key, Contract? contract, UInt160 scriptHash) : base(scriptHash, settings)
+        public DevWalletAccount(ProtocolSettings settings, KeyPair keyPair)
+            : this(settings, keyPair, Contract.CreateSignatureContract(keyPair.PublicKey))
+        {
+        }
+
+        public DevWalletAccount(ProtocolSettings settings, KeyPair? key, Contract contract) : base(contract.ScriptHash, settings)
         {
             this.key = key;
             Contract = contract;
         }
 
-        public DevWalletAccount(ProtocolSettings settings, KeyPair? key, Contract contract) : base(contract.ScriptHash, settings)
+        public DevWalletAccount(ProtocolSettings settings, KeyPair? key, Contract? contract, UInt160 scriptHash) : base(scriptHash, settings)
         {
             this.key = key;
             Contract = contract;
@@ -45,17 +50,7 @@ namespace NeoExpress.Models
         public static DevWalletAccount FromExpressWalletAccount(ProtocolSettings settings, ExpressWalletAccount account)
         {
             var keyPair = new KeyPair(account.PrivateKey.HexToBytes());
-            var contract = new Contract()
-            {
-                Script = account.Contract?.Script.HexToBytes(),
-                ParameterList = account.Contract?.Parameters
-                    .Select(Enum.Parse<ContractParameterType>)
-                    .ToArray()
-            };
-
-            var scriptHash = account.ScriptHash.ToScriptHash(settings.AddressVersion);
-
-            return new DevWalletAccount(settings, keyPair, contract, scriptHash)
+            return new DevWalletAccount(settings, keyPair)
             {
                 Label = account.Label,
                 IsDefault = account.IsDefault

--- a/src/neoxp/Models/DevWalletAccount.cs
+++ b/src/neoxp/Models/DevWalletAccount.cs
@@ -22,10 +22,10 @@ namespace NeoExpress.Models
             Contract = contract;
         }
 
-        public DevWalletAccount(ProtocolSettings settings, KeyPair? key, Contract? contract, UInt160 scriptHash) : base(scriptHash, settings)
+        public DevWalletAccount(ProtocolSettings settings, UInt160 scriptHash) : base(scriptHash, settings)
         {
-            this.key = key;
-            Contract = contract;
+            this.key = null;
+            Contract = null;
         }
 
         public override bool HasKey => key != null;


### PR DESCRIPTION
Instead of parsing contract details out of ExpressWalletAccount in FromExpressWalletAccount, use the private key to generate the signature contract. This ensures the contract is always up to date and not out of sync w/ the key.

