### PR TITLE
Refresh sample contract Neo tooling

### DIFF
--- a/samples/.config/dotnet-tools.json
+++ b/samples/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "neo.express": {
-      "version": "3.6.17",
+      "version": "3.9.1",
       "commands": [
         "neoxp"
       ]
     },
     "neo.compiler.csharp": {
-      "version": "3.8.1",
+      "version": "3.9.1",
       "commands": [
         "nccs"
       ]

--- a/samples/src/contract.cs
+++ b/samples/src/contract.cs
@@ -1,7 +1,17 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// contract.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
 using Neo.SmartContract.Framework;
 
 public class TestContract : TokenContract
 {
-    public override byte Decimals() => 0;
-    public override string Symbol() => "TEST";
+    public override byte Decimals => 0;
+    public override string Symbol => "TEST";
 }

--- a/samples/src/contract.csproj
+++ b/samples/src/contract.csproj
@@ -4,10 +4,10 @@
     <NeoExpressBatchFile>../express.batch</NeoExpressBatchFile>
     <Nullable>enable</Nullable>
     <TargetFramework>net10.0</TargetFramework>
-    <NeoTestVersion>3.5.17</NeoTestVersion>
+    <NeoTestVersion>3.8.2</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.8.1" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="3.9.1" />
     <PackageReference Include="Neo.BuildTasks" Version="$(NeoTestVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/samples/test/contract-test.csproj
+++ b/samples/test/contract-test.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>ContractTests</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
-    <NeoTestVersion>3.5.17</NeoTestVersion>
+    <NeoTestVersion>3.8.2</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
     <NeoContractReference Include="..\src\contract.csproj" />


### PR DESCRIPTION
## Summary
- update sample dotnet tools to Neo.Express and Neo.Compiler.CSharp 3.9.1
- update the sample contract framework to Neo.SmartContract.Framework 3.9.1
- adjust the sample TokenContract overrides to the current property-based API
- move sample BuildTasks/Test package references from 3.5.17 to 3.8.2, the latest published version verified to contain runnable build-task assets

## Notes
- Neo.BuildTasks 3.9.1 was checked but not used because the published package restores without the tasks/net10.0/neo-build-tasks.dll asset referenced by its targets.

## Verification
- dotnet tool restore
- dotnet restore samples/src/contract.csproj
- dotnet restore samples/test/contract-test.csproj
- dotnet build samples/test/contract-test.csproj --configuration Release --no-restore
- dotnet test samples/test/contract-test.csproj --configuration Release --no-build --no-restore
- dotnet format samples/build-tasks-sample.sln --verify-no-changes --include samples/src/contract.cs