### PR TITLE
Replace deprecated extension JSON fetch helper

### DIFF
--- a/extentions/neo3-visual-tracker/package-lock.json
+++ b/extentions/neo3-visual-tracker/package-lock.json
@@ -43,7 +43,6 @@
         "typescript": "^5.9.3",
         "webpack": "^5.105.0",
         "webpack-cli": "^6.0.1",
-        "wget-improved": "^3.4.0",
         "which": "^2.0.2"
       },
       "engines": {
@@ -8403,30 +8402,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/wget-improved": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.4.0.tgz",
-      "integrity": "sha512-mHCdqImHntGzaauaQrfhkcHO0sAOp9Fd/9v5PXwrvHK+nggRWG9en5UH72/WitJFv3d3iFwJSAVMrRaCjW6dAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "1.2.6",
-        "tunnel": "0.0.6"
-      },
-      "bin": {
-        "nwget": "bin/nwget"
-      },
-      "engines": {
-        "node": ">= 0.6.18"
-      }
-    },
-    "node_modules/wget-improved/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -376,7 +376,6 @@
     "typescript": "^5.9.3",
     "webpack": "^5.105.0",
     "webpack-cli": "^6.0.1",
-    "wget-improved": "^3.4.0",
     "which": "^2.0.2"
   },
   "dependencies": {

--- a/extentions/neo3-visual-tracker/src/extension/util/tryFetchJson.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/tryFetchJson.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import * as http from "node:http";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+type ModuleWithLoad = typeof import("node:module") & {
+  _load: (
+    request: string,
+    parent: NodeJS.Module | null,
+    isMain: boolean
+  ) => unknown;
+};
+
+const requireFromTest = createRequire(__filename);
+const moduleLoader = requireFromTest("node:module") as ModuleWithLoad;
+const originalLoad = moduleLoader._load;
+
+moduleLoader._load = function (
+  request: string,
+  parent: NodeJS.Module | null,
+  isMain: boolean
+) {
+  if (request === "vscode") {
+    return {
+      window: {
+        createOutputChannel: () => ({
+          appendLine: () => undefined,
+          dispose: () => undefined,
+        }),
+      },
+    };
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const tryFetchJson = requireFromTest("./tryFetchJson")
+  .default as typeof import("./tryFetchJson").default;
+moduleLoader._load = originalLoad;
+
+type TestServer = {
+  close: () => Promise<void>;
+  host: string;
+};
+
+async function createTestServer(
+  handler: http.RequestListener
+): Promise<TestServer> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      }),
+    host: `127.0.0.1:${address.port}`,
+  };
+}
+
+test("tryFetchJson returns parsed JSONC from successful responses", async () => {
+  const server = await createTestServer((request, response) => {
+    assert.equal(request.url, "/templates/neo");
+    response.end('{ "name": "neo", // comment\n "enabled": true }');
+  });
+
+  try {
+    assert.deepEqual(await tryFetchJson("http", server.host, "/templates/neo"), {
+      enabled: true,
+      name: "neo",
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("tryFetchJson returns an empty object for non-200 responses", async () => {
+  const server = await createTestServer((_request, response) => {
+    response.statusCode = 404;
+    response.end("missing");
+  });
+
+  try {
+    assert.deepEqual(await tryFetchJson("http", server.host, "/missing"), {});
+  } finally {
+    await server.close();
+  }
+});
+
+test("tryFetchJson returns an empty object for malformed JSONC", async () => {
+  const server = await createTestServer((_request, response) => {
+    response.end("{{{{");
+  });
+
+  try {
+    assert.deepEqual(await tryFetchJson("http", server.host, "/bad"), {});
+  } finally {
+    await server.close();
+  }
+});

--- a/extentions/neo3-visual-tracker/src/extension/util/tryFetchJson.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/tryFetchJson.ts
@@ -1,5 +1,3 @@
-import * as wget from "wget-improved";
-
 import JSONC from "./JSONC";
 import Log from "./log";
 
@@ -9,54 +7,31 @@ const LOG_PREFIX = "tryFetchJson";
 // a HTTP 200 status code and provide valid JSONC in the response body. Upon success, the
 // parsed JSONC object is returned. Upon failure, a warning is logged and an empty object
 // is returned.
-export default function tryFetchJson(
+export default async function tryFetchJson(
   protocol: "https" | "http",
   host: string,
   path: string
-): any {
-  return new Promise((resolve) => {
-    const request = wget.request(
-      { host, method: "GET", path: encodeURI(path), protocol },
-      (response) => {
-        if (response.statusCode !== 200) {
-          Log.warn(
-            LOG_PREFIX,
-            `Got HTTP code ${response.statusCode} when attempting to download ${protocol}://${host}${path}`
-          );
-          resolve({});
-        } else {
-          let content = "";
-          response.on("error", (err) => {
-            Log.warn(
-              LOG_PREFIX,
-              `Error ("${err}") when processing response from ${protocol}://${host}${path}`
-            );
-            resolve({});
-          });
-          response.on("data", (data) => {
-            content = content + data;
-          });
-          response.on("end", () => {
-            try {
-              resolve(JSONC.parse(content));
-            } catch (e : any) {
-              Log.warn(
-                LOG_PREFIX,
-                `Exception ("${e}") when parsing JSON from ${protocol}://${host}${path}`
-              );
-              resolve({});
-            }
-          });
-        }
-      }
-    );
-    request.on("error", (err) => {
+): Promise<any> {
+  const url = `${protocol}://${host}${encodeURI(path)}`;
+  try {
+    const response = await fetch(url);
+    if (response.status !== 200) {
       Log.warn(
         LOG_PREFIX,
-        `Error ("${err}") when sending request to ${protocol}://${host}${path}`
+        `Got HTTP code ${response.status} when attempting to download ${url}`
       );
-      resolve({});
-    });
-    request.end();
-  });
+      return {};
+    }
+
+    const content = await response.text();
+    try {
+      return JSONC.parse(content);
+    } catch (e : any) {
+      Log.warn(LOG_PREFIX, `Exception ("${e}") when parsing JSON from ${url}`);
+      return {};
+    }
+  } catch (e : any) {
+    Log.warn(LOG_PREFIX, `Error ("${e}") when sending request to ${url}`);
+    return {};
+  }
 }


### PR DESCRIPTION
## Summary
- Treats this as a valid low-severity extension fuzzer/dependency finding: the extension depended on deprecated `wget-improved` for one JSONC GET helper.
- Replaces that helper with native `fetch`, preserving the existing `{}`-on-failure contract.
- Removes `wget-improved` from `package.json` and `package-lock.json`.

## Fuzzer issue
- Fixes EXT-7 from the extension fuzzer findings.

## Validation
- Initial behavior test exposed the old helper failing `host:port` local URLs (`getaddrinfo ENOTFOUND`), confirming the transport boundary was brittle.
- `node --test -r ts-node/register src/extension/util/tryFetchJson.test.ts`
- `npm run test:quickstart`
- `node -e "const lock=require('./package-lock.json'); if (lock.packages['node_modules/wget-improved']) process.exit(1); console.log('wget-improved removed')"`
- `npm run compile`
