### PR TITLE
Added default filenames and fixes

### DIFF
--- a/src/bctklib/Constants.cs
+++ b/src/bctklib/Constants.cs
@@ -15,6 +15,12 @@ namespace Neo.BlockchainToolkit
     {
         public const string EXPRESS_EXTENSION = ".neo-express";
         public const string DEFAULT_EXPRESS_FILENAME = "default" + EXPRESS_EXTENSION;
+
+        public const string EXPRESS_BATCH_EXTENSION = ".batch";
+        public const string DEFAULT_BATCH_FILENAME = "default" + EXPRESS_BATCH_EXTENSION;
+        public const string DEFAULT_INIT_BATCH_FILENAME = "init" + EXPRESS_BATCH_EXTENSION;
+        public const string DEFAULT_SETUP_BATCH_FILENAME = "setup" + EXPRESS_BATCH_EXTENSION;
+
         public const string WORKNET_EXTENSION = ".neo-worknet";
         public const string DEFAULT_WORKNET_FILENAME = "default" + WORKNET_EXTENSION;
 

--- a/src/bctklib/Constants.cs
+++ b/src/bctklib/Constants.cs
@@ -13,6 +13,8 @@ namespace Neo.BlockchainToolkit
 {
     public static class Constants
     {
+        public const string JSON_EXTENSION = ".json";
+
         public const string EXPRESS_EXTENSION = ".neo-express";
         public const string DEFAULT_EXPRESS_FILENAME = "default" + EXPRESS_EXTENSION;
 
@@ -20,6 +22,7 @@ namespace Neo.BlockchainToolkit
         public const string DEFAULT_BATCH_FILENAME = "default" + EXPRESS_BATCH_EXTENSION;
         public const string DEFAULT_INIT_BATCH_FILENAME = "init" + EXPRESS_BATCH_EXTENSION;
         public const string DEFAULT_SETUP_BATCH_FILENAME = "setup" + EXPRESS_BATCH_EXTENSION;
+        public const string DEAULT_POLICY_FILENAME = "default" + JSON_EXTENSION;
 
         public const string WORKNET_EXTENSION = ".neo-worknet";
         public const string DEFAULT_WORKNET_FILENAME = "default" + WORKNET_EXTENSION;

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -199,7 +199,7 @@ namespace NeoExpress.Commands
             }
 
             [Command("policy")]
-            [Subcommand(typeof(Block), typeof(Set), typeof(Unblock))]
+            [Subcommand(typeof(Block), typeof(Set), typeof(Sync), typeof(Unblock))]
             internal class Policy
             {
                 [Command("block")]

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -12,6 +12,7 @@
 using McMaster.Extensions.CommandLineUtils;
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
+using static Neo.BlockchainToolkit.Constants;
 
 namespace NeoExpress.Commands
 {
@@ -29,8 +30,7 @@ namespace NeoExpress.Commands
             this.txExecutorFactory = txExecutorFactory;
         }
 
-        [Argument(0, Description = "Path to batch file to run")]
-        [Required]
+        [Argument(0, Description = $"Path to {EXPRESS_BATCH_EXTENSION} file to run")]
         internal string BatchFile { get; init; } = string.Empty;
 
         [Option("-r|--reset[:<CHECKPOINT>]", CommandOptionType.SingleOrNoValue,
@@ -40,19 +40,21 @@ namespace NeoExpress.Commands
         [Option(Description = "Enable contract execution tracing")]
         internal bool Trace { get; init; } = false;
 
-        [Option(Description = "Path to neo-express data file")]
+        [Option(Description = $"Path to {EXPRESS_EXTENSION} data file")]
         internal string Input { get; init; } = string.Empty;
 
         internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
         {
             try
             {
-                if (!fileSystem.File.Exists(BatchFile))
-                    throw new Exception($"Batch file {BatchFile} couldn't be found");
-                var batchFileInfo = fileSystem.FileInfo.New(BatchFile);
+                var batchFilename = fileSystem.ResolveFileName(BatchFile, EXPRESS_BATCH_EXTENSION, () => DEFAULT_BATCH_FILENAME);
+
+                if (!fileSystem.File.Exists(batchFilename))
+                    throw new Exception($"Batch file \"{batchFilename}\" could not be found");
+                var batchFileInfo = fileSystem.FileInfo.New(batchFilename);
                 var batchDirInfo = batchFileInfo.Directory ?? throw new InvalidOperationException("batchFileInfo.Directory is null");
 
-                var commands = await fileSystem.File.ReadAllLinesAsync(BatchFile, token).ConfigureAwait(false);
+                var commands = await fileSystem.File.ReadAllLinesAsync(batchFilename, token).ConfigureAwait(false);
                 await ExecuteAsync(batchDirInfo, commands, console.Out).ConfigureAwait(false);
                 return 0;
             }

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -65,9 +65,11 @@ namespace NeoExpress.Commands
             }
         }
 
-        internal async Task ExecuteAsync(IDirectoryInfo root, ReadOnlyMemory<string> commands, System.IO.TextWriter writer)
+        internal async Task ExecuteAsync(IDirectoryInfo root, ReadOnlyMemory<string> commands, System.IO.TextWriter writer, ExpressChainManager? chainManager = null)
         {
-            var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+            if (chainManager == null)
+                chainManager = chainManagerFactory.LoadChain(Input).manager;
+
             if (chainManager.IsRunning())
             {
                 throw new Exception("Cannot run batch command while blockchain is running");
@@ -228,8 +230,7 @@ namespace NeoExpress.Commands
                         }
                     case CommandLineApplication<BatchFileCommands.Policy.Sync> cmd:
                         {
-                            var values = await txExec.TryLoadPolicyFromFileSystemAsync(
-                                root.Resolve(cmd.Model.Source))
+                            var values = await txExec.TryLoadPolicyFromFileSystemAsync(cmd.Model.Source)
                                 .ConfigureAwait(false);
                             if (values.TryPickT0(out var policyValues, out _))
                             {

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -114,7 +114,7 @@ namespace NeoExpress.Commands
                         {
                             _ = await chainManager.CreateCheckpointAsync(
                                 txExec.ExpressNode,
-                                root.Resolve(cmd.Model.Name),
+                                cmd.Model.Name,
                                 cmd.Model.Force,
                                 writer).ConfigureAwait(false);
                             break;

--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -26,6 +26,9 @@ namespace NeoExpress
                 fileName = getDefaultFileName();
             }
 
+            if (extension.Equals(fileSystem.Path.GetExtension(fileName), StringComparison.InvariantCultureIgnoreCase) == false)
+                fileName = $"{fileName}{extension}";
+
             if (fileSystem.Path.IsPathFullyQualified(fileName) == false)
             {
                 var defaultFileName = fileSystem.Path.Combine(fileSystem.Directory.GetCurrentDirectory(), fileName);
@@ -41,8 +44,7 @@ namespace NeoExpress
                     fileName = defaultFileName;
             }
 
-            return extension.Equals(fileSystem.Path.GetExtension(fileName), StringComparison.OrdinalIgnoreCase)
-                ? fileName : fileName + extension;
+            return fileName;
         }
 
         public static string GetTempFolder(this IFileSystem fileSystem)

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -24,6 +24,7 @@ using OneOf;
 using OneOf.Types;
 using System.IO.Abstractions;
 using System.Numerics;
+using static Neo.BlockchainToolkit.Constants;
 using static Neo.BlockchainToolkit.Utility;
 
 namespace NeoExpress
@@ -459,11 +460,12 @@ namespace NeoExpress
             return default(None);
         }
 
-        public async Task<OneOf<PolicyValues, None>> TryLoadPolicyFromFileSystemAsync(string path)
+        public async Task<OneOf<PolicyValues, None>> TryLoadPolicyFromFileSystemAsync(string filename)
         {
-            if (fileSystem.File.Exists(path))
+            filename = fileSystem.ResolveFileName(filename, JSON_EXTENSION, () => DEAULT_POLICY_FILENAME);
+            if (fileSystem.File.Exists(filename))
             {
-                using var stream = fileSystem.File.OpenRead(path);
+                using var stream = fileSystem.File.OpenRead(filename);
                 using var reader = new StreamReader(stream);
                 var text = await reader.ReadToEndAsync().ConfigureAwait(false);
                 var json = (Neo.Json.JObject)Neo.Json.JObject.Parse(text)!;


### PR DESCRIPTION
**Change Log**
- Updated batch command to use ResolveFileName for new default path
- Fixed bug with ResolveFileName; not adding extension
- Added default policy filename
- Removed policy sync on create command
- Fixed bug with sync not being used in batch files
- Changed sync resolve path for default policy and to resolve to global directory
- Added defaults for `setup.batch`  on create command

Directory `%userprofile%\.neo-express` defaults
![image](https://github.com/neo-project/neo-express/assets/8141309/9a8d9e44-7cfb-4aa3-bb58-61954a8c705f)

**Example content**
```
checkpoint create checkpoints/init-blockchain -f
policy sync mainnet-policy genesis
checkpoint create checkpoints/policy-sync-mainnet -f
```
