### PR TITLE
Let discard runs start without existing node state

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -307,11 +307,12 @@ namespace NeoExpress
         public IExpressStorage GetNodeStorageProvider(ExpressConsensusNode node, bool discard)
         {
             var nodePath = fileSystem.GetNodePath(node);
+            if (discard)
+                return CheckpointExpressStorage.OpenForDiscard(nodePath);
+
             if (!fileSystem.Directory.Exists(nodePath))
                 fileSystem.Directory.CreateDirectory(nodePath);
-            return discard
-                ? CheckpointExpressStorage.OpenForDiscard(nodePath)
-                : new RocksDbExpressStorage(nodePath);
+            return new RocksDbExpressStorage(nodePath);
         }
 
         public IExpressStorage GetCheckpointStorageProvider(string checkPointPath)


### PR DESCRIPTION
## Summary
Fixes the CLI-6 fuzz finding by letting `OpenForDiscard` handle an absent node data directory instead of pre-creating an empty RocksDB directory that leaks a missing `CURRENT` marker error.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct `run --discard` on a freshly created chain reaches `Neo express is running (CheckpointExpressStorage)` without RocksDB `CURRENT` errors.
