### PR TITLE
Bug. Fix State in GetTransfers

### DIFF
--- a/src/bctklib/plugins/ToolkitRpcServer.cs
+++ b/src/bctklib/plugins/ToolkitRpcServer.cs
@@ -34,7 +34,7 @@ namespace Neo.BlockchainToolkit.Plugins
         const string NEP_11 = "NEP-11";
         const string NEP_17 = "NEP-17";
 
-        private static IReadOnlyList<string> Nep11PropertyNames { get; } = new[]
+        public static IReadOnlyList<string> Nep11PropertyNames { get; } = new[]
         {
             "name",
             "description",


### PR DESCRIPTION
# Description

- Fix GetTransfer accesing to State[0] twice, once for `from` address and other one for `to` address. It should access to `State[1]` for `to` address.
- Improve exception handling by using `ArgumentOutOfRangeException`
- Other improvements and styles

## Type of change

- [ ] Optimization (the change is only an optimization)
- [x] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
