### PR TITLE
Set release version to 3.6

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.6-preview",
+  "version": "3.6",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/master-2.x$",


### PR DESCRIPTION
This repo's release branch was produced by [nbgv-cli](https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/nbgv-cli.md) in the past, which need an admin permission to maintain.
Since we are using custom release branch now, I suggest that we should keep some rules same with the nbgv tool behaviour:
1. In `release/v*` branch, the version number should be only number and not contain any preview suffix, example: `3.6`,`3.7`.
2. In `master` branch, the version number should be the next release number with preview suffix, I suggest it change to `3.7-preview` for the moment.

When we want to create a production v3.6 release, we can merge `master` into `release/v3.6` then run release action on `release/v3.6`.
When we want to create a preview v3.7 release, we run release action on `master`.