### PR TITLE
Treat null config settings as empty

### DIFF
--- a/src/bctklib/models/ExpressChain.cs
+++ b/src/bctklib/models/ExpressChain.cs
@@ -15,6 +15,8 @@ namespace Neo.BlockchainToolkit.Models
 {
     public class ExpressChain
     {
+        private Dictionary<string, string> settings = new Dictionary<string, string>();
+
         private readonly static ImmutableHashSet<uint> KNOWN_NETWORK_NUMBERS = ImmutableHashSet.Create<uint>(
             /* Neo 2 MainNet */ 7630401,
             /* Neo 2 TestNet */ 1953787457,
@@ -54,6 +56,10 @@ namespace Neo.BlockchainToolkit.Models
         public List<ExpressWallet> Wallets { get; set; } = new List<ExpressWallet>();
 
         [JsonProperty("settings")]
-        public Dictionary<string, string> Settings { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Settings
+        {
+            get => settings;
+            set => settings = value ?? new Dictionary<string, string>();
+        }
     }
 }

--- a/test/test.bctklib/ExpressChainTest.cs
+++ b/test/test.bctklib/ExpressChainTest.cs
@@ -99,5 +99,17 @@ namespace test.bctklib
 
             chain.Settings.Should().Contain(TEST_SETTING, TEST_SETTING_VALUE);
         }
+
+        [Fact]
+        public void null_settings_load_as_empty_dictionary()
+        {
+            var fileSystem = new MockFileSystem();
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
+            fileSystem.AddFile(fileName, new MockFileData("{'settings': null}"));
+
+            var chain = fileSystem.LoadChain(fileName);
+
+            chain.Settings.Should().BeEmpty();
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes the CLI-8 fuzz finding by preserving `settings: null` as an empty settings dictionary instead of allowing a later null-reference path.

## Verification
- `dotnet test test/test.bctklib/test.bctklib.csproj --filter ExpressChainTest`
