### PR TITLE
Refactor RunCommand to avoid code duplication in test classes

### DIFF
--- a/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
@@ -353,7 +353,7 @@ public class NeoxpAdvancedIntegrationTests : IDisposable
 
     public void Dispose()
     {
-        //// Clean up any running processes
+        // Clean up any running processes
         _runCommand.Dispose();
 
         // Ensure neoxp is stopped

--- a/test/test.workflowvalidation/RunCommand.cs
+++ b/test/test.workflowvalidation/RunCommand.cs
@@ -1,0 +1,126 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// RunCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace test.workflowvalidation;
+public sealed class RunCommand(ITestOutputHelper output, string solutionPath, string tempDirectory) : IDisposable
+{
+    private const string COMMAND_DOTNET = "dotnet";
+    private const string COMMAND_NEOXP = "neoxp";
+    private readonly ITestOutputHelper _output = output;
+    private readonly string _tempDirectory = tempDirectory;
+    private readonly string _workingDirectory = Path.GetDirectoryName(solutionPath);
+    private readonly List<Process> _runningProcesses = [];
+
+    private async Task<(int ExitCode, string Output, string Error)> RunProcess(string fileName, string? command = null, TimeSpan? timeout = null, params string[] args)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName, nameof(fileName));
+        string directory = fileName.Equals(COMMAND_DOTNET) ? _workingDirectory : _tempDirectory;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = directory
+        };
+
+        if (!string.IsNullOrWhiteSpace(command))
+        {
+            psi.ArgumentList.Add(command);
+        }
+
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = psi };
+        _runningProcesses.Add(process);
+
+        process.Start();
+
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        if (timeout != null)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(timeout.Value);
+                await process.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill();
+                throw new TimeoutException($"Command '{fileName} {args}' timed out after {timeout}");
+            }
+        }
+        else
+        {
+            await process.WaitForExitAsync();
+        }
+
+        var output = await outputTask;
+        var error = await errorTask;
+
+        _output.WriteLine($"Exit Code: {process.ExitCode}");
+        if (!string.IsNullOrWhiteSpace(output))
+            _output.WriteLine($"Output: {output}");
+        if (!string.IsNullOrWhiteSpace(error))
+            _output.WriteLine($"Error: {error}");
+
+        return (process.ExitCode, output, error);
+    }
+
+    internal async Task<(int ExitCode, string Output, string Error)> RunDotNetCommand(string command, params string[] arguments)
+    {
+        var (exitCode, output, error) = await RunProcess(COMMAND_DOTNET, command, null, arguments);
+        return (exitCode, output, error);
+    }
+
+    internal async Task<(int ExitCode, string Output, string Error)> RunNeoxpCommand(params string[] arguments)
+    {
+        var (exitCode, output, error) = await RunProcess(COMMAND_NEOXP, null, null, arguments);
+        return (exitCode, output, error);
+    }
+
+    internal async Task<(int ExitCode, string Output, string Error)> RunNeoxpCommandWithTimeout(TimeSpan timeout, params string[] arguments)
+    {
+        var (exitCode, output, error) = await RunProcess(COMMAND_NEOXP, null, timeout, arguments);
+        return (exitCode, output, error);
+    }
+
+    public void Dispose()
+    {
+        // Clean up any running processes
+        foreach (var process in _runningProcesses)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                    process.WaitForExit(5000);
+                }
+                process.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Error disposing process: {ex.Message}");
+            }
+        }
+    }
+}

--- a/test/test.workflowvalidation/RunCommand.cs
+++ b/test/test.workflowvalidation/RunCommand.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using Xunit;
 
 namespace test.workflowvalidation;
+
 public sealed class RunCommand(ITestOutputHelper output, string solutionPath, string tempDirectory) : IDisposable
 {
     private const string COMMAND_DOTNET = "dotnet";


### PR DESCRIPTION
# Description
The `RunCommand` class is created to avoid repeating code across the three test classes (`NeoxpAdvancedIntegrationTests`, `NeoxpToolIntegrationTests`, and `WorkflowValidationTests`).
An Argument List is used for the case of executing neoxp. 
Additionally, some code readability improvements are made.

## Type of change

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules