### PR TITLE
Treat unreadable execute input as invalid script

### DIFF
--- a/src/neoxp/Commands/ExecuteCommand.cs
+++ b/src/neoxp/Commands/ExecuteCommand.cs
@@ -110,22 +110,32 @@ namespace NeoExpress.Commands
 
         private static Script? LoadFileScript(string fileName)
         {
-            var fileText = File.ReadAllText(fileName);
-            var txScript = ConvertTextToScript(fileText);
-            if (txScript != null)
-            {
-                return txScript;
-
-            }
-            var file = File.ReadAllBytes(fileName);
             try
             {
-                var nef = file.AsSerializable<NefFile>();
-                return nef?.Script;
+                if (!File.Exists(fileName))
+                    return null;
+
+                var fileText = File.ReadAllText(fileName);
+                var txScript = ConvertTextToScript(fileText);
+                if (txScript != null)
+                {
+                    return txScript;
+
+                }
+                var file = File.ReadAllBytes(fileName);
+                try
+                {
+                    var nef = file.AsSerializable<NefFile>();
+                    return nef?.Script;
+                }
+                catch (Exception)
+                {
+                }
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
             {
             }
+
             return null;
         }
 

--- a/src/neoxp/Commands/ExecuteCommand.cs
+++ b/src/neoxp/Commands/ExecuteCommand.cs
@@ -122,16 +122,10 @@ namespace NeoExpress.Commands
                     return txScript;
                 }
                 var file = File.ReadAllBytes(fileName);
-                try
-                {
-                    var nef = file.AsSerializable<NefFile>();
-                    return nef?.Script;
-                }
-                catch (Exception)
-                {
-                }
+                var nef = file.AsSerializable<NefFile>();
+                return nef?.Script;
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or FormatException or InvalidOperationException)
             {
             }
 

--- a/src/neoxp/Commands/ExecuteCommand.cs
+++ b/src/neoxp/Commands/ExecuteCommand.cs
@@ -120,7 +120,6 @@ namespace NeoExpress.Commands
                 if (txScript != null)
                 {
                     return txScript;
-
                 }
                 var file = File.ReadAllBytes(fileName);
                 try

--- a/test/test.workflowvalidation/ExecuteCommandTests.cs
+++ b/test/test.workflowvalidation/ExecuteCommandTests.cs
@@ -1,0 +1,30 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExecuteCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using System.Reflection;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ExecuteCommandTests
+{
+    [Fact]
+    public void LoadFileScript_returns_null_for_long_non_file_input()
+    {
+        var method = typeof(ExecuteCommand).GetMethod("LoadFileScript", BindingFlags.NonPublic | BindingFlags.Static);
+        var longInput = $"0x{new string('b', 1026)}";
+
+        var result = method!.Invoke(null, [longInput]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes fuzzer-identified issue `EXEC-1`.

`neoxp execute <long invalid hex> --results` fell through script/base64 parsing and treated the raw argument as a file path. Very long fuzzed input could therefore leak `PathTooLongException` from the filesystem probe instead of reporting an invalid script.

This keeps existing script-file and NEF-file behavior, but treats unreadable or invalid file probes as a normal parse miss so the CLI returns `Invalid script: ...`.

## Validation

- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter ExecuteCommandTests`
- `dotnet build src/neoxp/neoxp.csproj`
- `dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal`
- Direct fuzzer repro: long `0xb0...` execute input exits 1 with `Invalid script`, no `PathTooLongException`
