### PR TITLE
Validate stop node index before stopping

### DIFF
--- a/src/neoxp/Commands/StopCommand.cs
+++ b/src/neoxp/Commands/StopCommand.cs
@@ -59,6 +59,11 @@ namespace NeoExpress.Commands
                         ? 0
                         : throw new InvalidOperationException("node index or --all must be specified when resetting a multi-node chain");
 
+                if (nodeIndex < 0 || nodeIndex >= chain.ConsensusNodes.Count)
+                {
+                    throw new ArgumentException($"node-index must be in [0, {chain.ConsensusNodes.Count - 1}]", nameof(NodeIndex));
+                }
+
                 var wasRunning = await chainManager.StopNodeAsync(chain.ConsensusNodes[nodeIndex]).ConfigureAwait(false);
                 await console.Out.WriteLineAsync($"node {nodeIndex} {(wasRunning ? "stopped" : "was not running")}").ConfigureAwait(false);
             }


### PR DESCRIPTION
## Summary
Fixes the CLI-1 fuzz finding by rejecting out-of-range `stop --node-index` values before indexing the consensus node list.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct CLI repro with `stop --node-index -1` returns `node-index must be in [0, 0]` instead of `ArgumentOutOfRangeException`.
