### PR TITLE
Gate extension changes on TypeScript typecheck

### DIFF
--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -33,6 +33,10 @@ jobs:
       working-directory: extentions/neo3-visual-tracker
       run: npm ci
 
+    - name: Typecheck
+      working-directory: extentions/neo3-visual-tracker
+      run: npm run typecheck
+
     - name: Compile
       working-directory: extentions/neo3-visual-tracker
       run: npm run compile

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -330,6 +330,7 @@
     "bundle-nxp-download": "shx rm -rf deps/nxp && shx mkdir -p deps/nxp && curl -fL \"https://www.nuget.org/api/v2/package/Neo.Express/%npm_package_version%\" -o deps/nxp/nxp.nupkg",
     "bundle-nxp-extract": "cd deps/nxp && extract-zip nxp.nupkg",
     "compile": "npm run compile-ext && npm run compile-panel",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "compile-ext": "webpack --config src/extension/webpack.config.js --mode development",
     "compile-panel": "webpack --config src/panel/webpack.config.js --mode development",
     "compile-prod": "npm run compile-prod-ext && npm run compile-prod-panel",

--- a/extentions/neo3-visual-tracker/tsconfig.json
+++ b/extentions/neo3-visual-tracker/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2020",
     "lib": ["esnext", "dom", "dom.iterable"],
     "esModuleInterop": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary

Addresses the still-valid part of fuzzer/process finding `EXT-3`.

`origin/master` already has the `EXT-1` Quick Start event fix and extension PR CI, but the CI still only runs webpack `compile`. Full `tsc --noEmit` still failed because the extension targeted ES5 while `@cityofzion/neon-core` declarations use private identifiers.

This PR:

- raises the extension TypeScript target to `es2020`
- adds `npm run typecheck`
- runs typecheck in the extension PR workflow before compile/test

## Validation

Before this change:

- `node node_modules/typescript/lib/tsc.js --noEmit -p tsconfig.json` failed with `TS18028` on `neon-core` private identifiers.
- `npm run compile` still passed, confirming webpack compile was masking the full typecheck failure.

After this change:

- `npm ci --ignore-scripts`
- `npm run typecheck`
- `npm run compile`
- `npm run test:quickstart`
