### PR TITLE
Reject extreme fast-forward counts

### DIFF
--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -16,6 +16,8 @@ namespace NeoExpress.Commands
     [Command("fastfwd", Description = "Mint empty blocks to fast forward the block chain")]
     class FastForwardCommand
     {
+        internal const uint MaxFastForwardCount = 100_000;
+
         readonly ExpressChainManagerFactory chainManagerFactory;
 
         public FastForwardCommand(ExpressChainManagerFactory chainManagerFactory)
@@ -37,6 +39,8 @@ namespace NeoExpress.Commands
         {
             try
             {
+                ValidateCount(Count);
+
                 var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                 using var expressNode = chainManager.GetExpressNode();
 
@@ -51,6 +55,12 @@ namespace NeoExpress.Commands
                 app.WriteException(ex);
                 return 1;
             }
+        }
+
+        internal static void ValidateCount(uint count)
+        {
+            if (count > MaxFastForwardCount)
+                throw new Exception($"Cannot mint more than {MaxFastForwardCount} blocks at once");
         }
 
         internal static TimeSpan ParseTimestampDelta(string timestampDelta)

--- a/test/test.workflowvalidation/FastForwardCommandTests.cs
+++ b/test/test.workflowvalidation/FastForwardCommandTests.cs
@@ -1,0 +1,27 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// FastForwardCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class FastForwardCommandTests
+{
+    [Fact]
+    public void ValidateCount_rejects_extreme_counts()
+    {
+        var action = () => FastForwardCommand.ValidateCount(2_147_483_647);
+
+        action.Should().Throw<Exception>()
+            .WithMessage($"Cannot mint more than {FastForwardCommand.MaxFastForwardCount} blocks at once");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes fuzzer-identified issue `HANG-4`.

`neoxp fastfwd 2147483647` accepted an extreme block count and entered prohibitively large minting work. This PR rejects counts above `100000` before loading the chain or starting block production.

The cap keeps ordinary bulk minting available while preventing a single pathological CLI input from monopolizing execution.

## Validation

- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter FastForwardCommandTests`
- `dotnet build src/neoxp/neoxp.csproj`
- `dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal`
- Direct fuzzer repro: `timeout 10s neoxp fastfwd 2147483647 --input default.neo-express` exits 1 with count-bound error, not timeout 124
