### PR TITLE
Keep WorkNet RPC bound to loopback by default

### DIFF
--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -136,7 +136,7 @@ partial class RunCommand
             var settings = new Dictionary<string, string>()
                 {
                     { "PluginConfiguration:Network", $"{worknet.BranchInfo.Network}" },
-                    { "PluginConfiguration:BindAddress", $"{IPAddress.Any}" },
+                    { "PluginConfiguration:BindAddress", $"{IPAddress.Loopback}" },
                     { "PluginConfiguration:Port", $"{30332}" },
                     { "PluginConfiguration:SessionEnabled", $"{true}"}
                 };


### PR DESCRIPTION
## Summary
- change WorkNet RPC bind address from all interfaces to loopback
- keep the existing port and session configuration unchanged

## Verification
- dotnet build src/worknet/neoworknet.csproj --configuration Release

## Notes
The build succeeds with existing nullable warnings in bctklib/worknet; those are addressed separately in the warning-cleanup PR.