### PR TITLE
Modify the document link

### DIFF
--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -12,7 +12,7 @@ We would like to use GitHub for bug reports and feature requests only.
 Try our following resources:
 
 Discord - https://discord.io/neo
-official documentation - https://developers.neo.org/
+official documentation - https://docs.neo.org/
 
 If the above resources don't help feel encouraged to create an issue here
 on GitHub.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -95,7 +95,7 @@ These default templates are available after installing [Neo.SmartContract.Templa
 - neocontractoracle - A contract template using OracleRequest.
 - neocontractnep17 - NEP-17 contract template, including the Mint and Burn methods.
 
-More Neo.SmartContract.Template information can be found [here](https://developers.neo.org/docs/n3/develop/write/dotnet#neosmartcontracttemplate).
+More Neo.SmartContract.Template information can be found [here](https://docs.neo.org/docs/n3/develop/write/1_dotnet.html#neosmartcontracttemplate).
 
 ### Create a project using templates with Terminal
 
@@ -131,7 +131,7 @@ nccs
 
 Related contract files are outputted under `bin\sc` path in the contract project directory.
 
-More Neo.Compiler.CSharp information can be found [here](https://developers.neo.org/docs/n3/develop/write/dotnet#neocompilercsharp).
+More Neo.Compiler.CSharp information can be found [here](https://docs.neo.org/docs/n3/develop/write/1_dotnet.html#neocompilercsharp).
 
 ## Deploying and invoking smart contracts using NeoExpress
 


### PR DESCRIPTION
After some discussion, the documentation was changed back to docs.neo.org