### PR TITLE
.neo-worknet / .neo-express file compat

### DIFF
--- a/src/worknet/Commands/CreateCommand.cs
+++ b/src/worknet/Commands/CreateCommand.cs
@@ -84,6 +84,7 @@ class CreateCommand
 
             var consensusWallet = new ToolkitWallet("consensus", branchInfo.ProtocolSettings);
             var consensusAccount = consensusWallet.CreateAccount();
+            consensusAccount.IsDefault = true;
 
             fs.SaveWorknetFile(filename, uri, branchInfo, consensusWallet);
 

--- a/src/worknet/Utility.cs
+++ b/src/worknet/Utility.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using System.IO.Abstractions;
 using static Neo.BlockchainToolkit.Constants;
 using static Crayon.Output;
+using Neo.Wallets;
 
 namespace NeoWorkNet;
 
@@ -54,6 +55,28 @@ static class Utility
         writer.Formatting = Formatting.Indented;
 
         using var _ = writer.WriteObject();
+        writer.WriteProperty("magic", branch.Network);
+        writer.WriteProperty("address-version", branch.AddressVersion);
+        {
+            using var _1 = writer.WritePropertyArray("consensus-nodes");
+            using var _2 = writer.WriteObject();
+            writer.WriteProperty("rpc-port", 30332);
+            using var _3 = writer.WritePropertyObject("wallet");
+            writer.WriteProperty("name", "node1");
+            using var _4 = writer.WritePropertyArray("accounts");
+            foreach (var account in wallet.GetAccounts())
+            {
+                using var _5 = writer.WriteObject();
+                var key = account.GetKey();
+                if (key is not null) 
+                {
+                    writer.WriteProperty("private-key", Convert.ToHexString(key.PrivateKey));
+                }
+                writer.WriteProperty("script-hash", account.ScriptHash.ToAddress(branch.AddressVersion));
+                writer.WriteProperty("is-default", account.IsDefault);
+            }
+        }
+
         writer.WriteProperty("uri", uri.ToString());
         writer.WritePropertyName("branch-info");
         branch.WriteJson(writer);

--- a/src/worknet/Utility.cs
+++ b/src/worknet/Utility.cs
@@ -70,9 +70,9 @@ static class Utility
                 var key = account.GetKey();
                 if (key is not null) 
                 {
-                    writer.WriteProperty("private-key", Convert.ToHexString(key.PrivateKey));
+                    writer.WriteProperty("private-key", Convert.ToHexString(key.PrivateKey).ToLower());
                 }
-                writer.WriteProperty("script-hash", account.ScriptHash.ToAddress(branch.AddressVersion));
+                writer.WriteProperty("address", account.ScriptHash.ToAddress(branch.AddressVersion));
                 writer.WriteProperty("is-default", account.IsDefault);
             }
         }


### PR DESCRIPTION
emit properties to .neo-worknet file for compatibility with .neo-express. In particular

* 'magic` 
* 'address-version' 
* 'consensus-nodes'

> Note: this is preliminary work intended to unblock other work. In particular, only `SaveWorknetFile` has been updated. These fields are ignored by `LoadWorknetAsync`. Once the [blockchain toolkit library is moved over to this repo](https://github.com/ngdenterprise/neo-blockchaintoolkit-library/issues/81), we will unify file management code across express and worknet.