### PR TITLE
Fix: Scale ExecutionFeeFactor for Policy when Faun is active (#526)

### DIFF
--- a/src/neoxp/Extensions/PolicyExecutionFeeExtensions.cs
+++ b/src/neoxp/Extensions/PolicyExecutionFeeExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// PolicyExecutionFeeExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract;
+using NeoExpress.Models;
+
+namespace NeoExpress
+{
+    internal static class PolicyExecutionFeeExtensions
+    {
+        internal static ulong GetScaledExecFeeFactorArgument(uint logicalFactor, bool isFaunEnabled)
+        {
+            return isFaunEnabled
+                ? (ulong)logicalFactor * ApplicationEngine.FeeFactor
+                : (ulong)logicalFactor;
+        }
+
+        internal static ulong GetScaledExecFeeFactorArgument(this PolicyValues policy, bool isFaunEnabled) =>
+            GetScaledExecFeeFactorArgument(policy.ExecutionFeeFactor, isFaunEnabled);
+    }
+}

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -644,12 +644,21 @@ namespace NeoExpress
             return new None();
         }
 
+        private async Task<bool> IsFaunHardforkEnabledForNextTxAsync()
+        {
+            var latest = await expressNode.GetLatestBlockAsync().ConfigureAwait(false);
+            var nextBlockIndex = latest.Index + 1;
+            return expressNode.ProtocolSettings.IsHardforkEnabled(Hardfork.HF_Faun, nextBlockIndex);
+        }
+
         public async Task SetPolicyAsync(PolicyValues policyValues, string account, string password)
         {
             if (!chainManager.TryGetSigningAccount(account, password, out var wallet, out var accountHash))
             {
                 throw new Exception($"{account} account not found.");
             }
+
+            var faunExecFeeScale = await IsFaunHardforkEnabledForNextTxAsync().ConfigureAwait(false);
 
             using var builder = new ScriptBuilder();
             builder.EmitDynamicCall(NativeContract.NEO.Hash, "setGasPerBlock", policyValues.GasPerBlock.Value);
@@ -658,7 +667,7 @@ namespace NeoExpress
             builder.EmitDynamicCall(NativeContract.Oracle.Hash, "setPrice", policyValues.OracleRequestFee.Value);
             builder.EmitDynamicCall(NativeContract.Policy.Hash, "setFeePerByte", policyValues.NetworkFeePerByte.Value);
             builder.EmitDynamicCall(NativeContract.Policy.Hash, "setStoragePrice", policyValues.StorageFeeFactor);
-            builder.EmitDynamicCall(NativeContract.Policy.Hash, "setExecFeeFactor", policyValues.ExecutionFeeFactor);
+            builder.EmitDynamicCall(NativeContract.Policy.Hash, "setExecFeeFactor", policyValues.GetScaledExecFeeFactorArgument(faunExecFeeScale));
 
             var txHash = await expressNode.ExecuteAsync(wallet, accountHash, WitnessScope.CalledByEntry, builder.ToArray()).ConfigureAwait(false);
             await writer.WriteTxHashAsync(txHash, $"Policies Set", json).ConfigureAwait(false);
@@ -701,7 +710,10 @@ namespace NeoExpress
                     throw new InvalidOperationException($"{policy} policy requires a whole number value");
                 if (decimalValue.Value > uint.MaxValue)
                     throw new InvalidOperationException($"{policy} policy requires a value less than {uint.MaxValue}");
-                builder.EmitDynamicCall(hash, operation, (uint)decimalValue.Value);
+                var whole = (uint)decimalValue.Value;
+                var faunExecFeeScale = policy == PolicySettings.ExecutionFeeFactor
+                    && await IsFaunHardforkEnabledForNextTxAsync().ConfigureAwait(false);
+                builder.EmitDynamicCall(hash, operation, PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(whole, faunExecFeeScale));
             }
 
             var txHash = await expressNode.ExecuteAsync(wallet, accountHash, WitnessScope.CalledByEntry, builder.ToArray()).ConfigureAwait(false);

--- a/test/test.workflowvalidation/PolicyExecutionFeeScalingTests.cs
+++ b/test/test.workflowvalidation/PolicyExecutionFeeScalingTests.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// PolicyExecutionFeeScalingTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using NeoExpress;
+using NeoExpress.Models;
+using System.Collections.Immutable;
+using System.Numerics;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class PolicyExecutionFeeScalingTests
+{
+    [Theory]
+    [InlineData(1u, false, 1u)]
+    [InlineData(30u, false, 30u)]
+    [InlineData(100u, false, 100u)]
+    [InlineData(1u, true, 10_000u)]
+    [InlineData(30u, true, 300_000u)]
+    [InlineData(100u, true, 1_000_000u)]
+    public void GetScaledExecFeeFactorArgument_uint_matches_expected_storage_units(uint logical, bool faun, ulong expected)
+    {
+        PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(logical, faun).Should().Be(expected);
+        logical.Should().BeLessOrEqualTo(100u, "Neo Policy MaxExecFeeFactor is 100 for the logical factor");
+        if (faun)
+            expected.Should().Be((ulong)logical * ApplicationEngine.FeeFactor);
+    }
+
+    [Fact]
+    public void GetScaledExecFeeFactorArgument_on_PolicyValues_delegates_to_uint_overload()
+    {
+        var policy = CreatePolicyValues(executionFeeFactor: 42);
+        PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(policy, isFaunEnabled: false).Should().Be(42u);
+        PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(policy, isFaunEnabled: true)
+            .Should().Be(42u * ApplicationEngine.FeeFactor);
+    }
+
+    /// <summary>
+    /// Documents the same rule as <c>TransactionExecutor.IsFaunHardforkEnabledForNextTxAsync</c>:
+    /// use the block after the chain tip when deciding whether the upcoming tx runs under Faun.
+    /// </summary>
+    [Theory]
+    [InlineData(0u, 0u, true)]
+    [InlineData(0u, 1u, true)]
+    [InlineData(100u, 99u, false)]
+    [InlineData(100u, 100u, true)]
+    [InlineData(100u, 101u, true)]
+    public void IsHardforkEnabled_Faun_uses_block_index_like_next_tx_check(uint faunActivationHeight, uint indexToCheck, bool expectedEnabled)
+    {
+        var settings = ProtocolSettingsWithFaunAt(faunActivationHeight);
+        settings.IsHardforkEnabled(Hardfork.HF_Faun, indexToCheck).Should().Be(expectedEnabled);
+    }
+
+    [Fact]
+    public void Next_block_after_tip_uses_tip_index_plus_one()
+    {
+        const uint tipIndex = 99;
+        var settings = ProtocolSettingsWithFaunAt(100);
+        settings.IsHardforkEnabled(Hardfork.HF_Faun, tipIndex).Should().BeFalse();
+        settings.IsHardforkEnabled(Hardfork.HF_Faun, tipIndex + 1).Should().BeTrue();
+    }
+
+    static ProtocolSettings ProtocolSettingsWithFaunAt(uint faunHeight)
+    {
+        var baseForks = ProtocolSettings.Default.Hardforks;
+        var builder = ImmutableDictionary.CreateBuilder<Hardfork, uint>();
+        foreach (var pair in baseForks)
+            builder.Add(pair.Key, pair.Key == Hardfork.HF_Faun ? faunHeight : pair.Value);
+        if (!builder.ContainsKey(Hardfork.HF_Faun))
+            builder.Add(Hardfork.HF_Faun, faunHeight);
+
+        return ProtocolSettings.Default with { Hardforks = builder.ToImmutable() };
+    }
+
+    static PolicyValues CreatePolicyValues(uint executionFeeFactor, uint storageFeeFactor = 1)
+    {
+        var zero = new BigDecimal(BigInteger.Zero, NativeContract.GAS.Decimals);
+        return new PolicyValues
+        {
+            GasPerBlock = zero,
+            MinimumDeploymentFee = zero,
+            CandidateRegistrationFee = zero,
+            OracleRequestFee = zero,
+            NetworkFeePerByte = zero,
+            StorageFeeFactor = storageFeeFactor,
+            ExecutionFeeFactor = executionFeeFactor,
+        };
+    }
+}


### PR DESCRIPTION
## Motivation
After the Faun hardfork, the logical policy execution fee factor must be converted to the same storage units the VM uses (`ApplicationEngine.FeeFactor`). Without this scaling, policy updates from neo-express are interpreted as near-zero values by the native contract, causing them to either be persisted as 0 or fail validation rules.
## Changes
- **`PolicyExecutionFeeExtensions`:** Added a new internal helper to centralize the scaling logic between logical units (1–100) and protocol units (pico-units).
- **`IsFaunHardforkEnabledForNextTxAsync()`:** Implemented a check that uses the block index after the current tip (`latest.Index + 1`). This ensures scaling is applied according to the block where the transaction will be persisted.
- **`TransactionExecutor.cs`:** Integrated the scaling logic into both `SetPolicyAsync` flows (batch and single-policy paths).
- **`PolicyExecutionFeeScalingTests`:** Added a test suite covering:
  - Scaling calculations for pre-Faun and post-Faun scenarios
  - Hardfork activation height logic
  - Edge cases for block index transitions
## Testing
The fix was validated through unit tests and manual CLI simulation.
**Unit tests**
```bash
dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter "FullyQualifiedName~PolicyExecutionFeeScalingTests"
```
## Local Testing
- Created a custom network and started a node.
- Ran `neoxp policy set ExecutionFeeFactor 15 genesis`.
- Confirmed with `neoxp policy get` that the value persisted as **15**(previously it could remain at 30 or drop to 0).
## Checklist
- [x] Tests added for the new scaling behavior
- [x] Verified locally against the scenario described in issue #526