### PR TITLE
Revert "Inconsistent account naming"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,4 @@ src/neoxp/default.neo-express
 src/trace/*.neo-trace
 src/worknet/default.neo-worknet
 src/worknet/data/*
+src/neoxp/Properties/launchSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -419,4 +419,3 @@ src/neoxp/default.neo-express
 src/trace/*.neo-trace
 src/worknet/default.neo-worknet
 src/worknet/data/*
-/src/neoxp/Properties/launchSettings.json

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -152,11 +152,10 @@ namespace NeoExpress
 
         public static async Task<OneOf<UInt160, None>> TryGetAccountHashAsync(this IExpressNode expressNode, ExpressChain chain, string name)
         {
-            if (name.StartsWith('@'))
+            if (name.StartsWith('#'))
             {
-                name = name[1..];
                 var contracts = await expressNode.ListContractsAsync().ConfigureAwait(false);
-                if (TryGetContractHash(contracts, name, out var contractHash))
+                if (TryGetContractHash(contracts, name.Substring(1), out var contractHash))
                 {
                     return contractHash;
                 }


### PR DESCRIPTION
Reverts neo-project/neo-express#305

This is a big change. This breaks old batch files that have been developed by users.

Sorry 😢 

Ill see if i can get some unit tests going for `neo-express` as well to prevent things like this.