### PR TITLE
Report malformed chain config JSON cleanly

### DIFF
--- a/src/bctklib/Extensions.cs
+++ b/src/bctklib/Extensions.cs
@@ -48,8 +48,15 @@ namespace Neo.BlockchainToolkit
             using var stream = fileSystem.File.OpenRead(path);
             using var streamReader = new System.IO.StreamReader(stream);
             using var reader = new JsonTextReader(streamReader);
-            return serializer.Deserialize<ExpressChain>(reader)
-                ?? throw new Exception($"Cannot load Neo-Express instance information from {path}");
+            try
+            {
+                return serializer.Deserialize<ExpressChain>(reader)
+                    ?? throw new Exception($"Cannot load Neo-Express instance information from {path}");
+            }
+            catch (JsonException ex)
+            {
+                throw new Exception($"Cannot load Neo-Express instance information from {path}: invalid JSON ({ex.Message})");
+            }
         }
 
         public static void SaveChain(this IFileSystem fileSystem, ExpressChain chain, string path)

--- a/test/test.bctklib/ExpressChainTest.cs
+++ b/test/test.bctklib/ExpressChainTest.cs
@@ -99,5 +99,19 @@ namespace test.bctklib
 
             chain.Settings.Should().Contain(TEST_SETTING, TEST_SETTING_VALUE);
         }
+
+        [Fact]
+        public void malformed_json_reports_config_load_error()
+        {
+            var fileSystem = new MockFileSystem();
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
+            fileSystem.AddFile(fileName, new MockFileData("NaN"));
+
+            var action = () => fileSystem.LoadChain(fileName);
+
+            var exception = action.Should().Throw<System.Exception>().Which;
+            exception.Message.Should().StartWith($"Cannot load Neo-Express instance information from {fileName}: invalid JSON");
+            exception.InnerException.Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes the CLI-4 fuzz finding by wrapping malformed neo-express config JSON in a user-facing load error instead of leaking raw JSON parser exceptions.

## Verification
- `dotnet test test/test.bctklib/test.bctklib.csproj --filter ExpressChainTest`
