### PR TITLE
Validate reset node index before resetting

### DIFF
--- a/src/neoxp/Commands/ResetCommand.cs
+++ b/src/neoxp/Commands/ResetCommand.cs
@@ -60,6 +60,11 @@ namespace NeoExpress.Commands
                         ? 0
                         : throw new InvalidOperationException("node index or --all must be specified when resetting a multi-node chain");
 
+                if (nodeIndex < 0 || nodeIndex >= chain.ConsensusNodes.Count)
+                {
+                    throw new ArgumentException($"node-index must be in [0, {chain.ConsensusNodes.Count - 1}]", nameof(NodeIndex));
+                }
+
                 chainManager.ResetNode(chain.ConsensusNodes[nodeIndex], Force);
                 console.Out.WriteLine($"node {nodeIndex} reset");
             }


### PR DESCRIPTION
## Summary
Fixes the CLI-2 fuzz finding by rejecting out-of-range `reset --node-index` values before indexing the consensus node list.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct CLI repro with `reset --node-index -1` returns `node-index must be in [0, 0]` instead of `ArgumentOutOfRangeException`.
