### PR TITLE
Fix contract download arg parsing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fix releases, but
 may not exactly match a publicly released version.
 
-## [Unreleased]
+## [3.3] - 2022-06-28
 
 #### Changed
 * Updated to Neo 3.3.1 (af99e7030dbbe671d25a45a6e758f8d61c9b38de)

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,15 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fix releases, but
 may not exactly match a publicly released version.
 
+## [Unreleased]
+
+### NeoExpress
+
+#### Fixed
+
+* Fixed parsing of `contract download --force` option ([#237](https://github.com/neo-project/neo-express/issues/237))
+* Changed `height` argument for batch mode `contract download` to option for consistency with non-batch mode command ([#238](https://github.com/neo-project/neo-express/issues/238))
+
 ## [3.3] - 2022-06-28
 
 #### Changed

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Different versions of Neo-Express require different versions of .NET Core.
 
 |Neo-Express Version|.NET Core Version|
 |-------------------|-----------------|
-| v3.1 | [v6.0](https://dotnet.microsoft.com/download/dotnet/6.0) |
+| v3.1 and later | [v6.0](https://dotnet.microsoft.com/download/dotnet/6.0) |
 | v3.0 | [v5.0](https://dotnet.microsoft.com/download/dotnet/5.0) |
 | v1.1 | [v3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1) |
 | v1.0 | [v3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1) |

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -73,9 +73,8 @@ namespace NeoExpress.Commands
                     internal uint Height { get; } = 0;
 
                     [Option(CommandOptionType.SingleOrNoValue,
-                        Description = "Replace contract and storage if it already exists (Default: All)")]
-                    [AllowedValues(StringComparison.OrdinalIgnoreCase, "All", "ContractOnly", "StorageOnly")]
-                    internal ContractCommand.OverwriteForce Force { get; init; } = ContractCommand.OverwriteForce.None;
+                        Description = "Replace contract and storage if it already exists\nDefaults to None if option unspecified, All if option value unspecified")]
+                    internal (bool hasValue, ContractCommand.OverwriteForce value) Force { get; init; }
                 }
 
                 [Command("invoke")]

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -68,7 +68,7 @@ namespace NeoExpress.Commands
                     [Required]
                     internal string RpcUri { get; } = string.Empty;
 
-                    [Argument(2, Description = "Block height to get contract state for")]
+                    [Option(Description = "Block height to get contract state for")]
                     [Required]
                     internal uint Height { get; } = 0;
 

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -135,12 +135,14 @@ namespace NeoExpress.Commands
                                 throw new ArgumentException("Contract download is only supported for single-node consensus");
                             }
 
+                            var force = ContractCommand.Download.ParseOverwriteForceOption(cmd);
+
                             await ContractCommand.Download.ExecuteAsync(
                                 txExec.ExpressNode,
                                 cmd.Model.Contract,
                                 cmd.Model.RpcUri,
                                 cmd.Model.Height,
-                                cmd.Model.Force,
+                                force,
                                 writer).ConfigureAwait(false);
                             break;
                         }


### PR DESCRIPTION
`contract download` option defaults to `None` if option is unspecified and defaults to `All` if option value is unspecified. fixes #237

Also changed `batch` command `contract download` `height` from argument to option in order to match non-batch version of `contract download` . Fixes #238

cc @ixje