### PR TITLE
Fix Oracle Response RequestId parameter

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -136,6 +136,9 @@ namespace NeoExpress.Commands
                     [Argument(1, Description = "Path to JSON file with oracle response content")]
                     [Required]
                     internal string ResponsePath { get; init; } = string.Empty;
+
+                    [Option(Description = "Oracle request ID")]
+                    internal ulong? RequestId { get; }
                 }
             }
 

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -163,7 +163,8 @@ namespace NeoExpress.Commands
                         {
                             await txExec.OracleResponseAsync(
                                 cmd.Model.Url,
-                                root.Resolve(cmd.Model.ResponsePath)).ConfigureAwait(false);
+                                root.Resolve(cmd.Model.ResponsePath),
+                                cmd.Model.RequestId).ConfigureAwait(false);
                             break;
                         }
                     case CommandLineApplication<BatchFileCommands.Policy.Block> cmd:

--- a/src/neoxp/Commands/OracleCommand.Response.cs
+++ b/src/neoxp/Commands/OracleCommand.Response.cs
@@ -28,7 +28,7 @@ namespace NeoExpress.Commands
             internal string ResponsePath { get; init; } = string.Empty;
 
             [Option(Description = "Oracle request ID")]
-            internal (bool hasValue, ulong value) RequestId { get; }
+            internal ulong? RequestId { get; }
 
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
@@ -45,7 +45,7 @@ namespace NeoExpress.Commands
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    await txExec.OracleResponseAsync(Url, ResponsePath, RequestId.hasValue ? RequestId.value : null).ConfigureAwait(false);
+                    await txExec.OracleResponseAsync(Url, ResponsePath, RequestId).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
fix #212

RequestId should have been declared as a ulong? instead of as a hasValue/value tuple. The hasValue/value patten leads to an option use like `oracle response --request-id:1` instead of `oracle response --request-id 1` 

Also added request id option to batch mode version of oracle response