### PR TITLE
Fix Invalid GetNep17Balances results

### DIFF
--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -1,14 +1,18 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Neo;
 using Neo.IO;
 using Neo.Persistence;
+using Neo.SmartContract.Iterators;
 using Neo.SmartContract.Native;
 using Neo.VM;
 using NeoExpress.Models;
 using ByteString = Neo.VM.Types.ByteString;
 using Integer = Neo.VM.Types.Integer;
+using InteropInterface = Neo.VM.Types.InteropInterface;
+using StackItemType = Neo.VM.Types.StackItemType;
 
 namespace NeoExpress
 {
@@ -83,11 +87,35 @@ namespace NeoExpress
             return TryGetBalance(snapshot, builder, settings, out var balance) ? balance : BigInteger.Zero;
         }
 
-        public static bool TryGetDivisibleNep11Balance(this DataCache snapshot, UInt160 asset, ByteString tokenId, UInt160 address, ProtocolSettings settings, out BigInteger balance)
+        public static IEnumerable<ReadOnlyMemory<byte>> GetNep11Tokens(this DataCache snapshot, UInt160 asset, UInt160 address, ProtocolSettings settings)
         {
             using var builder = new ScriptBuilder();
-            builder.EmitDynamicCall(asset, "balanceOf", address.ToArray(), tokenId);
-            return TryGetBalance(snapshot, builder, settings, out balance);
+            builder.EmitDynamicCall(asset, "tokensOf", address.ToArray());
+            using var engine = builder.Invoke(settings, snapshot);
+            if (engine.State != VMState.FAULT
+                && engine.ResultStack.Count >= 1
+                && engine.ResultStack.Pop() is InteropInterface interop
+                && interop.GetInterface<object>() is IIterator iterator)
+            {
+                while (iterator.Next())
+                {
+                    var value = iterator.Value();
+                    var byteString = value.Type == StackItemType.ByteString
+                        ? (ByteString)value
+                        : (ByteString)(value.ConvertTo(StackItemType.ByteString));
+
+                    yield return (ReadOnlyMemory<byte>)byteString;
+                }
+            }
+        }
+
+        public static BigInteger GetDivisibleNep11Balance(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, UInt160 address, ProtocolSettings settings)
+        {
+            using var builder = new ScriptBuilder();
+            builder.EmitDynamicCall(asset, "balanceOf", address.ToArray(), (ByteString)tokenId);
+            return TryGetBalance(snapshot, builder, settings, out var balance)
+                ? balance
+                : BigInteger.Zero;
         }
 
         static bool TryGetBalance(DataCache snapshot, ScriptBuilder builder, ProtocolSettings settings, out BigInteger balance)
@@ -105,10 +133,14 @@ namespace NeoExpress
             return false;
         }
 
-        public static bool TryGetIndivisibleNep11Owner(this DataCache snapshot, UInt160 asset, ByteString tokenId, ProtocolSettings settings, out UInt160 owner)
+
+        public static UInt160 GetIndivisibleNep11Owner(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, ProtocolSettings settings)
+            => TryGetIndivisibleNep11Owner(snapshot, asset, tokenId, settings, out var owner) ? owner : UInt160.Zero;
+
+        public static bool TryGetIndivisibleNep11Owner(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, ProtocolSettings settings, out UInt160 owner)
         {
             using var builder = new ScriptBuilder();
-            builder.EmitDynamicCall(asset, "ownerOf", tokenId);
+            builder.EmitDynamicCall(asset, "ownerOf", (ByteString)tokenId);
 
             using var engine = builder.Invoke(settings, snapshot);
             if (engine.State != VMState.FAULT

--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -76,11 +76,11 @@ namespace NeoExpress
             return false;
         }
 
-        public static bool TryGetNep17Balance(this DataCache snapshot, UInt160 asset, UInt160 address, ProtocolSettings settings, out BigInteger balance)
+        public static BigInteger GetNep17Balance(this DataCache snapshot, UInt160 asset, UInt160 address, ProtocolSettings settings)
         {
             using var builder = new ScriptBuilder();
             builder.EmitDynamicCall(asset, "balanceOf", address.ToArray());
-            return TryGetBalance(snapshot, builder, settings, out balance);
+            return TryGetBalance(snapshot, builder, settings, out var balance) ? balance : BigInteger.Zero;
         }
 
         public static bool TryGetDivisibleNep11Balance(this DataCache snapshot, UInt160 asset, ByteString tokenId, UInt160 address, ProtocolSettings settings, out BigInteger balance)

--- a/src/neoxp/Models/TransferNotificationRecord.cs
+++ b/src/neoxp/Models/TransferNotificationRecord.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Neo;
 using Neo.VM.Types;
@@ -11,10 +12,10 @@ namespace NeoExpress.Models
         public readonly UInt160 From;
         public readonly UInt160 To;
         public readonly BigInteger Amount;
-        public readonly Neo.VM.Types.ByteString? TokenId;
+        public readonly ReadOnlyMemory<byte> TokenId;
         public readonly NotificationRecord Notification;
 
-        public TransferNotificationRecord(UInt160 asset, UInt160 from, UInt160 to, BigInteger amount, ByteString? tokenId, NotificationRecord notification)
+        public TransferNotificationRecord(UInt160 asset, UInt160 from, UInt160 to, BigInteger amount, ReadOnlyMemory<byte> tokenId, NotificationRecord notification)
         {
             Asset = asset;
             From = from;
@@ -41,7 +42,7 @@ namespace NeoExpress.Models
             var asset = notification.ScriptHash;
             return notification.State.Count switch
             {
-                3 => new TransferNotificationRecord(asset, from, to, amount, null, notification),
+                3 => new TransferNotificationRecord(asset, from, to, amount, default, notification),
                 4 when (notification.State[3] is Neo.VM.Types.ByteString tokenId)
                     => new TransferNotificationRecord(asset, from, to, amount, tokenId, notification),
                 _ => null

--- a/src/neoxp/Node/Modules/ExpressRpcMethods.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcMethods.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -8,6 +10,7 @@ using Neo.BlockchainToolkit.Persistence;
 using Neo.IO;
 using Neo.IO.Json;
 using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
 using Neo.Plugins;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
@@ -248,14 +251,16 @@ namespace NeoExpress.Node
             int take = @params.Count >= 4 ? (int)@params[3].AsNumber() : MAX_NOTIFICATIONS;
             if (take > MAX_NOTIFICATIONS) take = MAX_NOTIFICATIONS;
 
-            var notifications = PersistencePlugin.GetNotifications(storageProvider,
-                Neo.Persistence.SeekDirection.Backward,
-                contracts.Count > 0 ? contracts : null, 
-                events.Count > 0 ? events : null)
+            var notifications = PersistencePlugin
+                .GetNotifications(
+                    storageProvider,
+                    SeekDirection.Backward,
+                    contracts.Count > 0 ? contracts : null,
+                    events.Count > 0 ? events : null)
                 .Skip(skip);
 
             var count = 0;
-            var jNotifications = new JArray();
+            var jsonNotifications = new JArray();
             var truncated = false;
             foreach (var (blockIndex, _, notification) in notifications)
             {
@@ -274,13 +279,13 @@ namespace NeoExpress.Node
                     ["inventory-hash"] = notification.InventoryHash.ToString(),
                     ["state"] = Neo.VM.Helper.ToJson(notification.State),
                 };
-                jNotifications.Add(jNotification);
+                jsonNotifications.Add(jNotification);
             }
 
             return new JObject
             {
                 ["truncated"] = truncated,
-                ["notifications"] = jNotifications,
+                ["notifications"] = jsonNotifications,
             };
         }
 
@@ -306,28 +311,59 @@ namespace NeoExpress.Node
         {
             var address = AsScriptHash(@params[0]);
 
-            // collect a list of assets the address has either sent or received
-            // and the last block index a transfer occurred
-            var assets = new Dictionary<UInt160, uint>();
             using var snapshot = neoSystem.GetSnapshot();
-            foreach (var (blockIndex, _, transfer) in PersistencePlugin.GetTransferNotifications(snapshot, storageProvider, TokenStandard.Nep17, address))
+
+            // collect the non-zero balances of all the deployed Nep17 contracts for the specified account
+            var addressBalances = TokenContract.Enumerate(snapshot)
+                .Where(c => c.standard == TokenStandard.Nep17)
+                .Select(c => (
+                    scriptHash: c.scriptHash,
+                    balance: snapshot.GetNep17Balance(c.scriptHash, address, neoSystem.Settings)))
+                .Where(t => !t.balance.IsZero)
+                .ToList();
+
+            // collect the last block index a transfer occurred for all account balances
+            var updateIndexes = new Dictionary<UInt160, uint>();
+            if (addressBalances.Count > 0)
             {
-                assets[transfer.Asset] = blockIndex;
+                var notifications = PersistencePlugin.GetNotifications(
+                    storageProvider,
+                    SeekDirection.Backward,
+                    addressBalances.Select(b => b.scriptHash).ToHashSet(),
+                    new HashSet<string> { "Transfer " });
+
+                foreach (var (blockIndex, _, notification) in notifications)
+                {
+                    // iterate backwards thru the notifications looking for all the Transfer events from a contract
+                    // in assets where a Transfer event hasn't already been recorded
+                    if (!updateIndexes.ContainsKey(notification.ScriptHash))
+                    {
+                        var transfer = TransferNotificationRecord.Create(notification);
+                        if (transfer is not null
+                            && (transfer.From == address || transfer.To == address))
+                        {
+                            // if the specified account was the sender or receiver of the current transfer,
+                            // record the update index. Stop the iteration if indexes for all the assets are 
+                            // have been recorded
+                            updateIndexes.Add(notification.ScriptHash, blockIndex);
+                            if (updateIndexes.Count == addressBalances.Count) break;
+                        }
+                    }
+                }
             }
 
-            // get current balance for each asset with at least one transfer record
             var balances = new JArray();
-            foreach (var (asset, lastUpdatedBlock) in assets)
+            for (int i = 0; i < addressBalances.Count; i++)
             {
-                if (snapshot.TryGetNep17Balance(asset, address, neoSystem.Settings, out var balance))
+                var (scriptHash, balance) = addressBalances[i];
+                var lastUpdatedBlock = updateIndexes.TryGetValue(scriptHash, out var _index) ? _index : 0;
+
+                balances.Add(new JObject
                 {
-                    balances.Add(new JObject
-                    {
-                        ["assethash"] = asset.ToString(),
-                        ["amount"] = balance.ToString(),
-                        ["lastupdatedblock"] = lastUpdatedBlock,
-                    });
-                }
+                    ["assethash"] = scriptHash.ToString(),
+                    ["amount"] = balance.ToString(),
+                    ["lastupdatedblock"] = lastUpdatedBlock,
+                });
             }
 
             return new JObject
@@ -340,72 +376,105 @@ namespace NeoExpress.Node
         [RpcMethod]
         public JObject GetNep17Transfers(JArray @params) => GetTransfers(@params, TokenStandard.Nep17);
 
+        class TokenEqualityComparer : IEqualityComparer<(UInt160 scriptHash, ReadOnlyMemory<byte> tokenId)>
+        {
+            public static TokenEqualityComparer Instance = new();
+
+            private TokenEqualityComparer() { }
+
+            public bool Equals((UInt160 scriptHash, ReadOnlyMemory<byte> tokenId) x, (UInt160 scriptHash, ReadOnlyMemory<byte> tokenId) y)
+                => x.scriptHash.Equals(y.scriptHash)
+                    && x.tokenId.Span.SequenceEqual(y.tokenId.Span);
+
+            public int GetHashCode((UInt160 scriptHash, ReadOnlyMemory<byte> tokenId) obj)
+            {
+                HashCode code = new();
+                code.Add(obj.scriptHash);
+                for (int i = 0; i < obj.tokenId.Length; i++)
+                {
+                    code.Add(obj.tokenId.Span[i]);
+                }
+                return code.ToHashCode();
+            }
+        }
+
+
         [RpcMethod]
         public JObject GetNep11Balances(JArray @params)
         {
             var address = AsScriptHash(@params[0]);
 
-            // collect a list of assets + tokens that address has sent or received
-            // and the last block index a transfer occurred
-
-            var assets = new Dictionary<UInt160, Dictionary<ByteString, uint>>();
             using var snapshot = neoSystem.GetSnapshot();
-            foreach (var (blockIndex, _, transfer) in PersistencePlugin.GetTransferNotifications(snapshot, storageProvider, TokenStandard.Nep11, address))
+
+            List<(UInt160 scriptHash, ReadOnlyMemory<byte> tokenId, BigInteger balance)> tokens = new();
+            foreach (var contract in NativeContract.ContractManagement.ListContracts(snapshot))
             {
-                if (transfer.TokenId == null) continue;
-                var tokens = assets.GetOrAdd(transfer.Asset, _ => new Dictionary<ByteString, uint>());
-                tokens[transfer.TokenId] = blockIndex;
+                if (!contract.Manifest.SupportedStandards.Contains("NEP-11")) continue;
+                var balanceOf = contract.Manifest.Abi.GetMethod("balanceOf", -1);
+                if (balanceOf is null) continue;
+                var divisible = balanceOf.Parameters.Length == 2;
+
+                foreach (var tokenId in snapshot.GetNep11Tokens(contract.Hash, address, neoSystem.Settings))
+                {
+                    var balance = divisible
+                        ? snapshot.GetDivisibleNep11Balance(contract.Hash, tokenId, address, neoSystem.Settings)
+                        : snapshot.GetIndivisibleNep11Owner(contract.Hash, tokenId, neoSystem.Settings) == address
+                            ? BigInteger.One
+                            : BigInteger.Zero;
+
+                    if (balance.IsZero) continue;
+
+                    tokens.Add((contract.Hash, tokenId, balance));
+                }
             }
 
-            JArray balances = new();
-            foreach (var (asset, tokens) in assets)
+            // collect the last block index a transfer occurred for all tokens
+            var updateIndexes = new Dictionary<(UInt160 scriptHash, ReadOnlyMemory<byte> tokenId), uint>(TokenEqualityComparer.Instance);
+            if (tokens.Count > 0)
             {
-                // Balance logic is different for divisible and non-divisible NFTs
-                if (snapshot.TryGetDecimals(asset, neoSystem.Settings, out var decimals))
-                {
-                    JArray jsonTokens = new();
-                    foreach (var (token, lastUpdatedBlock) in tokens)
-                    {
-                        if (decimals == 0)
-                        {
-                            // for non divisible tokens, check to see if the token owner 
-                            // matches the current address
-                            if (snapshot.TryGetIndivisibleNep11Owner(asset, token, neoSystem.Settings, out var owner)
-                                && owner == address)
-                            {
-                                jsonTokens.Add(new JObject
-                                {
-                                    ["tokenid"] = token.GetSpan().ToHexString(),
-                                    ["amount"] = BigInteger.One.ToString(),
-                                    ["lastupdatedblock"] = lastUpdatedBlock
-                                });
-                            }
-                        }
-                        else
-                        {
-                            // for divisible NFTs, get the asset/token balance for this address 
-                            if (snapshot.TryGetDivisibleNep11Balance(asset, token, address, neoSystem.Settings, out var balance)
-                                && balance > BigInteger.Zero)
-                            {
-                                jsonTokens.Add(new JObject
-                                {
-                                    ["tokenid"] = token.GetSpan().ToHexString(),
-                                    ["amount"] = balance.ToString(),
-                                    ["lastupdatedblock"] = lastUpdatedBlock
-                                });
-                            }
-                        }
-                    }
+                var notifications = PersistencePlugin.GetNotifications(
+                    storageProvider,
+                    SeekDirection.Backward,
+                    tokens.Select(b => b.scriptHash).ToHashSet(),
+                    new HashSet<string> { "Transfer " });
 
-                    if (jsonTokens.Count > 0)
-                    {
-                        balances.Add(new JObject
-                        {
-                            ["assethash"] = asset.ToString(),
-                            ["tokens"] = jsonTokens,
-                        });
-                    }
+                foreach (var (blockIndex, _, notification) in notifications)
+                {
+                    var transfer = TransferNotificationRecord.Create(notification);
+                    if (transfer is null) continue;
+                    if (transfer.From != address && transfer.To != address) continue;
+                    if (transfer.TokenId.Length == 0) continue;
+                    var key = (notification.ScriptHash, transfer.TokenId);
+                    if (updateIndexes.ContainsKey(key)) continue;
+                    updateIndexes.Add(key, blockIndex);
+                    if (updateIndexes.Count == tokens.Count) break;
                 }
+            }
+
+            var balances = new JArray();
+
+            foreach (var asset in tokens.GroupBy(t => t.scriptHash))
+            {
+                var jsonTokens = new JArray();
+                foreach (var (_, tokenId, balance) in asset)
+                {
+                    if (balance.IsZero) continue;
+
+                    var lastUpdatedBlock = updateIndexes.TryGetValue((asset.Key, tokenId), out var value)
+                        ? value : 0;
+                    jsonTokens.Add(new JObject
+                    {
+                        ["tokenid"] = tokenId.Span.ToHexString(),
+                        ["amount"] = balance.ToString(),
+                        ["lastupdatedblock"] = lastUpdatedBlock
+                    });
+                }
+
+                balances.Add(new JObject
+                {
+                    ["assethash"] = asset.ToString(),
+                    ["tokens"] = jsonTokens,
+                });
             }
 
             return new JObject
@@ -421,6 +490,7 @@ namespace NeoExpress.Node
         [RpcMethod]
         public JObject GetNep11Properties(JArray @params)
         {
+            // logic replicated from TokenTracker.GetNep11Properties. 
             var nep11Hash = AsScriptHash(@params[0]);
             var tokenId = @params[1].AsString().HexToBytes();
 
@@ -477,40 +547,51 @@ namespace NeoExpress.Node
             var received = new JArray();
 
             using var snapshot = neoSystem.GetSnapshot();
-            foreach (var (blockIndex, txIndex, transfer) in PersistencePlugin.GetTransferNotifications(snapshot, storageProvider, standard, address))
+
+            var contracts = TokenContract.Enumerate(snapshot)
+                .Where(c => c.standard == standard)
+                .Select(c => c.scriptHash)
+                .ToHashSet();
+            var notifications = PersistencePlugin.GetNotifications(storageProvider,
+                contracts: contracts,
+                eventNames: new HashSet<string> { "Transfer" });
+
+            foreach (var (blockIndex, txIndex, notification) in notifications)
             {
                 var header = NativeContract.Ledger.GetHeader(snapshot, blockIndex);
-                if (startTime <= header.Timestamp || header.Timestamp <= endTime)
+                if (startTime > header.Timestamp || header.Timestamp > endTime) continue;
+
+                var transfer = TransferNotificationRecord.Create(notification);
+                if (transfer is null) continue;
+                if (transfer.From != address && transfer.To != address) continue;
+
+                // create a JSON object to represent the transfer
+                var jsonTransfer = new JObject()
                 {
-                    // create a JSON object to represent the transfer
-                    var json = new JObject()
-                    {
-                        ["timestamp"] = header.Timestamp,
-                        ["assethash"] = transfer.Asset.ToString(),
-                        ["amount"] = transfer.Amount.ToString(),
-                        ["blockindex"] = header.Index,
-                        ["transfernotifyindex"] = txIndex,
-                        ["txhash"] = transfer.Notification.InventoryHash.ToString(),
-                    };
+                    ["timestamp"] = header.Timestamp,
+                    ["assethash"] = transfer.Asset.ToString(),
+                    ["amount"] = transfer.Amount.ToString(),
+                    ["blockindex"] = header.Index,
+                    ["transfernotifyindex"] = txIndex,
+                    ["txhash"] = transfer.Notification.InventoryHash.ToString(),
+                };
 
-                    // NEP-11 transfer records include an extra field for the token ID (if present)
-                    if (standard == TokenStandard.Nep11
-                        && transfer.TokenId != null)
-                    {
-                        json["tokenid"] = transfer.TokenId.GetSpan().ToHexString();
-                    }
+                // NEP-11 transfer records include an extra field for the token ID (if present)
+                if (standard == TokenStandard.Nep11 && transfer.TokenId.Length > 0)
+                {
+                    jsonTransfer["tokenid"] = transfer.TokenId.Span.ToHexString();
+                }
 
-                    // add the json transfer object to send and/or receive collections as appropriate
-                    if (address == transfer.From)
-                    {
-                        json["transferaddress"] = transfer.To.ToString();
-                        sent.Add(json);
-                    }
-                    if (address == transfer.To)
-                    {
-                        json["transferaddress"] = transfer.From.ToString();
-                        received.Add(json);
-                    }
+                // add the json transfer object to send and/or receive collections as appropriate
+                if (address == transfer.From)
+                {
+                    jsonTransfer["transferaddress"] = transfer.To.ToString();
+                    sent.Add(jsonTransfer);
+                }
+                if (address == transfer.To)
+                {
+                    jsonTransfer["transferaddress"] = transfer.From.ToString();
+                    received.Add(jsonTransfer);
                 }
             }
 

--- a/src/neoxp/Node/Modules/ExpressRpcMethods.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcMethods.cs
@@ -241,6 +241,7 @@ namespace NeoExpress.Node
         }
 
         const int MAX_NOTIFICATIONS = 100;
+        const string TRANSFER = "Transfer";
 
         [RpcMethod]
         public JObject ExpressEnumNotifications(JArray @params)
@@ -330,7 +331,7 @@ namespace NeoExpress.Node
                     storageProvider,
                     SeekDirection.Backward,
                     addressBalances.Select(b => b.scriptHash).ToHashSet(),
-                    new HashSet<string> { "Transfer " });
+                    TRANSFER);
 
                 foreach (var (blockIndex, _, notification) in notifications)
                 {
@@ -436,7 +437,7 @@ namespace NeoExpress.Node
                     storageProvider,
                     SeekDirection.Backward,
                     tokens.Select(b => b.scriptHash).ToHashSet(),
-                    new HashSet<string> { "Transfer " });
+                    TRANSFER);
 
                 foreach (var (blockIndex, _, notification) in notifications)
                 {
@@ -553,8 +554,7 @@ namespace NeoExpress.Node
                 .Select(c => c.scriptHash)
                 .ToHashSet();
             var notifications = PersistencePlugin.GetNotifications(storageProvider,
-                contracts: contracts,
-                eventNames: new HashSet<string> { "Transfer" });
+                SeekDirection.Forward, contracts, TRANSFER);
 
             foreach (var (blockIndex, txIndex, notification) in notifications)
             {

--- a/src/neoxp/Node/Modules/PersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/PersistencePlugin.cs
@@ -43,7 +43,8 @@ namespace NeoExpress.Node
                 : null;
         }
 
-        static Lazy<byte[]> backwardsNotificationsPrefix = new Lazy<byte[]>(() => {
+        static Lazy<byte[]> backwardsNotificationsPrefix = new Lazy<byte[]>(() =>
+        {
             var buffer = new byte[sizeof(uint) + sizeof(ushort)];
             BinaryPrimitives.WriteUInt32BigEndian(buffer, uint.MaxValue);
             BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(sizeof(uint)), ushort.MaxValue);
@@ -58,7 +59,7 @@ namespace NeoExpress.Node
         {
             var store = GetNotificationsStore(storageProvider);
 
-            var prefix = direction == SeekDirection.Forward 
+            var prefix = direction == SeekDirection.Forward
                 ? Array.Empty<byte>()
                 : backwardsNotificationsPrefix.Value;
 

--- a/src/neoxp/Node/Modules/PersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/PersistencePlugin.cs
@@ -43,20 +43,24 @@ namespace NeoExpress.Node
                 : null;
         }
 
-        public static IEnumerable<(uint blockIndex, ushort txIndex, NotificationRecord notification)> GetNotifications(IStorageProvider storageProvider,
+        static Lazy<byte[]> backwardsNotificationsPrefix = new Lazy<byte[]>(() => {
+            var buffer = new byte[sizeof(uint) + sizeof(ushort)];
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, uint.MaxValue);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(sizeof(uint)), ushort.MaxValue);
+            return buffer;
+        });
+
+        public static IEnumerable<(uint blockIndex, ushort txIndex, NotificationRecord notification)> GetNotifications(
+            IStorageProvider storageProvider,
             SeekDirection direction = SeekDirection.Forward,
             IReadOnlySet<UInt160>? contracts = null,
             IReadOnlySet<string>? eventNames = null)
         {
             var store = GetNotificationsStore(storageProvider);
 
-            var prefix = Array.Empty<byte>();
-            if (direction == SeekDirection.Backward)
-            {
-                prefix = new byte[sizeof(uint) * 2];
-                BinaryPrimitives.WriteUInt32BigEndian(prefix, uint.MaxValue);
-                BinaryPrimitives.WriteUInt32BigEndian(prefix.AsSpan(sizeof(uint)), uint.MaxValue);
-            }
+            var prefix = direction == SeekDirection.Forward 
+                ? Array.Empty<byte>()
+                : backwardsNotificationsPrefix.Value;
 
             return store.Seek(prefix, direction)
                 .Select(t => ParseNotification(t.Key, t.Value))
@@ -68,44 +72,6 @@ namespace NeoExpress.Node
                 var blockIndex = BinaryPrimitives.ReadUInt32BigEndian(key.AsSpan(0, sizeof(uint)));
                 var txIndex = BinaryPrimitives.ReadUInt16BigEndian(key.AsSpan(sizeof(uint), sizeof(ushort)));
                 return (blockIndex, txIndex, notification: value.AsSerializable<NotificationRecord>());
-            }
-        }
-
-        public static IEnumerable<(uint blockIndex, ushort txIndex, TransferNotificationRecord transfer)> GetTransferNotifications(
-            DataCache snapshot,
-            IStorageProvider storageProvider,
-            TokenStandard standard,
-            UInt160 address)
-        {
-            // valid number of state arguments depends on the token standard
-            var stateCount = standard switch
-            {
-                TokenStandard.Nep17 => 3,
-                TokenStandard.Nep11 => 4,
-                _ => throw new ArgumentException("Unexpected standard value", nameof(standard))
-            };
-
-            // collect a set of hashes for contracts that implement the specified standard
-            HashSet<UInt160> tokenContracts = new();
-            foreach (var (contractHash, tokenStandard) in TokenContract.Enumerate(snapshot))
-            {
-                if (tokenStandard == standard) tokenContracts.Add(contractHash);
-            }
-
-            // collect latest block index of transfer records involving provided address
-            foreach (var (blockIndex, txIndex, notification) in PersistencePlugin.GetNotifications(storageProvider))
-            {
-                if (notification.EventName == "Transfer"
-                     && notification.State.Count == stateCount
-                     && tokenContracts.Contains(notification.ScriptHash))
-                {
-                    var transfer = TransferNotificationRecord.Create(notification);
-                    if (transfer != null
-                        && (transfer.From == address || transfer.To == address))
-                    {
-                        yield return (blockIndex, txIndex, transfer);
-                    }
-                }
             }
         }
 

--- a/src/neoxp/Node/Modules/PersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/PersistencePlugin.cs
@@ -53,6 +53,15 @@ namespace NeoExpress.Node
 
         public static IEnumerable<(uint blockIndex, ushort txIndex, NotificationRecord notification)> GetNotifications(
             IStorageProvider storageProvider,
+            SeekDirection direction,
+            IReadOnlySet<UInt160>? contracts,
+            string eventName) => string.IsNullOrEmpty(eventName)
+                ? GetNotifications(storageProvider, direction, contracts)
+                : GetNotifications(storageProvider, direction, contracts, 
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase) { eventName });
+
+        public static IEnumerable<(uint blockIndex, ushort txIndex, NotificationRecord notification)> GetNotifications(
+            IStorageProvider storageProvider,
             SeekDirection direction = SeekDirection.Forward,
             IReadOnlySet<UInt160>? contracts = null,
             IReadOnlySet<string>? eventNames = null)

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -15,6 +15,7 @@ using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC;
 using Neo.Network.RPC.Models;
+using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Native;
@@ -412,7 +413,7 @@ namespace NeoExpress.Node
 #pragma warning disable 1998 
         public async IAsyncEnumerable<(uint blockIndex, NotificationRecord notification)> EnumerateNotificationsAsync(IReadOnlySet<UInt160>? contractFilter, IReadOnlySet<string>? eventFilter)
         {
-            var notifications = PersistencePlugin.GetNotifications(this.rocksDbStorageProvider, Neo.Persistence.SeekDirection.Backward, contractFilter, eventFilter);
+            var notifications = PersistencePlugin.GetNotifications(this.rocksDbStorageProvider, SeekDirection.Backward, contractFilter, eventFilter);
             foreach (var (block, _, notification) in notifications)
             {
                 yield return (block, notification);

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -326,33 +326,31 @@ namespace NeoExpress.Node
         {
             using var snapshot = neoSystem.GetSnapshot();
             var contracts = TokenContract.Enumerate(snapshot)
-                .Where(c => c.standard == TokenStandard.Nep17);
+                .Where(c => c.standard == TokenStandard.Nep17)
+                .ToList();
 
             var addressArray = address.ToArray();
-            var contractCount = 0;
             using var builder = new ScriptBuilder();
-            foreach (var c in contracts.Reverse())
+            for (var i = contracts.Count; i-- > 0;)
             {
-                builder.EmitDynamicCall(c.scriptHash, "symbol");
-                builder.EmitDynamicCall(c.scriptHash, "decimals");
-                builder.EmitDynamicCall(c.scriptHash, "balanceOf", addressArray);
-                contractCount++;
+                builder.EmitDynamicCall(contracts[i].scriptHash, "symbol");
+                builder.EmitDynamicCall(contracts[i].scriptHash, "decimals");
+                builder.EmitDynamicCall(contracts[i].scriptHash, "balanceOf", addressArray);
             }
 
             List<(TokenContract contract, BigInteger balance)> balances = new();
             using var engine = builder.Invoke(neoSystem.Settings, snapshot);
-            if (engine.State != VMState.FAULT && engine.ResultStack.Count == contractCount * 3)
+            if (engine.State != VMState.FAULT && engine.ResultStack.Count == contracts.Count * 3)
             {
                 var resultStack = engine.ResultStack;
-                for (var i = 0; i < contractCount; i++)
+                for (var i = 0; i < contracts.Count; i++)
                 {
                     var index = i * 3;
                     var symbol = resultStack.Peek(index + 2).GetString();
                     if (symbol == null) continue;
                     var decimals = (byte)resultStack.Peek(index + 1).GetInteger();
                     var balance = resultStack.Peek(index).GetInteger();
-                    var (scriptHash, standard) = contracts.ElementAt(i);
-                    balances.Add((new TokenContract(symbol, decimals, scriptHash, standard), balance));
+                    balances.Add((new TokenContract(symbol, decimals, contracts[i].scriptHash, contracts[i].standard), balance));
                 }
             }
 
@@ -408,9 +406,9 @@ namespace NeoExpress.Node
         public Task<IReadOnlyList<ExpressStorage>> ListStoragesAsync(UInt160 scriptHash)
             => MakeAsync(() => ListStorages(scriptHash));
 
-// warning CS1998: This async method lacks 'await' operators and will run synchronously.
-// EnumerateNotificationsAsync has to be async in order to be polymorphic with OnlineNode's implementation
-#pragma warning disable 1998 
+        // warning CS1998: This async method lacks 'await' operators and will run synchronously.
+        // EnumerateNotificationsAsync has to be async in order to be polymorphic with OnlineNode's implementation
+#pragma warning disable 1998
         public async IAsyncEnumerable<(uint blockIndex, NotificationRecord notification)> EnumerateNotificationsAsync(IReadOnlySet<UInt160>? contractFilter, IReadOnlySet<string>? eventFilter)
         {
             var notifications = PersistencePlugin.GetNotifications(this.rocksDbStorageProvider, SeekDirection.Backward, contractFilter, eventFilter);

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -241,12 +241,11 @@ namespace NeoExpress.Node
 
         public async Task<IReadOnlyList<(TokenContract contract, BigInteger balance)>> ListBalancesAsync(UInt160 address)
         {
-            var contracts = (await ListTokenContractsAsync().ConfigureAwait(false))
-                .ToDictionary(c => c.ScriptHash);
             var rpcBalances = await rpcClient.GetNep17BalancesAsync(address.ToAddress(ProtocolSettings.AddressVersion))
                 .ConfigureAwait(false);
-
-            return rpcBalances.Balances.Select(b => (contracts[b.AssetHash], b.Amount)).ToList();
+            var balanceMap = rpcBalances.Balances.ToDictionary(b => b.AssetHash, b => b.Amount);
+            var contracts = await ListTokenContractsAsync().ConfigureAwait(false);
+            return contracts.Select(c => (c, balanceMap.TryGetValue(c.ScriptHash, out var value) ? value : 0)).ToList();
         }
 
         public async Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync()


### PR DESCRIPTION
fixes #220, cc @gsmachado

issue #220 is an edge case - `GetNep17Balances` returns no results for genesis account in a blockchain where there have been no transfers (such as right after reset). The production `TokenTracker` plugin has the same issue, but is not an issue since chains with `TokenTracker` plugin are not going to be reset to genesis like Express does.

To fix this, I changed GetNep17Balances to collect account balances for all NEP-17 contracts then filter out ones that have zero balance. This ensures that we get valid balances even if there are no Transfer notifications. Once we have a list of tokens + balances, GetNep17Balances searchs backwards thru notifications to find the most recent block with a transfer notification for the specified account/token. If no transfer notifications are found, zero is used for the lastUpdatedBlock value. GetNep11Balances was modified similarly

As part of this work, I did some other cleanup that was started by the addition of the `contract notification` command. 

* Removed PersistencePlugin.GetTransferNotifications. Methods that need to process transfer notifications can now simply call GetNotifications and pass in an eventNames filter set
* OnlineNode.ListBalancesAsync now returns balance info for all NEP-17 tokens, even if the balance is zero. This matches OfflineNode's implementation
* Slightly improved efficiency of OfflineNode.ListBalances
* Changed definition of TransferNotificationRecord.TokenId to be ROM<byte> instead of ByteString
