### PR TITLE
Fix neo3-visual-tracker release download

### DIFF
--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -327,7 +327,7 @@
   "scripts": {
     "vscode:prepublish": "npm run compile-prod && npm run bundle-nxp",
     "bundle-nxp": "npm run bundle-nxp-download && npm run bundle-nxp-extract",
-    "bundle-nxp-download": "shx rm -rf deps/nxp && shx mkdir -p deps/nxp && nwget \"https://github.com/neo-project/neo-express/releases/download/3.7.6/Neo.Express.3.7.6.nupkg\" -O deps/nxp/nxp.nupkg",
+    "bundle-nxp-download": "shx rm -rf deps/nxp && shx mkdir -p deps/nxp && curl -fL \"https://www.nuget.org/api/v2/package/Neo.Express/%npm_package_version%\" -o deps/nxp/nxp.nupkg",
     "bundle-nxp-extract": "cd deps/nxp && extract-zip nxp.nupkg",
     "compile": "npm run compile-ext && npm run compile-panel",
     "compile-ext": "webpack --config src/extension/webpack.config.js --mode development",


### PR DESCRIPTION
# Description
`bundle-nxp-download` is using a broken URI and version 3.7.6 instead of 3.8.2. It is adjusted so that the URI depends on the version and it downloads from NuGet instead of Git.

## Type of change

- [x] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules