### PR TITLE
Add net9 and remove NetStandard&NetFramework

### DIFF
--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -5,7 +5,9 @@
         <PackageId>Neo.BuildTasks</PackageId>
         <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
 
-        <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <PackBuildOutput>false</PackBuildOutput>
+        <BuildOutputTargetFolder></BuildOutputTargetFolder>
         <IsPackable>true</IsPackable>
 
         <DevelopmentDependency>true</DevelopmentDependency>
@@ -18,22 +20,53 @@
         <InternalsVisibleTo Include="test-build-tasks" />
     </ItemGroup>
 
+    <!-- Pack targets if exists -->
     <ItemGroup>
         <Content Include="build\*" Pack="true" PackagePath="build\" Condition="Exists('build')" />
         <Content Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting\" Condition="Exists('buildMultiTargeting')" />
     </ItemGroup>
 
-    <Target Name="PackTaskBinaries"
-            DependsOnTargets="Build"
+    <ItemGroup>
+        <None Remove="$(MSBuildProjectDirectory)\bin\**" />
+        <Content Remove="$(MSBuildProjectDirectory)\bin\**" />
+        <TfmSpecificPackageFile Remove="$(MSBuildProjectDirectory)\bin\**" />
+    </ItemGroup>
+
+    <Target Name="EnsureTaskBinariesForPack"
             BeforeTargets="GetPackageContents">
-        <!-- $(TargetDir) == bin/$(Configuration)/$(TargetFramework)/ -->
         <ItemGroup>
-            <TfmSpecificPackageFile Include="$(TargetDir)$(AssemblyName).dll">
-                <PackagePath>tasks/$(TargetFramework)/</PackagePath>
+            <_Tfms Include="net9.0" />
+            <_Tfms Include="netstandard2.0" />
+        </ItemGroup>
+
+        <MSBuild Projects="$(MSBuildProjectFullPath)"
+                 Targets="Restore;Build"
+                 Properties="TargetFramework=%(_Tfms.Identity);Configuration=$(Configuration)"
+                 Condition="!Exists('$(MSBuildProjectDirectory)\bin\$(Configuration)\%(_Tfms.Identity)\$(AssemblyName).dll')"
+                 ContinueOnError="WarnAndContinue" />
+
+        <ItemGroup>
+            <_Candidate Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\net9.0\$(AssemblyName).dll">
+                <Tfm>net9.0</Tfm>
+            </_Candidate>
+            <_Candidate Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\netstandard2.0\$(AssemblyName).dll">
+                <Tfm>netstandard2.0</Tfm>
+            </_Candidate>
+        </ItemGroup>
+
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="%(_Candidate.Identity)"
+                                    Condition="Exists('%(_Candidate.Identity)')">
+                <PackagePath>tasks/%(_Candidate.Tfm)/</PackagePath>
             </TfmSpecificPackageFile>
         </ItemGroup>
+
         <Message Importance="High"
-                 Text="Empaquetando $(TargetFramework): $(TargetDir)$(AssemblyName).dll → tasks/$(TargetFramework)/" />
+                 Text="Pack: include %(_Candidate.Tfm) → %(_Candidate.Identity)"
+                 Condition="Exists('%(_Candidate.Identity)')" />
+        <Message Importance="High"
+                 Text="Pack: not exists %(_Tfms.Identity); trying to compile and continue without it."
+                 Condition="!Exists('$(MSBuildProjectDirectory)\bin\$(Configuration)\%(_Tfms.Identity)\$(AssemblyName).dll')" />
     </Target>
 
     <ItemGroup>
@@ -44,5 +77,8 @@
         </PackageReference>
         <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
     </ItemGroup>
-
+    <PropertyGroup>
+        <IncludeSymbols>false</IncludeSymbols>
+        <SymbolPackageFormat></SymbolPackageFormat>
+    </PropertyGroup>
 </Project>

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -10,7 +10,7 @@
         <Nullable>enable</Nullable>
         <PackageId>Neo.BuildTasks</PackageId>
         <ImplicitUsings>disable</ImplicitUsings>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -1,16 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <AssemblyName>neo-build-tasks</AssemblyName>
-        <!-- Change the default location where NuGet will put the build output -->
+        <PackageId>Neo.BuildTasks</PackageId>
+        <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
+
         <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+        <IsPackable>true</IsPackable>
+
         <DevelopmentDependency>true</DevelopmentDependency>
-        <!-- Suppresses the warnings about the package not having assemblies in lib/*/.dll.-->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <Nullable>enable</Nullable>
-        <PackageId>Neo.BuildTasks</PackageId>
         <ImplicitUsings>disable</ImplicitUsings>
-        <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,24 +19,30 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="build\*" PackagePath="build\" />
-        <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\" />
+        <Content Include="build\*" Pack="true" PackagePath="build\" Condition="Exists('build')" />
+        <Content Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting\" Condition="Exists('buildMultiTargeting')" />
     </ItemGroup>
-    <ItemGroup>
-        <None Include="$(OutputPath)$(AssemblyName).dll"
-              Pack="true"
-              PackagePath="tasks/$(TargetFramework)/" />
-    </ItemGroup>
+
+    <Target Name="PackTaskBinaries"
+            DependsOnTargets="Build"
+            BeforeTargets="GetPackageContents">
+        <!-- $(TargetDir) == bin/$(Configuration)/$(TargetFramework)/ -->
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(TargetDir)$(AssemblyName).dll">
+                <PackagePath>tasks/$(TargetFramework)/</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+        <Message Importance="High"
+                 Text="Empaquetando $(TargetFramework): $(TargetDir)$(AssemblyName).dll → tasks/$(TargetFramework)/" />
+    </Target>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="All" />
         <PackageReference Include="PolySharp" Version="1.15.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
+        <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
     </ItemGroup>
 
 </Project>

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -10,8 +10,8 @@
         <Nullable>enable</Nullable>
         <PackageId>Neo.BuildTasks</PackageId>
         <ImplicitUsings>disable</ImplicitUsings>
-        <TargetFramework></TargetFramework>
-        <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+        <TargetFramework>net9.0</TargetFramework>
+        <!-- <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>-->
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -11,7 +11,6 @@
         <PackageId>Neo.BuildTasks</PackageId>
         <ImplicitUsings>disable</ImplicitUsings>
         <TargetFramework>net9.0</TargetFramework>
-        <!-- <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>-->
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -21,7 +21,11 @@
         <Content Include="build\*" PackagePath="build\" />
         <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\" />
     </ItemGroup>
-
+    <ItemGroup>
+        <None Include="$(OutputPath)$(AssemblyName).dll"
+              Pack="true"
+              PackagePath="tasks/$(TargetFramework)/" />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="All" />
         <PackageReference Include="PolySharp" Version="1.15.0">

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="NeoBuildTasksFolder;NeoBuildTasksAssembly">
 
   <PropertyGroup>
-    <NeoBuildTasksFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">netstandard2.0</NeoBuildTasksFolder>
-    <NeoBuildTasksFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">net472</NeoBuildTasksFolder>
+    <NeoBuildTasksFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">net9.0</NeoBuildTasksFolder>
+    <NeoBuildTasksFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">netstandard2.0</NeoBuildTasksFolder>
     <_NeoBuildTasksAssemblyPath>$([MSBuild]::ValueOrDefault('$(NeoBuildTasksAssembly)', '$(MSBuildThisFileDirectory)..\tasks\$(NeoBuildTasksFolder)\neo-build-tasks.dll'))</_NeoBuildTasksAssemblyPath>
     <CleanDependsOn>$(CleanDependsOn);CleanNeoCsc;CleanNeoExpressBatch</CleanDependsOn>
   </PropertyGroup>

--- a/src/collector/Utility/ZipStorer.cs
+++ b/src/collector/Utility/ZipStorer.cs
@@ -1109,7 +1109,7 @@ namespace System.IO.Compression
                         this.ExistingFiles = entries;
                         this.CentralDirImage = new byte[centralSize];
                         this.ZipFileStream.Seek(centralDirOffset, SeekOrigin.Begin);
-                        var resultRead = this.ZipFileStream.Read(this.CentralDirImage, 0, (int)centralSize);
+                        _ = this.ZipFileStream.Read(this.CentralDirImage, 0, (int)centralSize);
 
                         // Leave the pointer at the begining of central dir, to append new files
                         this.ZipFileStream.Seek(centralDirOffset, SeekOrigin.Begin);

--- a/src/collector/Utility/ZipStorer.cs
+++ b/src/collector/Utility/ZipStorer.cs
@@ -648,7 +648,7 @@ namespace System.IO.Compression
             byte[] buffer = new byte[2];
 
             this.ZipFileStream.Seek(_headerOffset + 26, SeekOrigin.Begin);
-            var resultReadFile = this.ZipFileStream.Read(buffer, 0, 2);
+            _ = this.ZipFileStream.Read(buffer, 0, 2);
             ushort filenameSize = BitConverter.ToUInt16(buffer, 0);
             _ = this.ZipFileStream.Read(buffer, 0, 2);
             ushort extraSize = BitConverter.ToUInt16(buffer, 0);

--- a/src/collector/Utility/ZipStorer.cs
+++ b/src/collector/Utility/ZipStorer.cs
@@ -519,7 +519,7 @@ namespace System.IO.Compression
 #if NOASYNC
                 this.ZipFileStream.Read(signature, 0, 4);
 #else
-            await this.ZipFileStream.ReadAsync(signature, 0, 4);
+            var resultReadSignature = await this.ZipFileStream.ReadAsync(signature, 0, 4);
 #endif
 
             if (BitConverter.ToUInt32(signature, 0) != 0x04034b50)
@@ -648,9 +648,9 @@ namespace System.IO.Compression
             byte[] buffer = new byte[2];
 
             this.ZipFileStream.Seek(_headerOffset + 26, SeekOrigin.Begin);
-            this.ZipFileStream.Read(buffer, 0, 2);
+            var resultReadFile = this.ZipFileStream.Read(buffer, 0, 2);
             ushort filenameSize = BitConverter.ToUInt16(buffer, 0);
-            this.ZipFileStream.Read(buffer, 0, 2);
+            var result = this.ZipFileStream.Read(buffer, 0, 2);
             ushort extraSize = BitConverter.ToUInt16(buffer, 0);
 
             return (uint)(30 + filenameSize + extraSize + _headerOffset);
@@ -1109,7 +1109,7 @@ namespace System.IO.Compression
                         this.ExistingFiles = entries;
                         this.CentralDirImage = new byte[centralSize];
                         this.ZipFileStream.Seek(centralDirOffset, SeekOrigin.Begin);
-                        this.ZipFileStream.Read(this.CentralDirImage, 0, (int)centralSize);
+                        var resultRead = this.ZipFileStream.Read(this.CentralDirImage, 0, (int)centralSize);
 
                         // Leave the pointer at the begining of central dir, to append new files
                         this.ZipFileStream.Seek(centralDirOffset, SeekOrigin.Begin);

--- a/src/collector/Utility/ZipStorer.cs
+++ b/src/collector/Utility/ZipStorer.cs
@@ -519,7 +519,7 @@ namespace System.IO.Compression
 #if NOASYNC
                 this.ZipFileStream.Read(signature, 0, 4);
 #else
-            var resultReadSignature = await this.ZipFileStream.ReadAsync(signature, 0, 4);
+            _ = await this.ZipFileStream.ReadAsync(signature, 0, 4);
 #endif
 
             if (BitConverter.ToUInt32(signature, 0) != 0x04034b50)

--- a/src/collector/Utility/ZipStorer.cs
+++ b/src/collector/Utility/ZipStorer.cs
@@ -650,7 +650,7 @@ namespace System.IO.Compression
             this.ZipFileStream.Seek(_headerOffset + 26, SeekOrigin.Begin);
             var resultReadFile = this.ZipFileStream.Read(buffer, 0, 2);
             ushort filenameSize = BitConverter.ToUInt16(buffer, 0);
-            var result = this.ZipFileStream.Read(buffer, 0, 2);
+            _ = this.ZipFileStream.Read(buffer, 0, 2);
             ushort extraSize = BitConverter.ToUInt16(buffer, 0);
 
             return (uint)(30 + filenameSize + extraSize + _headerOffset);

--- a/src/collector/collector.csproj
+++ b/src/collector/collector.csproj
@@ -8,7 +8,6 @@
         <RootNamespace>Neo.Collector</RootNamespace>
         <ImplicitUsings>disable</ImplicitUsings>
         <TargetFramework>net9.0</TargetFramework>
-        <!--<TargetFrameworks>netstandard2.0;net472</TargetFrameworks>-->
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <DebugType>portable</DebugType>
     </PropertyGroup>

--- a/src/collector/collector.csproj
+++ b/src/collector/collector.csproj
@@ -7,8 +7,8 @@
         <PackageId>Neo.Collector</PackageId>
         <RootNamespace>Neo.Collector</RootNamespace>
         <ImplicitUsings>disable</ImplicitUsings>
-        <TargetFramework></TargetFramework>
-        <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+        <TargetFramework>net9.0</TargetFramework>
+        <!--<TargetFrameworks>netstandard2.0;net472</TargetFrameworks>-->
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <DebugType>portable</DebugType>
     </PropertyGroup>


### PR DESCRIPTION
# Description

- Add `.Net9` in `build-tasks` and `collector` projects and remove `.netStandard` & `.NETFramework`
- Get result to avoid `CA2022` warning in `Test01_FormatValidation`

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
