### PR TITLE
Report missing storage contracts before update

### DIFF
--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -411,10 +411,15 @@ namespace NeoExpress.Node
         public Task<int> PersistStorageKeyValueAsync(UInt160 scripthash, (string key, string value) storagePair)
             => MakeAsync(() =>
             {
-                var state = NativeContract.ContractManagement.GetContract(neoSystem.StoreView, scripthash);
                 if (chain.ConsensusNodes.Count != 1)
                 {
                     throw new ArgumentException("Contract storage update is only supported for single-node consensus");
+                }
+
+                var state = NativeContract.ContractManagement.GetContract(neoSystem.StoreView, scripthash);
+                if (state is null)
+                {
+                    throw new Exception("Contract not found");
                 }
 
                 return NodeUtility.PersistStorageKeyValuePair(neoSystem, state, storagePair, ContractCommand.OverwriteForce.None);

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -280,6 +280,10 @@ namespace NeoExpress.Node
             }
 
             var state = await rpcClient.GetContractStateAsync(scripthash.ToString()).ConfigureAwait(false);
+            if (state is null)
+            {
+                throw new Exception("Contract not found");
+            }
 
             JObject o = new JObject();
             o["state"] = state.ToJson();


### PR DESCRIPTION
## Fuzzer context
This PR fixes BLOB-1, an issue identified by the neo-express fuzzer: `contract storage update` against a non-existent contract leaked `NullReferenceException`.

## Summary
- Validate that a target contract exists before applying `contract storage update`.
- Return `Contract not found` instead of leaking `NullReferenceException` for missing hashes.
- Covers BLOB-1.

## Verification
- `dotnet build src/neoxp/neoxp.csproj`
- Direct repro: `contract storage update 0x0101010101010101010101010101010101010101 key value --input default.neo-express` now returns `Contract not found` instead of `NullReferenceException`.
