### PR TITLE
Print account scripthash using hex

### DIFF
--- a/src/neoxp/Commands/WalletCommand.List.cs
+++ b/src/neoxp/Commands/WalletCommand.List.cs
@@ -123,7 +123,7 @@ namespace NeoExpress.Commands
                             var keyPair = account.GetKey() ?? throw new Exception();
 
                             writer.WriteLine($"  {account.Address} ({(account.IsDefault ? "Default" : account.Label)})");
-                            writer.WriteLine($"    script hash:       {BitConverter.ToString(account.ScriptHash.ToArray())}");
+                            writer.WriteLine($"    script hash:       {Convert.ToHexString(account.ScriptHash.ToArray())}");
                             writer.WriteLine($"    public key:        {Convert.ToHexString(keyPair.PublicKey.EncodePoint(true))}");
                             writer.WriteLine($"    private key:       {Convert.ToHexString(keyPair.PrivateKey)}");
                             writer.WriteLine($"    private key (WIF): {keyPair.Export()}");


### PR DESCRIPTION
When listing accounts using `neoxp wallet list`, the scripthash being printed is not usable by Neo Express (you can't copy and paste it). This PR fixes it.

Before:
 script hash:       77-85-FB-F0-72-5A-CD-DD-73-6F-38-A3-91-55-F0-71-B6-D6-97-F2

After:
script hash:       7785FBF0725ACDDD736F38A39155F071B6D697F2

