### PR TITLE
Snapshot. Add a copy of entries instead of the list itself

### DIFF
--- a/src/bctklib/persistence/StateServiceStore.MemoryCacheClient.cs
+++ b/src/bctklib/persistence/StateServiceStore.MemoryCacheClient.cs
@@ -124,16 +124,17 @@ namespace Neo.BlockchainToolkit.Persistence
 
                 public void Add(ReadOnlyMemory<byte> key, byte[] value)
                 {
-                    if (disposed)
-                        throw new ObjectDisposedException(nameof(MemoryCacheClient.Snapshot));
+                    ObjectDisposedException.ThrowIf(disposed, nameof(MemoryCacheClient.Snapshot));
                     entries.Add((key, value));
                 }
 
                 public void Commit()
                 {
-                    if (disposed)
-                        throw new ObjectDisposedException(nameof(MemoryCacheClient.Snapshot));
-                    if (!foundStateMap.TryAdd(hash, entries))
+                    ObjectDisposedException.ThrowIf(disposed, nameof(MemoryCacheClient.Snapshot));
+
+                    var entriescopy = entries.Count == 0 ? Array.Empty<(ReadOnlyMemory<byte>, byte[])>() : entries.ToArray();
+
+                    if (!foundStateMap.TryAdd(hash, entriescopy))
                     {
                         throw new Exception("Failed to add cached entries");
                     }


### PR DESCRIPTION
# Description
The problem is that Commit() stores the same instance of entries inside the concurrent dictionary.
When Dispose executes entries.Clear, it causes the list in the dictionary to be cleared.

Related to #486 

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules