### PR TITLE
Bound create batch file reads

### DIFF
--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -48,6 +48,8 @@ namespace NeoExpress.Commands
         [Option(Description = "Use a batch file to initialize the blockchain after creation.")]
         internal string BatchFilename { get; set; } = string.Empty;
 
+        internal const long MaxBatchFileBytes = 4 * 1024 * 1024;
+
         internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
         {
             try
@@ -84,7 +86,7 @@ namespace NeoExpress.Commands
                     var batchFileInfo = fileSystem.FileInfo.New(BatchFilename);
                     var batchDirInfo = batchFileInfo.Directory ?? throw new InvalidOperationException("batchFileInfo.Directory is null");
 
-                    var commands = await fileSystem.File.ReadAllLinesAsync(BatchFilename, token).ConfigureAwait(false);
+                    var commands = await LoadBatchCommandsAsync(fileSystem, BatchFilename, token).ConfigureAwait(false);
                     await batchCommand.ExecuteAsync(batchDirInfo, commands, console.Out, chainManager, outputPath).ConfigureAwait(false);
                 }
 
@@ -94,6 +96,62 @@ namespace NeoExpress.Commands
             {
                 app.WriteException(ex);
                 return 1;
+            }
+        }
+
+        internal static async Task<string[]> LoadBatchCommandsAsync(IFileSystem fileSystem, string batchFilename, CancellationToken token)
+        {
+            var fileInfo = fileSystem.FileInfo.New(batchFilename);
+            if (!fileInfo.Exists)
+                throw new FileNotFoundException(batchFilename);
+
+            if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                throw new Exception($"Batch file {batchFilename} is invalid: path is a directory");
+
+            if (fileInfo.Length > MaxBatchFileBytes)
+                throw new Exception($"Batch file {batchFilename} is invalid: file is larger than {MaxBatchFileBytes} bytes");
+
+            try
+            {
+                using var stream = fileSystem.File.OpenRead(batchFilename);
+                using var memory = new MemoryStream();
+                var buffer = new byte[8192];
+                long bytesRead = 0;
+
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                    if (read == 0)
+                        break;
+
+                    bytesRead += read;
+                    if (bytesRead > MaxBatchFileBytes)
+                        throw new IOException($"file is larger than {MaxBatchFileBytes} bytes");
+
+                    memory.Write(buffer, 0, read);
+                }
+
+                memory.Position = 0;
+                using var reader = new StreamReader(memory);
+                var commands = new List<string>();
+                while (await reader.ReadLineAsync(token).ConfigureAwait(false) is { } line)
+                {
+                    commands.Add(line);
+                }
+
+                return commands.ToArray();
+            }
+            catch (IOException ex)
+            {
+                throw new Exception($"Batch file {batchFilename} is invalid: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new Exception($"Batch file {batchFilename} is invalid: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
+            {
+                throw new Exception($"Batch file {batchFilename} is invalid: {ex.Message}");
             }
         }
     }

--- a/test/test.workflowvalidation/CreateCommandTests.cs
+++ b/test/test.workflowvalidation/CreateCommandTests.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CreateCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class CreateCommandTests
+{
+    [Fact]
+    public async Task LoadBatchCommandsAsync_rejects_oversized_batch_file()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), "/work");
+        fileSystem.Directory.CreateDirectory("/work");
+        var batchPath = fileSystem.Path.Combine("/work", "init.batch");
+        fileSystem.AddFile(batchPath, new MockFileData(new string(' ', (int)CreateCommand.MaxBatchFileBytes + 1)));
+
+        Func<Task> action = () => CreateCommand.LoadBatchCommandsAsync(fileSystem, batchPath, CancellationToken.None);
+
+        var exception = await action.Should().ThrowAsync<Exception>();
+        exception.Which.Message.Should().Be($"Batch file {batchPath} is invalid: file is larger than {CreateCommand.MaxBatchFileBytes} bytes");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes fuzzer-identified issue `HANG-3`.

`neoxp create --batch-filename /dev/zero` created the chain and then attempted to load the batch file with `ReadAllLinesAsync`. Character devices and other infinite streams never reach EOF, so the command could hang in an unbounded read.

This adds a small create-time batch loader with a 4 MiB read budget. Normal batch files still produce the same string-array input for `BatchCommand`, while directories, oversized files, and streams exceeding the budget fail with a bounded validation error.

## Validation

- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter CreateCommandTests`
- `dotnet build src/neoxp/neoxp.csproj`
- `dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal`
- Direct fuzzer repro: `timeout 10s neoxp create --output default.neo-express --batch-filename /dev/zero` exits 1 with bounded file-size error, not timeout 124
