### PR TITLE
Add show notification command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,12 +19,14 @@ may not exactly match a publicly released version.
 
 #### Added
 
+* `show notifications` command
 * `--json` option to `wallet list` command (3ea29881d8be352cedaeebd8b8b16e49aee3aed6)
 * `--data` option to `contract deploy` command (#214)
 
 #### Changed
 
 * In `batch` command, resolve non-absolute paths relative to the batch file location (#210)
+* In `show tx` command, modified output to be valid JSON that an be piped into JSON parsing scripts
 
 #### Fixed
 

--- a/src/neoxp/Commands/ShowCommand.Notifications.cs
+++ b/src/neoxp/Commands/ShowCommand.Notifications.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Neo;
+using Newtonsoft.Json;
+
+namespace NeoExpress.Commands
+{
+    partial class ShowCommand
+    {
+        [Command("notifications", Description = "Shows contract notifications in JSON format")]
+        internal class Notifications
+        {
+            readonly ExpressChainManagerFactory chainManagerFactory;
+
+            public Notifications(ExpressChainManagerFactory chainManagerFactory)
+            {
+                this.chainManagerFactory = chainManagerFactory;
+            }
+
+            [Option(Description = "Limit shown notifications to the specified contract")]
+            internal string Contract { get; init; } = string.Empty;
+
+            [Option("-n|--count", Description = "Limit number of shown notifications")]
+            internal uint? Count { get; init; }
+
+            [Option(Description = "Limit shown notifications to specified event name")]
+            internal string EventName { get; init; } = string.Empty;
+
+            [Option(Description = "Path to neo-express data file")]
+            internal string Input { get; init; } = string.Empty;
+
+            internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
+            {
+                try
+                {
+                    var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+                    using var expressNode = chainManager.GetExpressNode();
+
+                    var contracts = await expressNode.ListContractsAsync().ConfigureAwait(false);
+                    var contractMap = contracts.ToDictionary(c => c.hash, c => c.manifest.Name);
+
+                    IReadOnlySet<UInt160>? contractFilter = null;
+                    if (!string.IsNullOrEmpty(Contract))
+                    {
+                        if (UInt160.TryParse(Contract, out var _contract))
+                        {
+                            contractFilter = new HashSet<UInt160>() { _contract };
+                        }
+                        else
+                        {
+                            contractFilter = contracts
+                                .Where(c => Contract.Equals(c.manifest.Name, StringComparison.OrdinalIgnoreCase))
+                                .Select(c => c.hash)
+                                .ToHashSet();
+                            if (contractFilter.Count == 0) throw new Exception($"Couldn't resolve {Contract} contract");
+                        }
+                    }
+
+                    IReadOnlySet<string>? eventFilter = null;
+                    if (!string.IsNullOrEmpty(EventName))
+                    {
+                        eventFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { EventName };
+                    }
+
+                    using var writer = new JsonTextWriter(console.Out) { Formatting = Formatting.Indented };
+                    writer.WriteStartArray();
+                    var count = 0;
+                    await foreach (var (blockIndex, notification) in expressNode.EnumerateNotificationsAsync(contractFilter, eventFilter))
+                    {
+                        if (Count.HasValue && count++ >= Count.Value) break;
+
+                        writer.WriteStartObject();
+                        writer.WritePropertyName("block-index");
+                        writer.WriteValue(blockIndex);
+                        writer.WritePropertyName("script-hash");
+                        writer.WriteValue(notification.ScriptHash.ToString());
+                        if (contractMap.TryGetValue(notification.ScriptHash, out var name))
+                        {
+                            writer.WritePropertyName("contract-name");
+                            writer.WriteValue(name);
+                        }
+                        writer.WritePropertyName("event-name");
+                        writer.WriteValue(notification.EventName);
+                        writer.WritePropertyName("state");
+                        writer.WriteJson(Neo.VM.Helper.ToJson(notification.State)["value"]);
+                        writer.WriteEndObject();
+                    }
+                    writer.WriteEndArray();
+
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    app.WriteException(ex);
+                    return 1;
+                }
+            }
+        }
+    }
+}

--- a/src/neoxp/Commands/ShowCommand.cs
+++ b/src/neoxp/Commands/ShowCommand.cs
@@ -3,7 +3,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace NeoExpress.Commands
 {
     [Command("show", Description = "Show information")]
-    [Subcommand(typeof(Balance), typeof(Balances), typeof(Block), typeof(Transaction))]
+    [Subcommand(typeof(Balance), typeof(Balances), typeof(Block), typeof(Notifications), typeof(Transaction))]
     partial class ShowCommand
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -44,41 +44,41 @@ namespace NeoExpress
 
             WriteJson(writer, json);
             console.Out.WriteLine();
+        }
 
-            static void WriteJson(Newtonsoft.Json.JsonTextWriter writer, Neo.IO.Json.JObject json)
+        public static void WriteJson(this Newtonsoft.Json.JsonTextWriter writer, Neo.IO.Json.JObject json)
+        {
+            switch (json)
             {
-                switch (json)
-                {
-                    case null:
-                        writer.WriteNull();
-                        break;
-                    case Neo.IO.Json.JBoolean boolean:
-                        writer.WriteValue(boolean.Value);
-                        break;
-                    case Neo.IO.Json.JNumber number:
-                        writer.WriteValue(number.Value);
-                        break;
-                    case Neo.IO.Json.JString @string:
-                        writer.WriteValue(@string.Value);
-                        break;
-                    case Neo.IO.Json.JArray @array:
-                        writer.WriteStartArray();
-                        foreach (var value in @array)
-                        {
-                            WriteJson(writer, value);
-                        }
-                        writer.WriteEndArray();
-                        break;
-                    case Neo.IO.Json.JObject @object:
-                        writer.WriteStartObject();
-                        foreach (var (key, value) in @object.Properties)
-                        {
-                            writer.WritePropertyName(key);
-                            WriteJson(writer, value);
-                        }
-                        writer.WriteEndObject();
-                        break;
-                }
+                case null:
+                    writer.WriteNull();
+                    break;
+                case Neo.IO.Json.JBoolean boolean:
+                    writer.WriteValue(boolean.Value);
+                    break;
+                case Neo.IO.Json.JNumber number:
+                    writer.WriteValue(number.Value);
+                    break;
+                case Neo.IO.Json.JString @string:
+                    writer.WriteValue(@string.Value);
+                    break;
+                case Neo.IO.Json.JArray @array:
+                    writer.WriteStartArray();
+                    foreach (var value in @array)
+                    {
+                        WriteJson(writer, value);
+                    }
+                    writer.WriteEndArray();
+                    break;
+                case Neo.IO.Json.JObject @object:
+                    writer.WriteStartObject();
+                    foreach (var (key, value) in @object.Properties)
+                    {
+                        writer.WritePropertyName(key);
+                        WriteJson(writer, value);
+                    }
+                    writer.WriteEndObject();
+                    break;
             }
         }
 

--- a/src/neoxp/IExpressNode.cs
+++ b/src/neoxp/IExpressNode.cs
@@ -39,5 +39,7 @@ namespace NeoExpress
         Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync();
         Task<IReadOnlyList<ExpressStorage>> ListStoragesAsync(UInt160 scriptHash);
         Task<IReadOnlyList<TokenContract>> ListTokenContractsAsync();
+
+        IAsyncEnumerable<(uint blockIndex, NotificationRecord notification)> EnumerateNotificationsAsync(IReadOnlySet<UInt160>? contractFilter, IReadOnlySet<string>? eventFilter);
     }
 }

--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -16,8 +16,8 @@ namespace NeoExpress.Models
         public UInt160 ScriptHash { get; private set; } = null!;
         public string EventName { get; private set; } = null!;
         public Neo.VM.Types.Array State { get; private set; } = null!;
-        public UInt256 InventoryHash { get; private set; } = UInt256.Zero;
         public InventoryType InventoryType { get; private set; }
+        public UInt256 InventoryHash { get; private set; } = UInt256.Zero;
 
         public NotificationRecord()
         {
@@ -30,9 +30,18 @@ namespace NeoExpress.Models
             EventName = notification.EventName;
             if (notification.ScriptContainer is IInventory inventory)
             {
-                InventoryHash = inventory.Hash;
                 InventoryType = inventory.InventoryType;
+                InventoryHash = inventory.Hash;
             }
+        }
+
+        public NotificationRecord(UInt160 scriptHash, string eventName, Neo.VM.Types.Array state, InventoryType inventoryType, UInt256 inventoryHash)
+        {
+            ScriptHash = scriptHash;
+            EventName = eventName;
+            State = state;
+            InventoryType = inventoryType;
+            InventoryHash = inventoryHash;
         }
 
         public int Size => ScriptHash.Size

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -27,13 +27,13 @@ namespace NeoExpress.Node
 {
     internal sealed class OfflineNode : IDisposable, IExpressNode
     {
-        private readonly NeoSystem neoSystem;
-        private readonly ApplicationEngineProvider? applicationEngineProvider;
-        private readonly Wallet nodeWallet;
-        private readonly ExpressChain chain;
-        private readonly RocksDbStorageProvider rocksDbStorageProvider;
-        private readonly Lazy<KeyPair[]> consensusNodesKeys;
-        private bool disposedValue;
+        readonly NeoSystem neoSystem;
+        readonly ApplicationEngineProvider? applicationEngineProvider;
+        readonly Wallet nodeWallet;
+        readonly ExpressChain chain;
+        readonly RocksDbStorageProvider rocksDbStorageProvider;
+        readonly Lazy<KeyPair[]> consensusNodesKeys;
+        bool disposedValue;
 
         public ProtocolSettings ProtocolSettings => neoSystem.Settings;
 
@@ -406,5 +406,18 @@ namespace NeoExpress.Node
 
         public Task<IReadOnlyList<ExpressStorage>> ListStoragesAsync(UInt160 scriptHash)
             => MakeAsync(() => ListStorages(scriptHash));
+
+// warning CS1998: This async method lacks 'await' operators and will run synchronously.
+// EnumerateNotificationsAsync has to be async in order to be polymorphic with OnlineNode's implementation
+#pragma warning disable 1998 
+        public async IAsyncEnumerable<(uint blockIndex, NotificationRecord notification)> EnumerateNotificationsAsync(IReadOnlySet<UInt160>? contractFilter, IReadOnlySet<string>? eventFilter)
+        {
+            var notifications = PersistencePlugin.GetNotifications(this.rocksDbStorageProvider, Neo.Persistence.SeekDirection.Backward, contractFilter, eventFilter);
+            foreach (var (block, _, notification) in notifications)
+            {
+                yield return (block, notification);
+            }
+        }
+#pragma warning restore 1998
     }
 }

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -328,5 +328,42 @@ namespace NeoExpress.Node
 
             return Array.Empty<ExpressStorage>();
         }
+
+        public async IAsyncEnumerable<(uint blockIndex, NotificationRecord notification)> EnumerateNotificationsAsync(IReadOnlySet<UInt160>? contractFilter, IReadOnlySet<string>? eventFilter)
+        {
+            JObject contractsArg = (contractFilter ?? Enumerable.Empty<UInt160>())
+                .Select(c => (JString)c.ToString())
+                .ToArray();
+            JObject eventsArg = (eventFilter ?? Enumerable.Empty<string>())
+                .Select(e => (JString)e)
+                .ToArray();
+
+            var count = 0;
+
+            while (true)
+            {
+                var json = await rpcClient.RpcSendAsync("expressenumnotifications", contractsArg, eventsArg, count, 3)
+                    .ConfigureAwait(false);
+
+                var truncated = json["truncated"].AsBoolean();
+                var values = (JArray)json["notifications"];
+
+                foreach (var v in values)
+                {
+                    var blockIndex = (uint)v["block-index"].AsNumber();
+                    var scriptHash = UInt160.Parse(v["script-hash"].AsString());
+                    var eventName = v["event-name"].AsString();
+                    var invType = (InventoryType)(byte)v["inventory-type"].AsNumber();
+                    var invHash = UInt256.Parse(v["inventory-hash"].AsString());
+                    var state = (Neo.VM.Types.Array)Neo.Network.RPC.Utility.StackItemFromJson(v["state"]);
+                    var notification = new NotificationRecord(scriptHash, eventName, state, invType, invHash);
+                    yield return (blockIndex, notification);
+                }
+
+                if (!truncated) break;
+
+                count += values.Count;
+            }
+        }
     }
 }

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -342,13 +342,13 @@ namespace NeoExpress
 
         public static bool TryParseRpcUri(string value, [NotNullWhen(true)] out Uri? uri)
         {
-            if (value.Equals("mainnet", StringComparison.InvariantCultureIgnoreCase))
+            if (value.Equals("mainnet", StringComparison.OrdinalIgnoreCase))
             {
                 uri = new Uri("http://seed1.neo.org:10332");
                 return true;
             }
 
-            if (value.Equals("testnet", StringComparison.InvariantCultureIgnoreCase))
+            if (value.Equals("testnet", StringComparison.OrdinalIgnoreCase))
             {
                 uri = new Uri("http://seed1t4.neo.org:20332");
                 return true;


### PR DESCRIPTION
Adds a new `show notifications` command that dumps notifications in reverse chrono order in JSON format. includes arguments to limit notifications by count, by contract and by event name.

Other changes
* `show tx` emits valid JSON. Previously it emitted tx and app log as separate JSON objects
* Standardized on StringComparison.OrdinalIgnoreCase