### PR TITLE
Report malformed oracle response JSON cleanly

### DIFF
--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -425,7 +425,14 @@ namespace NeoExpress
                 using var stream = fileSystem.File.OpenRead(responsePath);
                 using var reader = new System.IO.StreamReader(stream);
                 using var jsonReader = new Newtonsoft.Json.JsonTextReader(reader);
-                responseJson = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+                try
+                {
+                    responseJson = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+                }
+                catch (JsonException ex)
+                {
+                    throw new Exception($"Oracle response file {responsePath} is invalid JSON: {ex.Message}");
+                }
             }
 
             var txHashes = await expressNode.SubmitOracleResponseAsync(url, OracleResponseCode.Success, responseJson, requestId).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
Fixes the ORC-1 fuzz finding by converting malformed `oracle response` JSON into a stable input error instead of leaking `JsonReaderException`.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct `oracle response` repro with `NaN` no longer emits `JsonReaderException`.
