### PR TITLE
Ignore custom RPC lists in untrusted workspaces

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
@@ -8,6 +8,7 @@ import IoHelpers from "../util/ioHelpers";
 import JSONC from "../util/JSONC";
 import Log from "../util/log";
 import posixPath from "../util/posixPath";
+import getTrustedWorkspaceServerListFiles from "./serverListWorkspaceTrust";
 
 const LOG_PREFIX = "ServerListDetector";
 
@@ -104,7 +105,18 @@ export default class ServerListDetector extends DetectorBase {
   async processFiles() {
     const blockchainNames = { ...WELL_KNOWN_BLOCKCHAINS };
     const rpcUrls: { [url: string]: boolean } = { ...SEED_URLS };
-    for (const file of this.files) {
+    const files = getTrustedWorkspaceServerListFiles(
+      this.files,
+      vscode.workspace.isTrusted
+    );
+    if (this.files.length && !files.length) {
+      Log.log(
+        LOG_PREFIX,
+        "Ignoring workspace RPC server list files because the workspace is not trusted"
+      );
+    }
+
+    for (const file of files) {
       try {
         const contents = JSONC.parse(
           (await fs.promises.readFile(file)).toString()

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListWorkspaceTrust.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListWorkspaceTrust.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import getTrustedWorkspaceServerListFiles from "./serverListWorkspaceTrust";
+
+test("getTrustedWorkspaceServerListFiles keeps workspace server lists in trusted workspaces", () => {
+  assert.deepEqual(
+    getTrustedWorkspaceServerListFiles(["/workspace/neo-servers.json"], true),
+    ["/workspace/neo-servers.json"]
+  );
+});
+
+test("getTrustedWorkspaceServerListFiles ignores workspace server lists in untrusted workspaces", () => {
+  assert.deepEqual(
+    getTrustedWorkspaceServerListFiles(["/workspace/neo-servers.json"], false),
+    []
+  );
+});

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListWorkspaceTrust.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListWorkspaceTrust.ts
@@ -1,0 +1,6 @@
+export default function getTrustedWorkspaceServerListFiles(
+  files: string[],
+  isTrusted: boolean
+): string[] {
+  return isTrusted ? [...files] : [];
+}


### PR DESCRIPTION
## Summary
- Treats the workspace-controlled RPC list finding as valid for untrusted workspaces.
- Keeps built-in seed RPC URLs available, but ignores `neo-servers.json` files until VS Code reports the workspace as trusted.
- Leaves trusted-workspace behavior unchanged.

## Fuzzer issue
- Partially fixes EXT-6 from the extension fuzzer findings by adding a VS Code workspace-trust boundary around custom RPC URL discovery.

## Validation
- Red test first: `node --test -r ts-node/register src/extension/fileDetectors/serverListWorkspaceTrust.test.ts` failed because the trust helper did not exist.
- `node --test -r ts-node/register src/extension/fileDetectors/serverListWorkspaceTrust.test.ts`
- `npm run test:quickstart`
- `npm run compile`

## Residual risk
- This does not add TLS pinning or change behavior for already trusted workspaces. That is a broader product/security policy decision and should not be hidden inside this small PR.
