### PR TITLE
Reject negative notification paging inputs

### DIFF
--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -301,10 +301,7 @@ namespace NeoExpress.Node
         {
             var contracts = ((JArray)@params[0]!).Select(j => UInt160.Parse(j!.AsString())).ToHashSet();
             var events = ((JArray)@params[1]!).Select(j => j!.AsString()).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            int skip = @params.Count >= 3 ? (int)@params[2]!.AsNumber() : 0;
-            int take = @params.Count >= 4 ? (int)@params[3]!.AsNumber() : MAX_NOTIFICATIONS;
-            if (take > MAX_NOTIFICATIONS)
-                take = MAX_NOTIFICATIONS;
+            var (skip, take) = GetNotificationPaging(@params);
 
             var notifications = persistencePlugin.Value
                 .GetNotifications(
@@ -350,6 +347,18 @@ namespace NeoExpress.Node
                 ["truncated"] = truncated,
                 ["notifications"] = jsonNotifications,
             };
+        }
+
+        internal static (int skip, int take) GetNotificationPaging(JArray @params)
+        {
+            int skip = @params.Count >= 3 ? (int)@params[2]!.AsNumber() : 0;
+            int take = @params.Count >= 4 ? (int)@params[3]!.AsNumber() : MAX_NOTIFICATIONS;
+            if (skip < 0 || take < 0)
+                throw new RpcException(-32602, "Invalid params");
+            if (take > MAX_NOTIFICATIONS)
+                take = MAX_NOTIFICATIONS;
+
+            return (skip, take);
         }
 
         // Neo-express uses a custom implementation of GetApplicationLog due to

--- a/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
+++ b/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
@@ -17,6 +17,7 @@ using NeoExpress.Node;
 using Xunit;
 
 using NeoArray = Neo.VM.Types.Array;
+using RpcException = Neo.Network.RPC.RpcException;
 
 namespace test.workflowvalidation;
 
@@ -40,6 +41,38 @@ public class ExpressRpcServerPluginTests
 
         response["truncated"]!.AsBoolean().Should().Be(expectedTruncated);
         ((JArray)response["notifications"]!).Count.Should().Be(expectedCount);
+    }
+
+    [Fact]
+    public void GetNotificationPaging_UsesDefaultsAndCapsTake()
+    {
+        ExpressRpcServerPlugin.GetNotificationPaging(CreateNotificationParams())
+            .Should().Be((0, 100));
+
+        ExpressRpcServerPlugin.GetNotificationPaging(CreateNotificationParams(skip: 7, take: 101))
+            .Should().Be((7, 100));
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(0, -1)]
+    public void GetNotificationPaging_RejectsNegativeValues(int skip, int take)
+    {
+        var exception = Assert.Throws<RpcException>(
+            () => ExpressRpcServerPlugin.GetNotificationPaging(CreateNotificationParams(skip, take)));
+
+        exception.Message.Should().Contain("Invalid params");
+    }
+
+    static JArray CreateNotificationParams(int? skip = null, int? take = null)
+    {
+        var @params = new JArray { new JArray(), new JArray() };
+        if (skip is not null)
+            @params.Add(skip.Value);
+        if (take is not null)
+            @params.Add(take.Value);
+
+        return @params;
     }
 
     static NotificationRecord CreateNotification(int index)


### PR DESCRIPTION
## Summary
- reject negative skip/take values in ExpressEnumNotifications as invalid RPC params
- keep the existing max take clamp for positive values

## Verification
- dotnet build src/neoxp/neoxp.csproj --configuration Release

## Notes
This PR is stacked on #545 so the diff only contains validation. The build succeeds with existing nullable warnings in neoxp.