### PR TITLE
Write block/tx/applog JSON to console using newtonsoft to avoid breaking base64 encoded values

### DIFF
--- a/src/neoxp/Commands/ShowCommand.Block.cs
+++ b/src/neoxp/Commands/ShowCommand.Block.cs
@@ -29,7 +29,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var expressNode = chainManager.GetExpressNode();
                     var block = await expressNode.GetBlockAsync(BlockHash).ConfigureAwait(false);
-                    console.WriteLine(block.ToJson(chainManager.ProtocolSettings).ToString(true));
+                    console.WriteJson(block.ToJson(chainManager.ProtocolSettings));
                     return 0;
                 }
                 catch (Exception ex)
@@ -38,7 +38,6 @@ namespace NeoExpress.Commands
                     return 1;
                 }
             }
-
         }
     }
 }

--- a/src/neoxp/Commands/ShowCommand.Transaction.cs
+++ b/src/neoxp/Commands/ShowCommand.Transaction.cs
@@ -31,8 +31,8 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var expressNode = chainManager.GetExpressNode();
                     var (tx, log) = await expressNode.GetTransactionAsync(Neo.UInt256.Parse(TransactionHash));
-                    console.WriteLine(tx.ToJson(chainManager.ProtocolSettings).ToString(true));
-                    if (log != null) console.WriteLine(log.ToJson().ToString(true));
+                    console.WriteJson(tx.ToJson(chainManager.ProtocolSettings));
+                    if (log != null) console.WriteJson(log.ToJson());
                     return 0;
                 }
                 catch (Exception ex)

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -30,6 +30,54 @@ namespace NeoExpress
             return value;
         }
 
+        public static void WriteJson(this IConsole console, Neo.IO.Json.JObject json)
+        {
+            using var writer = new Newtonsoft.Json.JsonTextWriter(console.Out)
+            {
+                Formatting = Newtonsoft.Json.Formatting.Indented
+            };
+
+            WriteJson(writer, json);
+            console.Out.WriteLine();
+
+            static void WriteJson(Newtonsoft.Json.JsonTextWriter writer, Neo.IO.Json.JObject json)
+            {
+                switch (json)
+                {
+                    case null:
+                        writer.WriteNull();
+                        break;
+                    case Neo.IO.Json.JBoolean boolean:
+                        writer.WriteValue(boolean.Value);
+                        break;
+                    case Neo.IO.Json.JNumber number:
+                        writer.WriteValue(number.Value);
+                        break;
+                    case Neo.IO.Json.JString @string:
+                        writer.WriteValue(@string.Value);
+                        break;
+                    case Neo.IO.Json.JArray @array:
+                        writer.WriteStartArray();
+                        foreach (var value in @array)
+                        {
+                            WriteJson(writer, value);
+                        }
+                        writer.WriteEndArray();
+                        break;
+                    case Neo.IO.Json.JObject @object:
+                        writer.WriteStartObject();
+                        foreach (var (key, value) in @object.Properties)
+                        {
+                            writer.WritePropertyName(key);
+                            WriteJson(writer, value);
+                        }
+                        writer.WriteEndObject();
+                        break;
+                }
+            }
+        }
+
+
         public static void WriteException(this CommandLineApplication app, Exception exception, bool showInnerExceptions = false)
         {
             var showStackTrace = ((CommandOption<bool>)app.GetOptions().Single(o => o.LongName == "stack-trace")).ParsedValue;


### PR DESCRIPTION
Neo.IO.Json types use Utf8JsonWriter under the hood when converting to an indendent string. Utf8JsonWriter encodes the '+' character - which occurs often in base64 encoded values - as '\u002b' for safety purposes. For example, the Base64 string `EQwhA6cH9+Easavr58RUB5argP11jo0vKfyuGkk2fngG8v86EUGe0Nw6` gets encoded as `EQwhA6cH9\u002bEasavr58RUB5argP11jo0vKfyuGkk2fngG8v86EUGe0Nw6` by JObject.ToString


Escaping the '+' character is important when transporting JSON across the internet. It's not important when writing JSON to the console. 

This PR adds a WriteJson extension method that uses newtonsoft (which does not encode '+' characters as Utf8JsonWriter does) to write a Neo JSON object to the console. 

Note, this approach is also slightly more efficient as there is no need to generate the in memory string representation of the entire JSON object when writing it to the console