### PR TITLE
Reject checkpoint paths outside the current directory

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -50,7 +50,31 @@ namespace NeoExpress
 
         public ExpressChain Chain => chain;
 
-        private string ResolveCheckpointFileName(string path) => fileSystem.ResolveFileName(path, CHECKPOINT_EXTENSION, () => $"{DateTimeOffset.Now:yyyyMMdd-hhmmss}");
+        private string ResolveCheckpointFileName(string path) => ResolveCheckpointFileName(fileSystem, path);
+
+        internal static string ResolveCheckpointFileName(IFileSystem fileSystem, string path)
+        {
+            var checkpointPath = fileSystem.ResolveFileName(path, CHECKPOINT_EXTENSION, () => $"{DateTimeOffset.Now:yyyyMMdd-hhmmss}");
+            checkpointPath = fileSystem.Path.GetFullPath(checkpointPath);
+
+            var currentDirectory = fileSystem.Path.GetFullPath(fileSystem.Directory.GetCurrentDirectory());
+            if (!IsPathWithinDirectory(fileSystem, checkpointPath, currentDirectory))
+            {
+                throw new ArgumentException("Checkpoint path must stay within the current directory", nameof(path));
+            }
+
+            return checkpointPath;
+        }
+
+        private static bool IsPathWithinDirectory(IFileSystem fileSystem, string path, string directory)
+        {
+            var comparison = fileSystem.Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            var directoryPrefix = directory.TrimEnd(fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar)
+                + fileSystem.Path.DirectorySeparatorChar;
+            return path.StartsWith(directoryPrefix, comparison);
+        }
 
         private static bool IsNodeRunning(ExpressConsensusNode node)
         {

--- a/test/test.workflowvalidation/ExpressChainManagerCheckpointTests.cs
+++ b/test/test.workflowvalidation/ExpressChainManagerCheckpointTests.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExpressChainManagerCheckpointTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ExpressChainManagerCheckpointTests
+{
+    [Fact]
+    public void ResolveCheckpointFileName_allows_relative_subdirectory_paths()
+    {
+        var fileSystem = CreateFileSystem();
+
+        var checkpointPath = ExpressChainManager.ResolveCheckpointFileName(fileSystem, "checkpoints/init");
+
+        checkpointPath.Should().Be(fileSystem.Path.Combine("/work", "checkpoints", "init.neoxp-checkpoint"));
+    }
+
+    [Theory]
+    [InlineData("../../../../etc/passwd")]
+    [InlineData("/tmp/passwd")]
+    public void ResolveCheckpointFileName_rejects_paths_outside_current_directory(string path)
+    {
+        var fileSystem = CreateFileSystem();
+
+        var action = () => ExpressChainManager.ResolveCheckpointFileName(fileSystem, path);
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("Checkpoint path must stay within the current directory*");
+    }
+
+    private static MockFileSystem CreateFileSystem()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), "/work");
+        fileSystem.Directory.CreateDirectory("/work");
+        fileSystem.Directory.SetCurrentDirectory("/work");
+        return fileSystem;
+    }
+}


### PR DESCRIPTION
## Fuzzer context
This PR fixes CLI-7, an issue identified by the neo-express fuzzer: `checkpoint create ../../../../etc/passwd` accepted a path that resolved outside the working directory.

## Summary
- Normalize checkpoint paths before use.
- Reject checkpoint create/restore/run paths that resolve outside the current directory.
- Preserve supported relative subdirectory paths like `checkpoints/init`.
- Covers CLI-7.

## Verification
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter ExpressChainManagerCheckpointTests`
- `dotnet build src/neoxp/neoxp.csproj`
- Direct repro: `checkpoint create ../../../../etc/passwd --input default.neo-express --force` now rejects the path.
- Direct compatibility check: `checkpoint create checkpoints/init --input default.neo-express --force` still succeeds and creates `checkpoints/init.neoxp-checkpoint`.
