### PR TITLE
Validate extension webview requests before dispatch

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/panelControllers/panelControllerBase.ts
+++ b/extentions/neo3-visual-tracker/src/extension/panelControllers/panelControllerBase.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import ControllerRequest from "../../shared/messages/controllerRequest";
 import Log from "../util/log";
 import posixPath from "../util/posixPath";
-import ViewRequest from "../../shared/messages/viewRequest";
+import { parseViewRequest } from "../../shared/messages/viewRequest";
 import ViewStateBase from "../../shared/viewState/viewStateBase";
 
 const LOG_PREFIX = "PanelControllerBase";
@@ -112,7 +112,13 @@ export default abstract class PanelControllerBase<
     await this.sendRequest({ viewState: this.viewState });
   }
 
-  private async recieveRequest(request: ViewRequest) {
+  private async recieveRequest(message: unknown) {
+    const request = parseViewRequest(message);
+    if (!request) {
+      Log.warn(LOG_PREFIX, "Ignoring malformed webview request");
+      return;
+    }
+
     Log.log(
       LOG_PREFIX,
       "Received:",
@@ -125,7 +131,7 @@ export default abstract class PanelControllerBase<
     if (request.typedRequest) {
       await this.sendRequest({ loadingState: { isLoading: true } });
       try {
-        await this.onRequest(request.typedRequest);
+        await this.onRequest(request.typedRequest as TViewRequest);
       } finally {
         await this.sendRequest({ loadingState: { isLoading: false } });
       }

--- a/extentions/neo3-visual-tracker/src/shared/messages/viewRequest.test.ts
+++ b/extentions/neo3-visual-tracker/src/shared/messages/viewRequest.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseViewRequest } from "./viewRequest";
+
+test("parseViewRequest rejects non-object envelopes", () => {
+  assert.equal(parseViewRequest(undefined), undefined);
+  assert.equal(parseViewRequest(null), undefined);
+  assert.equal(parseViewRequest("typed-request"), undefined);
+  assert.equal(parseViewRequest([]), undefined);
+});
+
+test("parseViewRequest rejects non-object typed requests", () => {
+  assert.equal(parseViewRequest({ typedRequest: "open" }), undefined);
+  assert.equal(parseViewRequest({ typedRequest: 1 }), undefined);
+  assert.equal(parseViewRequest({ typedRequest: null }), undefined);
+  assert.equal(parseViewRequest({ typedRequest: [] }), undefined);
+});
+
+test("parseViewRequest accepts supported request shapes", () => {
+  assert.deepEqual(parseViewRequest({ retrieveViewState: true }), {
+    retrieveViewState: true,
+  });
+  assert.deepEqual(parseViewRequest({ typedRequest: { command: "open" } }), {
+    typedRequest: { command: "open" },
+  });
+});

--- a/extentions/neo3-visual-tracker/src/shared/messages/viewRequest.ts
+++ b/extentions/neo3-visual-tracker/src/shared/messages/viewRequest.ts
@@ -1,6 +1,31 @@
 type ViewRequest = {
   retrieveViewState?: boolean;
-  typedRequest?: any;
+  typedRequest?: Record<string, unknown>;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseViewRequest(value: unknown): ViewRequest | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const request: ViewRequest = {};
+  if (value.retrieveViewState === true) {
+    request.retrieveViewState = true;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, "typedRequest")) {
+    if (!isRecord(value.typedRequest)) {
+      return undefined;
+    }
+    request.typedRequest = value.typedRequest;
+  }
+
+  return request;
+}
+
+export { parseViewRequest };
 export default ViewRequest;


### PR DESCRIPTION
## Summary
- Treats this as a valid extension fuzzer finding: webview IPC accepted arbitrary message envelopes and forwarded any truthy `typedRequest` to panel handlers.
- Adds a small shared parser that accepts only object envelopes and object typed requests.
- Drops malformed webview messages before logging `Object.keys(...)` or dispatching to typed handlers.

## Fuzzer issue
- Fixes EXT-5 from the extension fuzzer findings.

## Validation
- Red test first: `node --test -r ts-node/register src/shared/messages/viewRequest.test.ts` failed because `parseViewRequest` did not exist.
- `node --test -r ts-node/register src/shared/messages/viewRequest.test.ts`
- `npm run test:quickstart`
- `npm run compile`
- `npm run compile-ext`
