### PR TITLE
Report corrupt checkpoint archives cleanly

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -159,8 +159,15 @@ namespace NeoExpress
 
             var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);
             var multiSigAccount = wallet.GetMultiSigAccounts().Single();
-            RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
-                ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
+            try
+            {
+                RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
+                    ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
+            }
+            catch (Exception ex) when (ex is System.IO.InvalidDataException or System.IO.EndOfStreamException)
+            {
+                throw new Exception($"Checkpoint {checkPointArchive} is not a valid checkpoint archive: {ex.Message}");
+            }
             fileSystem.Directory.Move(checkpointTempPath, nodePath);
         }
 


### PR DESCRIPTION
## Summary
Fixes the CP-1 fuzz finding by wrapping corrupt checkpoint archive restore failures in a stable checkpoint input error.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct `checkpoint restore` repro with an empty archive no longer emits `InvalidDataException` or `EndOfStreamException`.
