### PR TITLE
Changed `file_header` to use `{fileName}`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ insert_final_newline = true
 # Organize usings
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = false
-file_header_template = Copyright (C) 2015-2023 The Neo Project.\n\n{fileName} is free software distributed under the MIT software license,\nsee the accompanying file LICENSE in the main directory of the\nproject or http://www.opensource.org/licenses/mit-license.php\nfor more details.\n\nRedistribution and use in source and binary forms with or without\nmodifications are permitted.
+file_header_template = Copyright (C) 2015-2023 The Neo Project.\n\n{fileName} file belongs to neo-express project and is free\nsoftware distributed under the MIT software license, see the\naccompanying file LICENSE in the main directory of the\nrepository or http://www.opensource.org/licenses/mit-license.php\nfor more details.\n\nRedistribution and use in source and binary forms with or without\nmodifications are permitted.
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false
@@ -242,3 +242,6 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# Require file header
+dotnet_diagnostic.IDE0073.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ insert_final_newline = true
 # Organize usings
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = false
-file_header_template = Copyright (C) 2015-2023 The Neo Project.\n\nThe neo is free software distributed under the MIT software license,\nsee the accompanying file LICENSE in the main directory of the\nproject or http://www.opensource.org/licenses/mit-license.php\nfor more details.\n\nRedistribution and use in source and binary forms with or without\nmodifications are permitted.
+file_header_template = Copyright (C) 2015-2023 The Neo Project.\n\n{fileName} is free software distributed under the MIT software license,\nsee the accompanying file LICENSE in the main directory of the\nproject or http://www.opensource.org/licenses/mit-license.php\nfor more details.\n\nRedistribution and use in source and binary forms with or without\nmodifications are permitted.
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// BatchCommand.BatchFileCommands.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// BatchCommand.BatchFileCommands.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// BatchCommand.BatchFileCommands.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// BatchCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// BatchCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// BatchCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
@@ -9,7 +9,6 @@
 // modifications are permitted.
 
 using McMaster.Extensions.CommandLineUtils;
-using Neo.BlockchainToolkit;
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
 

--- a/src/neoxp/Commands/CheckpointCommand.Create.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Create.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CheckpointCommand.Create.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CheckpointCommand.Create.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/CheckpointCommand.Create.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Create.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CheckpointCommand.Create.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/CheckpointCommand.Restore.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Restore.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CheckpointCommand.Restore.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/CheckpointCommand.Restore.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Restore.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CheckpointCommand.Restore.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CheckpointCommand.Restore.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/CheckpointCommand.Run.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Run.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CheckpointCommand.Run.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CheckpointCommand.Run.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/CheckpointCommand.Run.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Run.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CheckpointCommand.Run.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/CheckpointCommand.cs
+++ b/src/neoxp/Commands/CheckpointCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CheckpointCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/CheckpointCommand.cs
+++ b/src/neoxp/Commands/CheckpointCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CheckpointCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CheckpointCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Deploy.cs
+++ b/src/neoxp/Commands/ContractCommand.Deploy.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Deploy.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Deploy.cs
+++ b/src/neoxp/Commands/ContractCommand.Deploy.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Deploy.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Deploy.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Download.cs
+++ b/src/neoxp/Commands/ContractCommand.Download.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Download.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Download.cs
+++ b/src/neoxp/Commands/ContractCommand.Download.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Download.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Download.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Get.cs
+++ b/src/neoxp/Commands/ContractCommand.Get.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Get.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Get.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Get.cs
+++ b/src/neoxp/Commands/ContractCommand.Get.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Get.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Hash.cs
+++ b/src/neoxp/Commands/ContractCommand.Hash.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Hash.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Hash.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Hash.cs
+++ b/src/neoxp/Commands/ContractCommand.Hash.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Hash.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Invoke.cs
+++ b/src/neoxp/Commands/ContractCommand.Invoke.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Invoke.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Invoke.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Invoke.cs
+++ b/src/neoxp/Commands/ContractCommand.Invoke.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Invoke.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.List.cs
+++ b/src/neoxp/Commands/ContractCommand.List.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.List.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.List.cs
+++ b/src/neoxp/Commands/ContractCommand.List.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.List.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.List.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Run.cs
+++ b/src/neoxp/Commands/ContractCommand.Run.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Run.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Run.cs
+++ b/src/neoxp/Commands/ContractCommand.Run.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Run.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Run.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Storage.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Storage.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Storage.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.Update.cs
+++ b/src/neoxp/Commands/ContractCommand.Update.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.Update.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ContractCommand.Update.cs
+++ b/src/neoxp/Commands/ContractCommand.Update.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.Update.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.Update.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.cs
+++ b/src/neoxp/Commands/ContractCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ContractCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ContractCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ContractCommand.cs
+++ b/src/neoxp/Commands/ContractCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ContractCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CreateCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CreateCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CreateCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ExportCommand.cs
+++ b/src/neoxp/Commands/ExportCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExportCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ExportCommand.cs
+++ b/src/neoxp/Commands/ExportCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExportCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExportCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// FastForwardCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// FastForwardCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// FastForwardCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/OracleCommand.Enable.cs
+++ b/src/neoxp/Commands/OracleCommand.Enable.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OracleCommand.Enable.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OracleCommand.Enable.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/OracleCommand.Enable.cs
+++ b/src/neoxp/Commands/OracleCommand.Enable.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OracleCommand.Enable.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/OracleCommand.List.cs
+++ b/src/neoxp/Commands/OracleCommand.List.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OracleCommand.List.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OracleCommand.List.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/OracleCommand.List.cs
+++ b/src/neoxp/Commands/OracleCommand.List.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OracleCommand.List.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/OracleCommand.Requests.cs
+++ b/src/neoxp/Commands/OracleCommand.Requests.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OracleCommand.Requests.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OracleCommand.Requests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/OracleCommand.Requests.cs
+++ b/src/neoxp/Commands/OracleCommand.Requests.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OracleCommand.Requests.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/OracleCommand.Response.cs
+++ b/src/neoxp/Commands/OracleCommand.Response.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OracleCommand.Response.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OracleCommand.Response.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/OracleCommand.Response.cs
+++ b/src/neoxp/Commands/OracleCommand.Response.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OracleCommand.Response.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/OracleCommand.cs
+++ b/src/neoxp/Commands/OracleCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OracleCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/OracleCommand.cs
+++ b/src/neoxp/Commands/OracleCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OracleCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OracleCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.Block.cs
+++ b/src/neoxp/Commands/PolicyCommand.Block.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.Block.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.Block.cs
+++ b/src/neoxp/Commands/PolicyCommand.Block.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.Block.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.Block.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.Get.cs
+++ b/src/neoxp/Commands/PolicyCommand.Get.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.Get.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.Get.cs
+++ b/src/neoxp/Commands/PolicyCommand.Get.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.Get.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.Get.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
+++ b/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.IsBlocked.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
+++ b/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.IsBlocked.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.IsBlocked.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.Set.cs
+++ b/src/neoxp/Commands/PolicyCommand.Set.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.Set.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.Set.cs
+++ b/src/neoxp/Commands/PolicyCommand.Set.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.Set.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.Set.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.Sync.cs
+++ b/src/neoxp/Commands/PolicyCommand.Sync.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.Sync.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.Sync.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.Sync.cs
+++ b/src/neoxp/Commands/PolicyCommand.Sync.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.Sync.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.Unblock.cs
+++ b/src/neoxp/Commands/PolicyCommand.Unblock.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.Unblock.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.Unblock.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/PolicyCommand.Unblock.cs
+++ b/src/neoxp/Commands/PolicyCommand.Unblock.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.Unblock.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.cs
+++ b/src/neoxp/Commands/PolicyCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/PolicyCommand.cs
+++ b/src/neoxp/Commands/PolicyCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ResetCommand.cs
+++ b/src/neoxp/Commands/ResetCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ResetCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ResetCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ResetCommand.cs
+++ b/src/neoxp/Commands/ResetCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ResetCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/RunCommand.cs
+++ b/src/neoxp/Commands/RunCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// RunCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/RunCommand.cs
+++ b/src/neoxp/Commands/RunCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// RunCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// RunCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.Balance.cs
+++ b/src/neoxp/Commands/ShowCommand.Balance.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.Balance.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.Balance.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.Balance.cs
+++ b/src/neoxp/Commands/ShowCommand.Balance.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.Balance.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ShowCommand.Balances.cs
+++ b/src/neoxp/Commands/ShowCommand.Balances.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.Balances.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ShowCommand.Balances.cs
+++ b/src/neoxp/Commands/ShowCommand.Balances.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.Balances.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.Balances.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.Block.cs
+++ b/src/neoxp/Commands/ShowCommand.Block.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.Block.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ShowCommand.Block.cs
+++ b/src/neoxp/Commands/ShowCommand.Block.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.Block.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.Block.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.NFT.cs
+++ b/src/neoxp/Commands/ShowCommand.NFT.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.NFT.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.NFT.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.NFT.cs
+++ b/src/neoxp/Commands/ShowCommand.NFT.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.NFT.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ShowCommand.Notifications.cs
+++ b/src/neoxp/Commands/ShowCommand.Notifications.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.Notifications.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.Notifications.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.Notifications.cs
+++ b/src/neoxp/Commands/ShowCommand.Notifications.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.Notifications.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ShowCommand.Transaction.cs
+++ b/src/neoxp/Commands/ShowCommand.Transaction.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.Transaction.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.Transaction.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.Transaction.cs
+++ b/src/neoxp/Commands/ShowCommand.Transaction.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.Transaction.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/ShowCommand.cs
+++ b/src/neoxp/Commands/ShowCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ShowCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ShowCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/ShowCommand.cs
+++ b/src/neoxp/Commands/ShowCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ShowCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/StopCommand.cs
+++ b/src/neoxp/Commands/StopCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// StopCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// StopCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/StopCommand.cs
+++ b/src/neoxp/Commands/StopCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// StopCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/TransferCommand.cs
+++ b/src/neoxp/Commands/TransferCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TransferCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TransferCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/TransferCommand.cs
+++ b/src/neoxp/Commands/TransferCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// TransferCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/TransferNFTCommand.cs
+++ b/src/neoxp/Commands/TransferNFTCommand.cs
@@ -1,3 +1,13 @@
+// Copyright (C) 2015-2023 The Neo Project.
+//
+// TransferNFTCommand.cs is free software distributed under the MIT software license,
+// see the accompanying file LICENSE in the main directory of the
+// project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
 using McMaster.Extensions.CommandLineUtils;
 using Neo;
 using System.ComponentModel.DataAnnotations;

--- a/src/neoxp/Commands/TransferNFTCommand.cs
+++ b/src/neoxp/Commands/TransferNFTCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TransferNFTCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TransferNFTCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/WalletCommand.Create.cs
+++ b/src/neoxp/Commands/WalletCommand.Create.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WalletCommand.Create.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WalletCommand.Create.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/WalletCommand.Create.cs
+++ b/src/neoxp/Commands/WalletCommand.Create.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WalletCommand.Create.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/WalletCommand.Delete.cs
+++ b/src/neoxp/Commands/WalletCommand.Delete.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WalletCommand.Delete.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/WalletCommand.Delete.cs
+++ b/src/neoxp/Commands/WalletCommand.Delete.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WalletCommand.Delete.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WalletCommand.Delete.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/WalletCommand.Export.cs
+++ b/src/neoxp/Commands/WalletCommand.Export.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WalletCommand.Export.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/WalletCommand.Export.cs
+++ b/src/neoxp/Commands/WalletCommand.Export.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WalletCommand.Export.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WalletCommand.Export.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/WalletCommand.List.cs
+++ b/src/neoxp/Commands/WalletCommand.List.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WalletCommand.List.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WalletCommand.List.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Commands/WalletCommand.List.cs
+++ b/src/neoxp/Commands/WalletCommand.List.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WalletCommand.List.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/WalletCommand.cs
+++ b/src/neoxp/Commands/WalletCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WalletCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Commands/WalletCommand.cs
+++ b/src/neoxp/Commands/WalletCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WalletCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WalletCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/EventWrapper.cs
+++ b/src/neoxp/EventWrapper.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// EventWrapper.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// EventWrapper.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/EventWrapper.cs
+++ b/src/neoxp/EventWrapper.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// EventWrapper.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressChainManager.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressChainManager.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressChainManager.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/ExpressChainManagerFactory.cs
+++ b/src/neoxp/ExpressChainManagerFactory.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressChainManagerFactory.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/ExpressChainManagerFactory.cs
+++ b/src/neoxp/ExpressChainManagerFactory.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressChainManagerFactory.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressChainManagerFactory.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Extensions/ExpressChainExtensions.cs
+++ b/src/neoxp/Extensions/ExpressChainExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressChainExtensions.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Extensions/ExpressChainExtensions.cs
+++ b/src/neoxp/Extensions/ExpressChainExtensions.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressChainExtensions.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressChainExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressNodeExtensions.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressNodeExtensions.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressNodeExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Extensions.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Extensions.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Extensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// FileSystemExtensions.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// FileSystemExtensions.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// FileSystemExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// SmartContractExtensions.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// SmartContractExtensions.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// SmartContractExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/IExpressNode.cs
+++ b/src/neoxp/IExpressNode.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// IExpressNode.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// IExpressNode.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/IExpressNode.cs
+++ b/src/neoxp/IExpressNode.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// IExpressNode.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/IExpressStorage.cs
+++ b/src/neoxp/IExpressStorage.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// IExpressStorage.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// IExpressStorage.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/IExpressStorage.cs
+++ b/src/neoxp/IExpressStorage.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// IExpressStorage.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/DevWallet.cs
+++ b/src/neoxp/Models/DevWallet.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// DevWallet.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// DevWallet.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/DevWallet.cs
+++ b/src/neoxp/Models/DevWallet.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// DevWallet.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/DevWalletAccount.cs
+++ b/src/neoxp/Models/DevWalletAccount.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// DevWalletAccount.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/DevWalletAccount.cs
+++ b/src/neoxp/Models/DevWalletAccount.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// DevWalletAccount.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// DevWalletAccount.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/Nep17Contract.cs
+++ b/src/neoxp/Models/Nep17Contract.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Nep17Contract.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/Nep17Contract.cs
+++ b/src/neoxp/Models/Nep17Contract.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Nep17Contract.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Nep17Contract.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// NotificationRecord.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// NotificationRecord.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// NotificationRecord.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/PolicySettings.cs
+++ b/src/neoxp/Models/PolicySettings.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicySettings.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicySettings.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/PolicySettings.cs
+++ b/src/neoxp/Models/PolicySettings.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicySettings.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/PolicyValues.cs
+++ b/src/neoxp/Models/PolicyValues.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PolicyValues.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/PolicyValues.cs
+++ b/src/neoxp/Models/PolicyValues.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PolicyValues.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PolicyValues.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/TokenContract.cs
+++ b/src/neoxp/Models/TokenContract.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TokenContract.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TokenContract.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/TokenContract.cs
+++ b/src/neoxp/Models/TokenContract.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// TokenContract.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Models/TransferNotificationRecord.cs
+++ b/src/neoxp/Models/TransferNotificationRecord.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TransferNotificationRecord.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TransferNotificationRecord.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Models/TransferNotificationRecord.cs
+++ b/src/neoxp/Models/TransferNotificationRecord.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// TransferNotificationRecord.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/CheckpointExpressStorage.cs
+++ b/src/neoxp/Node/CheckpointExpressStorage.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CheckpointExpressStorage.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/CheckpointExpressStorage.cs
+++ b/src/neoxp/Node/CheckpointExpressStorage.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CheckpointExpressStorage.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CheckpointExpressStorage.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/Modules/ExpressApplicationEngineProvider.cs
+++ b/src/neoxp/Node/Modules/ExpressApplicationEngineProvider.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressApplicationEngineProvider.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressApplicationEngineProvider.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/Modules/ExpressApplicationEngineProvider.cs
+++ b/src/neoxp/Node/Modules/ExpressApplicationEngineProvider.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressApplicationEngineProvider.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/Modules/ExpressLogPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressLogPlugin.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressLogPlugin.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressLogPlugin.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/Modules/ExpressLogPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressLogPlugin.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressLogPlugin.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressPersistencePlugin.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressPersistencePlugin.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressPersistencePlugin.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressRpcServerPlugin.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressRpcServerPlugin.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressRpcServerPlugin.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/Modules/ExpressStoreProvider.cs
+++ b/src/neoxp/Node/Modules/ExpressStoreProvider.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ExpressStoreProvider.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ExpressStoreProvider.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/Modules/ExpressStoreProvider.cs
+++ b/src/neoxp/Node/Modules/ExpressStoreProvider.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ExpressStoreProvider.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// NodeUtility.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// NodeUtility.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// NodeUtility.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OfflineNode.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OfflineNode.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OfflineNode.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// OnlineNode.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// OnlineNode.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// OnlineNode.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/RocksDbExpressStorage.cs
+++ b/src/neoxp/Node/RocksDbExpressStorage.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// RocksDbExpressStorage.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// RocksDbExpressStorage.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Node/RocksDbExpressStorage.cs
+++ b/src/neoxp/Node/RocksDbExpressStorage.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// RocksDbExpressStorage.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/Program.cs
+++ b/src/neoxp/Program.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Program.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Program.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/Program.cs
+++ b/src/neoxp/Program.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Program.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// TransactionExecutor.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TransactionExecutor.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TransactionExecutor.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/TransactionExecutorFactory.cs
+++ b/src/neoxp/TransactionExecutorFactory.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TransactionExecutorFactory.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TransactionExecutorFactory.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/neoxp/TransactionExecutorFactory.cs
+++ b/src/neoxp/TransactionExecutorFactory.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// TransactionExecutorFactory.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/trace/Commands/BlockCommand.cs
+++ b/src/trace/Commands/BlockCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// BlockCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// BlockCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/trace/Commands/BlockCommand.cs
+++ b/src/trace/Commands/BlockCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// BlockCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/trace/Commands/TransactionCommand.cs
+++ b/src/trace/Commands/TransactionCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// TransactionCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// TransactionCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/trace/Commands/TransactionCommand.cs
+++ b/src/trace/Commands/TransactionCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// TransactionCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Program.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Program.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Program.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/CreateCommand.cs
+++ b/src/worknet/Commands/CreateCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// CreateCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// CreateCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Commands/CreateCommand.cs
+++ b/src/worknet/Commands/CreateCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// CreateCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/PrefetchCommand.cs
+++ b/src/worknet/Commands/PrefetchCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// PrefetchCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/PrefetchCommand.cs
+++ b/src/worknet/Commands/PrefetchCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// PrefetchCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// PrefetchCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Commands/ResetCommand.cs
+++ b/src/worknet/Commands/ResetCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// ResetCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// ResetCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Commands/ResetCommand.cs
+++ b/src/worknet/Commands/ResetCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// ResetCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// RunCommand.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// RunCommand.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// RunCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Commands/WorkNetLogPlugin.cs
+++ b/src/worknet/Commands/WorkNetLogPlugin.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WorkNetLogPlugin.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WorkNetLogPlugin.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Commands/WorkNetLogPlugin.cs
+++ b/src/worknet/Commands/WorkNetLogPlugin.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WorkNetLogPlugin.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/WorknetRpcServerPlugin.cs
+++ b/src/worknet/Commands/WorknetRpcServerPlugin.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WorknetRpcServerPlugin.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WorknetRpcServerPlugin.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Commands/WorknetRpcServerPlugin.cs
+++ b/src/worknet/Commands/WorknetRpcServerPlugin.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WorknetRpcServerPlugin.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/WorknetStorageProvider.cs
+++ b/src/worknet/Commands/WorknetStorageProvider.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WorknetStorageProvider.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Commands/WorknetStorageProvider.cs
+++ b/src/worknet/Commands/WorknetStorageProvider.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WorknetStorageProvider.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WorknetStorageProvider.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/DiagnosticObserver.cs
+++ b/src/worknet/DiagnosticObserver.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// DiagnosticObserver.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// DiagnosticObserver.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/DiagnosticObserver.cs
+++ b/src/worknet/DiagnosticObserver.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// DiagnosticObserver.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/KeyValuePairObserver.cs
+++ b/src/worknet/KeyValuePairObserver.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// KeyValuePairObserver.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/KeyValuePairObserver.cs
+++ b/src/worknet/KeyValuePairObserver.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// KeyValuePairObserver.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// KeyValuePairObserver.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Models/WorknetFile.cs
+++ b/src/worknet/Models/WorknetFile.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// WorknetFile.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Models/WorknetFile.cs
+++ b/src/worknet/Models/WorknetFile.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// WorknetFile.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// WorknetFile.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Program.InputFileConvention.cs
+++ b/src/worknet/Program.InputFileConvention.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Program.InputFileConvention.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Program.InputFileConvention.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Program.InputFileConvention.cs
+++ b/src/worknet/Program.InputFileConvention.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Program.InputFileConvention.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Program.cs
+++ b/src/worknet/Program.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Program.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Program.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without

--- a/src/worknet/Program.cs
+++ b/src/worknet/Program.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Program.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Utility.cs
+++ b/src/worknet/Utility.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// The neo is free software distributed under the MIT software license,
+// Utility.cs is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
 // project or http://www.opensource.org/licenses/mit-license.php
 // for more details.

--- a/src/worknet/Utility.cs
+++ b/src/worknet/Utility.cs
@@ -1,8 +1,9 @@
 // Copyright (C) 2015-2023 The Neo Project.
 //
-// Utility.cs is free software distributed under the MIT software license,
-// see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php
+// Utility.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
 // for more details.
 //
 // Redistribution and use in source and binary forms with or without


### PR DESCRIPTION
This update is to clean up the file header wording. Now uses filename instead of `neo`. 

Also changed each `*.cs` file to reflect this change.

**Change Log**
- Add filenames to the file header of each *.cs file
- Added missing file headers
- Added requirement for file header on build

```.editorconfig
# Require file header
dotnet_diagnostic.IDE0073.severity = error
```