### PR TITLE
Report malformed NEF files cleanly

### DIFF
--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -78,7 +78,14 @@ namespace NeoExpress
             static async Task<NefFile> LoadNefAsync(IFileSystem fileSystem, string contractPath)
             {
                 var buffer = await fileSystem.File.ReadAllBytesAsync(contractPath).ConfigureAwait(false);
-                return LoadNef(buffer);
+                try
+                {
+                    return LoadNef(buffer);
+                }
+                catch (Exception ex) when (ex is FormatException or ArgumentException)
+                {
+                    throw new Exception($"Contract file '{contractPath}' is not a valid NEF file: {ex.Message}");
+                }
 
             }
 


### PR DESCRIPTION
## Summary
Fixes the CLI-5/CLI-12 NEF parsing findings by converting malformed NEF parser failures into a concise contract input error.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct `contract hash` repro with an invalid NEF no longer emits `FormatException` or `ArgumentException`.
