### PR TITLE
Report malformed invocation files cleanly

### DIFF
--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -55,8 +55,15 @@ namespace Neo.BlockchainToolkit
 
             using var streamReader = fileSystem.File.OpenText(invokeFile);
             using var jsonReader = new JsonTextReader(streamReader);
-            var document = await JContainer.LoadAsync(jsonReader).ConfigureAwait(false);
-            return LoadInvocationScript(document);
+            try
+            {
+                var document = await JContainer.LoadAsync(jsonReader).ConfigureAwait(false);
+                return LoadInvocationScript(document);
+            }
+            catch (Exception ex) when (ex is JsonException or FormatException or InvalidCastException)
+            {
+                throw new Exception($"Invocation file {path} is invalid: {ex.Message}");
+            }
         }
 
         private Script LoadInvocationScript(JToken document)

--- a/test/test.bctklib/ContractParameterParserTest.cs
+++ b/test/test.bctklib/ContractParameterParserTest.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -270,6 +271,25 @@ namespace test.bctklib
             var exception = Assert.Throws<FileNotFoundException>(() => parser.ParseStringParameter($"file://{someFakePathFile}"));
 
             Assert.Equal(someFakePathFile, exception.FileName);
+        }
+
+        [Theory]
+        [InlineData("NaN")]
+        [InlineData("\"not an invocation\"")]
+        [InlineData("[\"not an invocation\"]")]
+        public async Task LoadInvocationScriptAsync_reports_invalid_invocation_file(string content)
+        {
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var invocationPath = fileSystem.Path.Combine(rootPath, "bad.neo-invoke.json");
+            fileSystem.AddFile(invocationPath, new MockFileData(content));
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var action = () => parser.LoadInvocationScriptAsync(invocationPath);
+
+            var exception = await action.Should().ThrowAsync<Exception>();
+            exception.Which.Message.Should().StartWith($"Invocation file {invocationPath} is invalid:");
+            exception.Which.InnerException.Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Fixes the CLI-9/CLI-11 invocation-file findings by wrapping malformed `.neo-invoke.json` JSON and shape errors with the invocation file path.

## Verification
- `dotnet test test/test.bctklib/test.bctklib.csproj --filter ContractParameterParserTest`
- `dotnet build src/neoxp/neoxp.csproj`
- Direct `contract invoke` repro with malformed JSON no longer emits parser exception types.
