### PR TITLE
Fix notification pagination off-by-one

### DIFF
--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -318,7 +318,7 @@ namespace NeoExpress.Node
             var truncated = false;
             foreach (var (blockIndex, _, notification) in notifications)
             {
-                if (count++ > take)
+                if (count++ >= take)
                 {
                     truncated = true;
                     break;

--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -301,10 +301,7 @@ namespace NeoExpress.Node
         {
             var contracts = ((JArray)@params[0]!).Select(j => UInt160.Parse(j!.AsString())).ToHashSet();
             var events = ((JArray)@params[1]!).Select(j => j!.AsString()).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            int skip = @params.Count >= 3 ? (int)@params[2]!.AsNumber() : 0;
-            int take = @params.Count >= 4 ? (int)@params[3]!.AsNumber() : MAX_NOTIFICATIONS;
-            if (take > MAX_NOTIFICATIONS)
-                take = MAX_NOTIFICATIONS;
+            var (skip, take) = GetNotificationPaging(@params);
 
             var notifications = persistencePlugin.Value
                 .GetNotifications(
@@ -350,6 +347,18 @@ namespace NeoExpress.Node
                 ["truncated"] = truncated,
                 ["notifications"] = jsonNotifications,
             };
+        }
+
+        internal static (int skip, int take) GetNotificationPaging(JArray @params)
+        {
+            int skip = @params.Count >= 3 ? (int)@params[2]!.AsNumber() : 0;
+            int take = @params.Count >= 4 ? (int)@params[3]!.AsNumber() : MAX_NOTIFICATIONS;
+            if (skip < 0 || take < 0)
+                throw new RpcException(-32602, "Invalid params");
+            if (take > MAX_NOTIFICATIONS)
+                take = MAX_NOTIFICATIONS;
+
+            return (skip, take);
         }
 
         // Neo-express uses a custom implementation of GetApplicationLog due to

--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -313,10 +313,19 @@ namespace NeoExpress.Node
                     events.Count > 0 ? events : null)
                 .Skip(skip);
 
+            return CreateNotificationsResponse(
+                notifications.Select(n => (n.blockIndex, n.notification)),
+                take);
+        }
+
+        internal static JObject CreateNotificationsResponse(
+            IEnumerable<(uint blockIndex, NotificationRecord notification)> notifications,
+            int take)
+        {
             var count = 0;
             var jsonNotifications = new JArray();
             var truncated = false;
-            foreach (var (blockIndex, _, notification) in notifications)
+            foreach (var (blockIndex, notification) in notifications)
             {
                 if (count++ >= take)
                 {

--- a/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
+++ b/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
@@ -17,6 +17,7 @@ using NeoExpress.Node;
 using Xunit;
 
 using NeoArray = Neo.VM.Types.Array;
+using RpcException = Neo.Network.RPC.RpcException;
 
 namespace test.workflowvalidation;
 
@@ -40,6 +41,38 @@ public class ExpressRpcServerPluginTests
 
         response["truncated"]!.AsBoolean().Should().Be(expectedTruncated);
         ((JArray)response["notifications"]!).Count.Should().Be(expectedCount);
+    }
+
+    [Fact]
+    public void GetNotificationPaging_UsesDefaultsAndCapsTake()
+    {
+        ExpressRpcServerPlugin.GetNotificationPaging(CreateNotificationParams())
+            .Should().Be((0, 100));
+
+        ExpressRpcServerPlugin.GetNotificationPaging(CreateNotificationParams(skip: 7, take: 101))
+            .Should().Be((7, 100));
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(0, -1)]
+    public void GetNotificationPaging_RejectsNegativeValues(int skip, int take)
+    {
+        var exception = Assert.Throws<RpcException>(
+            () => ExpressRpcServerPlugin.GetNotificationPaging(CreateNotificationParams(skip, take)));
+
+        exception.Message.Should().Contain("Invalid params");
+    }
+
+    static JArray CreateNotificationParams(int? skip = null, int? take = null)
+    {
+        var @params = new JArray { new JArray(), new JArray() };
+        if (skip is not null)
+            @params.Add(skip.Value);
+        if (take is not null)
+            @params.Add(take.Value);
+
+        return @params;
     }
 
     static NotificationRecord CreateNotification(int index)

--- a/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
+++ b/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExpressRpcServerPluginTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Json;
+using Neo.Network.P2P.Payloads;
+using NeoExpress.Models;
+using NeoExpress.Node;
+using Xunit;
+
+using NeoArray = Neo.VM.Types.Array;
+
+namespace test.workflowvalidation;
+
+public class ExpressRpcServerPluginTests
+{
+    [Theory]
+    [InlineData(3, 0, 0, true)]
+    [InlineData(3, 2, 2, true)]
+    [InlineData(3, 3, 3, false)]
+    [InlineData(0, 0, 0, false)]
+    public void CreateNotificationsResponse_RespectsTakeLimit(
+        int sourceCount,
+        int take,
+        int expectedCount,
+        bool expectedTruncated)
+    {
+        var notifications = Enumerable.Range(0, sourceCount)
+            .Select(i => ((uint)i, CreateNotification(i)));
+
+        var response = ExpressRpcServerPlugin.CreateNotificationsResponse(notifications, take);
+
+        response["truncated"]!.AsBoolean().Should().Be(expectedTruncated);
+        ((JArray)response["notifications"]!).Count.Should().Be(expectedCount);
+    }
+
+    static NotificationRecord CreateNotification(int index)
+        => new(
+            UInt160.Zero,
+            $"event-{index}",
+            new NeoArray(),
+            InventoryType.TX,
+            UInt256.Zero);
+}


### PR DESCRIPTION
## Summary
- make ExpressEnumNotifications return at most the requested take count
- preserve truncated=true detection when another notification exists

## Verification
- dotnet build src/neoxp/neoxp.csproj --configuration Release

## Notes
The build succeeds with existing nullable warnings in neoxp; this PR only fixes the pagination count behavior. Negative skip/take validation is split into a follow-up PR.