### PR TITLE
Bound oracle response file reads

### DIFF
--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -34,6 +34,8 @@ namespace NeoExpress
 
     class TransactionExecutor : IDisposable
     {
+        internal const long MaxOracleResponseFileBytes = 4 * 1024 * 1024;
+
         readonly ExpressChainManager chainManager;
         readonly IExpressNode expressNode;
         readonly IFileSystem fileSystem;
@@ -417,23 +419,7 @@ namespace NeoExpress
 
         public async Task OracleResponseAsync(string url, string responsePath, ulong? requestId = null)
         {
-            if (!fileSystem.File.Exists(responsePath))
-                throw new Exception($"Response File {responsePath} couldn't be found");
-
-            JObject responseJson;
-            {
-                using var stream = fileSystem.File.OpenRead(responsePath);
-                using var reader = new System.IO.StreamReader(stream);
-                using var jsonReader = new Newtonsoft.Json.JsonTextReader(reader);
-                try
-                {
-                    responseJson = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
-                }
-                catch (JsonException ex)
-                {
-                    throw new Exception($"Oracle response file {responsePath} is invalid JSON: {ex.Message}");
-                }
-            }
+            var responseJson = await LoadOracleResponseJsonAsync(fileSystem, responsePath).ConfigureAwait(false);
 
             var txHashes = await expressNode.SubmitOracleResponseAsync(url, OracleResponseCode.Success, responseJson, requestId).ConfigureAwait(false);
 
@@ -461,6 +447,61 @@ namespace NeoExpress
                         await writer.WriteLineAsync($"    {txHashes[i]}").ConfigureAwait(false);
                     }
                 }
+            }
+        }
+
+        internal static async Task<JObject> LoadOracleResponseJsonAsync(IFileSystem fileSystem, string responsePath, CancellationToken token = default)
+        {
+            if (!fileSystem.File.Exists(responsePath))
+                throw new Exception($"Response File {responsePath} couldn't be found");
+
+            var fileInfo = fileSystem.FileInfo.New(responsePath);
+            if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                throw new Exception($"Oracle response file {responsePath} is invalid: path is a directory");
+
+            if (fileInfo.Length > MaxOracleResponseFileBytes)
+                throw new Exception($"Oracle response file {responsePath} is invalid: file is larger than {MaxOracleResponseFileBytes} bytes");
+
+            try
+            {
+                using var stream = fileSystem.File.OpenRead(responsePath);
+                using var memory = new MemoryStream();
+                var buffer = new byte[8192];
+                long bytesRead = 0;
+
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                    if (read == 0)
+                        break;
+
+                    bytesRead += read;
+                    if (bytesRead > MaxOracleResponseFileBytes)
+                        throw new IOException($"file is larger than {MaxOracleResponseFileBytes} bytes");
+
+                    memory.Write(buffer, 0, read);
+                }
+
+                memory.Position = 0;
+                using var reader = new StreamReader(memory);
+                using var jsonReader = new JsonTextReader(reader);
+                return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+            }
+            catch (JsonException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid JSON: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid: {ex.Message}");
             }
         }
 

--- a/test/test.workflowvalidation/TransactionExecutorOracleResponseTests.cs
+++ b/test/test.workflowvalidation/TransactionExecutorOracleResponseTests.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TransactionExecutorOracleResponseTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class TransactionExecutorOracleResponseTests
+{
+    [Fact]
+    public async Task LoadOracleResponseJsonAsync_rejects_oversized_response_file()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), "/work");
+        fileSystem.Directory.CreateDirectory("/work");
+        var responsePath = fileSystem.Path.Combine("/work", "response.json");
+        fileSystem.AddFile(responsePath, new MockFileData(new string(' ', (int)TransactionExecutor.MaxOracleResponseFileBytes + 1)));
+
+        Func<Task> action = () => TransactionExecutor.LoadOracleResponseJsonAsync(fileSystem, responsePath, CancellationToken.None);
+
+        var exception = await action.Should().ThrowAsync<Exception>();
+        exception.Which.Message.Should().Be($"Oracle response file {responsePath} is invalid: file is larger than {TransactionExecutor.MaxOracleResponseFileBytes} bytes");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes fuzzer-identified issue `HANG-5`.

`neoxp oracle response https://x /dev/zero` parsed JSON directly from the supplied stream. Infinite streams never reach EOF, so the command could hang before JSON parsing returned.

This routes oracle response loading through a bounded helper: known oversized files are rejected up front, and streams are stopped after a 4 MiB budget. Existing malformed-JSON wrapping remains intact.

## Validation

- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter TransactionExecutorOracleResponseTests`
- `dotnet build src/neoxp/neoxp.csproj`
- `dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal`
- Direct fuzzer repro: `timeout 10s neoxp oracle response https://x /dev/zero --input default.neo-express` exits 1 with bounded file-size error, not timeout 124
- Malformed JSON still exits 1 with `invalid JSON` error
