### PR TITLE
Fixed backwards compatible `*.neo-express` file path

### DIFF
--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -24,7 +24,7 @@ namespace NeoExpress.Commands
             this.chainManagerFactory = chainManagerFactory;
         }
 
-        [Argument(0, Description = $"name of {EXPRESS_EXTENSION} file to create\nDefault location is home directory as:\nLinux: $HOME/.neo-express/{DEFAULT_EXPRESS_FILENAME}\nWindows: %UserProfile%\\.neo-express\\{DEFAULT_EXPRESS_FILENAME}")]
+        [Argument(0, Description = $"Name of {EXPRESS_EXTENSION} file to create\nDefault location is home directory as:\nLinux: $HOME/.neo-express/{DEFAULT_EXPRESS_FILENAME}\nWindows: %UserProfile%\\.neo-express\\{DEFAULT_EXPRESS_FILENAME}")]
         internal string Output { get; set; } = string.Empty;
 
         [Option(Description = "Number of consensus nodes to create (Default: 1)")]

--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -21,25 +21,24 @@ namespace NeoExpress
     {
         public static string ResolveFileName(this IFileSystem fileSystem, string fileName, string extension, Func<string> getDefaultFileName)
         {
-            var isDefaultPath = false;
             if (string.IsNullOrEmpty(fileName))
             {
                 fileName = getDefaultFileName();
-                isDefaultPath = true;
             }
 
-            if (!fileSystem.Path.IsPathFullyQualified(fileName))
+            if (fileSystem.Path.IsPathFullyQualified(fileName) == false)
             {
-                if (isDefaultPath)
+                var defaultFileName = fileSystem.Path.Combine(fileSystem.Directory.GetCurrentDirectory(), fileName);
+                if (fileSystem.File.Exists(defaultFileName) == false)
                 {
                     var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify);
-                    var folder = Path.Combine(homeDir, ".neo-express");
+                    var folder = fileSystem.Path.Combine(homeDir, ".neo-express");
                     if (fileSystem.Path.Exists(folder) == false)
                         fileSystem.Directory.CreateDirectory(folder);
                     fileName = fileSystem.Path.Combine(folder, fileName);
                 }
                 else
-                    fileName = fileSystem.Path.Combine(fileSystem.Directory.GetCurrentDirectory(), fileName);
+                    fileName = defaultFileName;
             }
 
             return extension.Equals(fileSystem.Path.GetExtension(fileName), StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Now will work with `*.neo-express` files in current directory. If they already exist.

**Change Log**
- Added `*.neo-express` file backwards compatible in current directory

Still creates by default in the currently directories
- `$HOME/.neo-express/`
- `%UserProfile%\.neo-express\`