### PR TITLE
Fix Test02_BuildValidation error when run in other languages

### DIFF
--- a/test/test.workflowvalidation/RunCommand.cs
+++ b/test/test.workflowvalidation/RunCommand.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using System.Diagnostics;
+using System.Globalization;
 using Xunit;
 
 namespace test.workflowvalidation;
@@ -21,6 +22,12 @@ public sealed class RunCommand(ITestOutputHelper output, string solutionPath, st
     private readonly string _tempDirectory = tempDirectory;
     private readonly string _workingDirectory = Path.GetDirectoryName(solutionPath);
     private readonly List<Process> _runningProcesses = [];
+    private string LANGUAGE = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+
+    public void SetLanguage(string language)
+    {
+        LANGUAGE = language;
+    }
 
     private async Task<(int ExitCode, string Output, string Error)> RunProcess(string fileName, string? command = null, TimeSpan? timeout = null, params string[] args)
     {
@@ -36,6 +43,8 @@ public sealed class RunCommand(ITestOutputHelper output, string solutionPath, st
             CreateNoWindow = true,
             WorkingDirectory = directory
         };
+
+        psi.Environment["DOTNET_CLI_UI_LANGUAGE"] = LANGUAGE;
 
         if (!string.IsNullOrWhiteSpace(command))
         {
@@ -81,6 +90,8 @@ public sealed class RunCommand(ITestOutputHelper output, string solutionPath, st
             _output.WriteLine($"Output: {output}");
         if (!string.IsNullOrWhiteSpace(error))
             _output.WriteLine($"Error: {error}");
+
+        psi.Environment["DOTNET_CLI_UI_LANGUAGE"] = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
 
         return (process.ExitCode, output, error);
     }

--- a/test/test.workflowvalidation/WorkflowValidationTests.cs
+++ b/test/test.workflowvalidation/WorkflowValidationTests.cs
@@ -9,9 +9,6 @@
 // modifications are permitted.
 
 using FluentAssertions;
-using System.Diagnostics;
-using System.IO.Abstractions.TestingHelpers;
-using System.Text.Json;
 using Xunit;
 
 namespace test.workflowvalidation;
@@ -186,7 +183,9 @@ public class WorkflowValidationTests : IDisposable
         restoreExitCode.Should().Be(0, "restore should succeed");
 
         // Equivalent to: dotnet build neo-express.sln --configuration Release --no-restore --verbosity normal
+        _runCommand.SetLanguage("en");
         var (buildExitCode, buildOutput, _) = await _runCommand.RunDotNetCommand("build", _solutionPath, "--configuration", _configuration, "--no-restore", "--verbosity", "normal");
+
         buildExitCode.Should().Be(0, "build should succeed");
         buildOutput.Should().Contain("Build succeeded", "build should complete successfully");
 


### PR DESCRIPTION
# Description
`Test02_BuildValidation` expects `"Build succeeded"` in the output which may not be present if the system is using a different language. Adding a way to set the run language explicitly.

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules