### PR TITLE
Report malformed contract manifests cleanly

### DIFF
--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -92,7 +92,14 @@ namespace NeoExpress
             {
                 var path = fileSystem.Path.ChangeExtension(contractPath, ".manifest.json");
                 var buffer = await fileSystem.File.ReadAllBytesAsync(path).ConfigureAwait(false);
-                return ContractManifest.Parse(buffer);
+                try
+                {
+                    return ContractManifest.Parse(buffer);
+                }
+                catch (Exception ex) when (ex is FormatException or InvalidCastException or NullReferenceException)
+                {
+                    throw new Exception($"Contract manifest '{path}' is invalid: {ex.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes the MF-1/MF-2/MF-3 manifest parsing findings by wrapping malformed contract manifest parse failures with the manifest path and a stable input-error message.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct `contract hash` repro with `abi: null` no longer emits `NullReferenceException`, `InvalidCastException`, or `FormatException`.
