### PR TITLE
Support WIF encoded private keys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,10 @@ may not exactly match a publicly released version.
 
 ## [3.6] - Unreleased
 
+### Added
+
+* WIF encoded private keys can be used to specify signing and non-signing accounts
+
 ## [3.5] - 2023-01-03
 
 ### Changed

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -21,11 +21,21 @@ multiple ways:
 - `genesis` to use the consensus node multi-sig account which holds the genesis NEO and GAS
 - Neo-Express wallet nickname (see `wallet create` below). Note, this includes `node1` etc to specify
   the default wallet account associated with each consensus node
+- A [WIF encoded](https://developer.bitcoin.org/devguide/wallets.html#wallet-import-format-wif) private key
 - A [standard NEP-2 Passphrase-protected private key](https://github.com/neo-project/proposals/blob/master/nep-2.mediawiki).
     - When using a NEP-2 protected private key, the passphrase must be specified using the `--password` option
 - The path to a [standard NEP-6 JSON wallet](https://github.com/neo-project/proposals/blob/master/nep-6.mediawiki).
     - When using a NEP-6 wallet, the password must be specified using the `--password` option. 
     - Note, Neo-Express only supports NEP-6 wallets with either a single account or a single default account
+
+NEP-2 private key and NEP-6 JSON wallet are password protected. When using one of these methods, the password
+can be specified using the `--password` option. If the password is not specified on the command line, Neo-Express
+will prompt the user to enter the password.
+
+> Note, `neoxp batch` command does not support interactive prompting. Using a NEP-2 private key or NEP-6 wallet
+> with `neoxp batch` also requires specifying the `--password` option. Needless to say, storing a password in 
+> an unencrpted batch file is not secure, and developers should not use wallets associated with production, mainnet
+> assets with Neo-Express.
 
 ### Specifying a Non-Signing Account
 
@@ -36,6 +46,7 @@ can be specified in multiple ways:
 - Neo-Express wallet nickname (see `wallet create` below). Note, this includes `node1` etc to specify
   the default wallet account associated with each consensus node
 - A standard Neo N3 address such as `Ne4Ko2JkzjAd8q2sasXsQCLfZ7nu8Gm5vR`
+- A [WIF encoded](https://developer.bitcoin.org/devguide/wallets.html#wallet-import-format-wif) private key
 
 ## neoxp create
 

--- a/src/neoxp/Commands/WalletCommand.List.cs
+++ b/src/neoxp/Commands/WalletCommand.List.cs
@@ -83,6 +83,8 @@ namespace NeoExpress.Commands
                             writer.WriteValue(account.ScriptHash.ToString());
                             writer.WritePropertyName("private-key");
                             writer.WriteValue(Convert.ToHexString(keyPair.PrivateKey));
+                            writer.WritePropertyName("private-key-wif");
+                            writer.WriteValue(keyPair.Export());
                             writer.WritePropertyName("public-key");
                             writer.WriteValue(Convert.ToHexString(keyPair.PublicKey.EncodePoint(true)));
                             writer.WriteEndObject();
@@ -121,9 +123,10 @@ namespace NeoExpress.Commands
                             var keyPair = account.GetKey() ?? throw new Exception();
 
                             writer.WriteLine($"  {account.Address} ({(account.IsDefault ? "Default" : account.Label)})");
-                            writer.WriteLine($"    script hash: {BitConverter.ToString(account.ScriptHash.ToArray())}");
-                            writer.WriteLine($"    public key:    {Convert.ToHexString(keyPair.PublicKey.EncodePoint(true))}");
-                            writer.WriteLine($"    private key:   {Convert.ToHexString(keyPair.PrivateKey)}");
+                            writer.WriteLine($"    script hash:       {BitConverter.ToString(account.ScriptHash.ToArray())}");
+                            writer.WriteLine($"    public key:        {Convert.ToHexString(keyPair.PublicKey.EncodePoint(true))}");
+                            writer.WriteLine($"    private key:       {Convert.ToHexString(keyPair.PrivateKey)}");
+                            writer.WriteLine($"    private key (WIF): {keyPair.Export()}");
                         }
                     }
 

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -114,7 +114,29 @@ namespace NeoExpress
                 return accountHash;
             }
 
+            if (TryGetWIFAccountHash(name, out accountHash))
+            {
+                return accountHash;
+            }
+
             return default(None);
+
+            static bool TryGetWIFAccountHash(string wif, out UInt160 accountHash)
+            {
+                try
+                {
+                    var privateKey = Wallet.GetPrivateKeyFromWIF(wif);
+                    var keyPair = new KeyPair(privateKey);
+                    var contract = Contract.CreateSignatureContract(keyPair.PublicKey);
+                    accountHash = contract.ScriptHash;
+                    return true;
+                }
+                catch
+                {
+                    accountHash = UInt160.Zero;
+                    return false;
+                }
+            }
         }
 
         public static async Task<UInt160> ParseAssetAsync(this IExpressNode expressNode, string asset)

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -168,6 +168,11 @@ namespace NeoExpress
                     }
                 }
 
+                if (TryGetWIF(name, settings, out wallet, out accountHash))
+                {
+                    return true;
+                }
+
                 if (!string.IsNullOrEmpty(password))
                 {
                     if (TryGetNEP2Wallet(name, password, settings, out wallet, out accountHash))
@@ -186,14 +191,27 @@ namespace NeoExpress
             accountHash = null;
             return false;
 
+            static bool TryGetWIF(string wif, ProtocolSettings settings, [MaybeNullWhen(false)] out Wallet wallet, [MaybeNullWhen(false)] out UInt160 accountHash)
+            {
+                try
+                {
+                    var privateKey = Wallet.GetPrivateKeyFromWIF(wif);
+                    CreateWallet(privateKey, settings, out wallet, out accountHash);
+                    return true;
+                }
+                catch
+                {
+                    wallet = null;
+                    accountHash = null;
+                    return false;
+                }
+            }
             static bool TryGetNEP2Wallet(string nep2, string password, ProtocolSettings settings, [MaybeNullWhen(false)] out Wallet wallet, [MaybeNullWhen(false)] out UInt160 accountHash)
             {
                 try
                 {
                     var privateKey = Wallet.GetPrivateKeyFromNEP2(nep2, password, settings.AddressVersion);
-                    wallet = new DevWallet(settings, string.Empty);
-                    var account = wallet.CreateAccount(privateKey);
-                    accountHash = account.ScriptHash;
+                    CreateWallet(privateKey, settings, out wallet, out accountHash);
                     return true;
                 }
                 catch
@@ -214,9 +232,7 @@ namespace NeoExpress
                         ?? throw new InvalidOperationException("Neo-express only supports NEP-6 wallets with a single default account or a single account");
                     if (nep6account.IsMultiSigContract()) throw new Exception("Neo-express doesn't supports multi-sig NEP-6 accounts");
                     var keyPair = nep6account.GetKey() ?? throw new Exception("account.GetKey() returned null");
-                    wallet = new DevWallet(settings, string.Empty);
-                    var account = wallet.CreateAccount(keyPair.PrivateKey);
-                    accountHash = account.ScriptHash;
+                    CreateWallet(keyPair.PrivateKey, settings, out wallet, out accountHash);
                     return true;
                 }
                 catch
@@ -226,6 +242,15 @@ namespace NeoExpress
                     return false;
                 }
             }
+
+            static void CreateWallet(byte[] privateKey, ProtocolSettings settings, out Wallet wallet, out UInt160 accountHash)
+            {
+                wallet = new DevWallet(settings, string.Empty);
+                var account = wallet.CreateAccount(privateKey);
+                accountHash = account.ScriptHash;
+            }
+
+
         }
     }
 }

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -168,7 +168,7 @@ namespace NeoExpress
                     }
                 }
 
-                if (TryGetWIF(name, settings, out wallet, out accountHash))
+                if (TryGetWIFWallet(name, settings, out wallet, out accountHash))
                 {
                     return true;
                 }
@@ -191,7 +191,7 @@ namespace NeoExpress
             accountHash = null;
             return false;
 
-            static bool TryGetWIF(string wif, ProtocolSettings settings, [MaybeNullWhen(false)] out Wallet wallet, [MaybeNullWhen(false)] out UInt160 accountHash)
+            static bool TryGetWIFWallet(string wif, ProtocolSettings settings, [MaybeNullWhen(false)] out Wallet wallet, [MaybeNullWhen(false)] out UInt160 accountHash)
             {
                 try
                 {
@@ -206,6 +206,7 @@ namespace NeoExpress
                     return false;
                 }
             }
+
             static bool TryGetNEP2Wallet(string nep2, string password, ProtocolSettings settings, [MaybeNullWhen(false)] out Wallet wallet, [MaybeNullWhen(false)] out UInt160 accountHash)
             {
                 try


### PR DESCRIPTION
A [WIF encoded](https://developer.bitcoin.org/devguide/wallets.html#wallet-import-format-wif) private key can be used to specify both signing accounts (such as a contract deployer or the transfer source account) and non-signing accounts (such as a transfer target account). 