### PR TITLE
optional data parameter for deploy

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -50,6 +50,9 @@ namespace NeoExpress.Commands
                     [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
                     internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
 
+                    [Option(Description = "Optional data parameter to pass to _deploy operation")]
+                    internal string Data { get; init; } = string.Empty;
+
                     [Option(Description = "Deploy contract regardless of name conflict")]
                     internal bool Force { get; }
                 }

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -118,6 +118,7 @@ namespace NeoExpress.Commands
                                 cmd.Model.Account,
                                 cmd.Model.Password,
                                 cmd.Model.WitnessScope,
+                                cmd.Model.Data,
                                 cmd.Model.Force).ConfigureAwait(false);
                             break;
                         }

--- a/src/neoxp/Commands/ContractCommand.Deploy.cs
+++ b/src/neoxp/Commands/ContractCommand.Deploy.cs
@@ -32,7 +32,10 @@ namespace NeoExpress.Commands
             [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
             internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
 
-            [Option(Description = "password to use for NEP-2/NEP-6 account")]
+            [Option(Description = "Optional data parameter to pass to _deploy operation")]
+            internal string Data { get; init; } = string.Empty;
+
+            [Option(Description = "Password to use for NEP-2/NEP-6 account")]
             internal string Password { get; init; } = string.Empty;
 
             [Option(Description = "Path to neo-express data file")]
@@ -54,7 +57,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    await txExec.ContractDeployAsync(Contract, Account, password, WitnessScope, Force).ConfigureAwait(false);
+                    await txExec.ContractDeployAsync(Contract, Account, password, WitnessScope, Data, Force).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)
@@ -63,7 +66,6 @@ namespace NeoExpress.Commands
                     return 1;
                 }
             }
-
         }
     }
 }

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -164,8 +164,16 @@ namespace NeoExpress
             }
         }
 
-        public static async Task<UInt256> DeployAsync(this IExpressNode expressNode, NefFile nefFile, ContractManifest manifest, Wallet wallet, UInt160 accountHash, WitnessScope witnessScope)
+        public static async Task<UInt256> DeployAsync(this IExpressNode expressNode,
+                                                      NefFile nefFile,
+                                                      ContractManifest manifest,
+                                                      Wallet wallet,
+                                                      UInt160 accountHash,
+                                                      WitnessScope witnessScope,
+                                                      ContractParameter? data)
         {
+            data ??= new ContractParameter(ContractParameterType.Any);
+
             // check for bad opcodes (logic borrowed from neo-cli LoadDeploymentScript)
             Neo.VM.Script script = nefFile.Script;
             for (var i = 0; i < script.Length;)
@@ -181,13 +189,16 @@ namespace NeoExpress
                     {
                         throw new FormatException($"Invalid opcode found at {i}-{((byte)instruction.OpCode).ToString("x2")}");
                     }
-
                     i += instruction.Size;
                 }
             }
 
             using var sb = new ScriptBuilder();
-            sb.EmitDynamicCall(NativeContract.ContractManagement.Hash, "deploy", nefFile.ToArray(), manifest.ToJson().ToString());
+            sb.EmitDynamicCall(NativeContract.ContractManagement.Hash,
+                "deploy",
+                nefFile.ToArray(),
+                manifest.ToJson().ToString(),
+                data);
             return await expressNode.ExecuteAsync(wallet, accountHash, witnessScope, sb.ToArray()).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Fixes #199

Note, the `contract deploy --data` option only supports simple binary contract parameters. For more complex data types, the developer needs to use an invoke file