### PR TITLE
Fix current directory

### DIFF
--- a/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
@@ -19,6 +19,7 @@ namespace test.workflowvalidation;
 /// Advanced integration tests for neoxp tool functionality including online tests
 /// These tests validate the more complex neoxp commands from test.yml
 /// </summary>
+//[Collection("PackExclusive")]
 public class NeoxpAdvancedIntegrationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;
@@ -37,7 +38,7 @@ public class NeoxpAdvancedIntegrationTests : IDisposable
         Directory.CreateDirectory(_tempDirectory);
 
         // Get the solution path relative to the test project
-        var currentDir = Directory.GetCurrentDirectory();
+        var currentDir = AppContext.BaseDirectory;
         var solutionDir = FindSolutionDirectory(currentDir);
         _solutionPath = Path.Combine(solutionDir, "neo-express.sln");
         _outDirectory = Path.Combine(_tempDirectory, "out");
@@ -283,7 +284,7 @@ public class NeoxpAdvancedIntegrationTests : IDisposable
         // Build and pack
         await _runCommand.RunDotNetCommand("restore", _solutionPath);
         await _runCommand.RunDotNetCommand("build", _solutionPath, "--configuration", _configuration, "--no-restore");
-        await _runCommand.RunDotNetCommand("pack", _solutionPath, "--configuration", _configuration, "--output", _outDirectory, "--no-build");
+        await _runCommand.RunDotNetCommand("pack", _solutionPath, "--configuration", _configuration, "--output", _outDirectory, "--no-build", "/m:1", "/nodeReuse:false");
 
         // Uninstall existing tool first (ignore errors if not installed)
         await _runCommand.RunDotNetCommand("tool", "uninstall", "--global", "neo.express");

--- a/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace test.workflowvalidation;
 /// Advanced integration tests for neoxp tool functionality including online tests
 /// These tests validate the more complex neoxp commands from test.yml
 /// </summary>
-//[Collection("PackExclusive")]
+[Collection("PackExclusive")]
 public class NeoxpAdvancedIntegrationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;

--- a/test/test.workflowvalidation/NeoxpToolIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpToolIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace test.workflowvalidation;
 /// Integration tests for neoxp tool functionality (equivalent to neoxp commands in test.yml)
 /// These tests validate the same neoxp tool commands as the CI/CD pipeline
 /// </summary>
-//[Collection("PackExclusive")]
+[Collection("PackExclusive")]
 public class NeoxpToolIntegrationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;

--- a/test/test.workflowvalidation/PackExclusiveCollection.cs
+++ b/test/test.workflowvalidation/PackExclusiveCollection.cs
@@ -1,0 +1,20 @@
+// Copyright (C) 2015-2025 The Neo Project.
+//
+// PackExclusiveCollection.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Xunit;
+
+namespace test.workflowvalidation;
+#if DISABLE_XUNIT_PARALLEL
+[CollectionDefinition("PackExclusive", DisableParallelization = true)]
+public sealed class PackExclusiveCollection { }
+#else
+[CollectionDefinition("PackExclusive", DisableParallelization = false)]
+public sealed class PackExclusiveCollection { }
+#endif

--- a/test/test.workflowvalidation/WorkflowValidationTests.cs
+++ b/test/test.workflowvalidation/WorkflowValidationTests.cs
@@ -17,6 +17,7 @@ namespace test.workflowvalidation;
 /// Integration tests that replicate the GitHub Actions workflow in test.yml
 /// These tests validate the same functionality as the CI/CD pipeline
 /// </summary>
+//[Collection("PackExclusive")]
 public class WorkflowValidationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;
@@ -32,7 +33,7 @@ public class WorkflowValidationTests : IDisposable
         Directory.CreateDirectory(_tempDirectory);
 
         // Get the solution path relative to the test project
-        var currentDir = Directory.GetCurrentDirectory();
+        var currentDir = AppContext.BaseDirectory;
         var solutionDir = FindSolutionDirectory(currentDir);
         _solutionPath = Path.Combine(solutionDir, "neo-express.sln");
         _runCommand = new RunCommand(_output, _solutionPath, _tempDirectory);
@@ -359,7 +360,7 @@ public class WorkflowValidationTests : IDisposable
         await _runCommand.RunDotNetCommand("build", _solutionPath, "--configuration", _configuration, "--no-restore");
 
         // Equivalent to: dotnet pack neo-express.sln --configuration Release --output ./out --no-build --verbosity normal
-        var (packExitCode, _, _) = await _runCommand.RunDotNetCommand("pack", _solutionPath, "--configuration", _configuration, "--output", outDir, "--no-build", "--verbosity", "normal");
+        var (packExitCode, _, _) = await _runCommand.RunDotNetCommand("pack", _solutionPath, "--configuration", _configuration, "--output", outDir, "--no-build", "--verbosity", "normal", "/m:1", "/nodeReuse:false");
         packExitCode.Should().Be(0, "pack should succeed");
 
         // Verify packages were created

--- a/test/test.workflowvalidation/WorkflowValidationTests.cs
+++ b/test/test.workflowvalidation/WorkflowValidationTests.cs
@@ -17,7 +17,7 @@ namespace test.workflowvalidation;
 /// Integration tests that replicate the GitHub Actions workflow in test.yml
 /// These tests validate the same functionality as the CI/CD pipeline
 /// </summary>
-//[Collection("PackExclusive")]
+[Collection("PackExclusive")]
 public class WorkflowValidationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
# Description

- Fix test initialization to avoid using `Directory.GetCurrentDirectory`, since it’s a global value that can be modified. This occasionally changed the working directory and prevented the solution from being found.

- Enable/Disable certain tests to run no-parallel using `DISABLE_XUNIT_PARALLEL` const especially those that perform `pack` to mitigate race conditions that could cause intermittent failures.

- Fix two call to `RunNeoxpCommand`

## Type of change

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
