### PR TITLE
Fix: delete [MessagePackObject]

### DIFF
--- a/src/bctklib/trace-models/TraceRecord.cs
+++ b/src/bctklib/trace-models/TraceRecord.cs
@@ -13,9 +13,9 @@ using Neo.VM;
 using System.Buffers;
 using ExecutionContext = Neo.VM.ExecutionContext;
 
+#pragma warning disable MsgPack003 // TraceRecord use manual formatter (TraceRecordFormatter)
 namespace Neo.BlockchainToolkit.TraceDebug
 {
-    [MessagePackObject]
     public partial class TraceRecord : ITraceDebugRecord
     {
         public const int RecordKey = 0;
@@ -66,3 +66,4 @@ namespace Neo.BlockchainToolkit.TraceDebug
         }
     }
 }
+#pragma warning restore MsgPack003


### PR DESCRIPTION
# Description
Remove MessagePackObject from TraceRecord due to two formatters are now being used for the same type.

## Type of change

- [ ] Optimization (the change is only an optimization)
- [ ] Style (the change is only a code style for better maintenance or standard purpose)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules