### PR TITLE
Fix: Unknown storage item to null in GetProvenState

### DIFF
--- a/src/bctklib/persistence/RpcClientExtensions.cs
+++ b/src/bctklib/persistence/RpcClientExtensions.cs
@@ -51,7 +51,9 @@ namespace Neo.BlockchainToolkit.Persistence
 
                 return null;
             }
-            catch (RpcException ex) when (ex.HResult == -100 && ex.Message == "Unknown value")
+            catch (RpcException ex) when (ex.HResult == -100 ||
+                                ex.Message?.IndexOf("Unknown value", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                ex.Message?.IndexOf("Unknown storage item", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 // Prior to Neo 3.3.0, StateService GetProof method threw a custom exception 
                 // instead of KeyNotFoundException like GetState. This catch clause detected

--- a/src/bctklib/persistence/RpcClientExtensions.cs
+++ b/src/bctklib/persistence/RpcClientExtensions.cs
@@ -21,6 +21,8 @@ namespace Neo.BlockchainToolkit.Persistence
         //     var result = await rpcClient.RpcSendAsync("getblockhash", index).ConfigureAwait(false);
         //     return UInt256.Parse(result.AsString());
         // }
+        private const int CODE_UNKNOWN_VALUE = -100;
+        private const int CODE_UNKNOWN_VALUE_STORAGE_ITEM = -104;
 
         internal static byte[] GetProof(this RpcClient rpcClient, UInt256 rootHash, UInt160 scriptHash, ReadOnlySpan<byte> key)
         {
@@ -51,9 +53,7 @@ namespace Neo.BlockchainToolkit.Persistence
 
                 return null;
             }
-            catch (RpcException ex) when (ex.HResult == -100 ||
-                                ex.Message?.IndexOf("Unknown value", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                                ex.Message?.IndexOf("Unknown storage item", StringComparison.OrdinalIgnoreCase) >= 0)
+            catch (RpcException ex) when (ex.HResult == CODE_UNKNOWN_VALUE || ex.HResult == CODE_UNKNOWN_VALUE_STORAGE_ITEM)
             {
                 // Prior to Neo 3.3.0, StateService GetProof method threw a custom exception 
                 // instead of KeyNotFoundException like GetState. This catch clause detected


### PR DESCRIPTION
# Description
Some `StateService` versions return `RpcException` with the message “Unknown storage item” when a key is not present in the state tree. Our `GetProvenState` only handled `KeyNotFound` and an older “Unknown value” variant, letting “Unknown storage item” bubble up and crash ApplicationEngine.Execute() during OnPersist

To fix it the error handling has been extended.

Merge after #490 
Related to #487 

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
