### PR TITLE
Report unbalanced quotes in batch files

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -298,7 +298,7 @@ namespace NeoExpress.Commands
         }
 
         // SplitCommandLine method adapted from CommandLineStringSplitter class in https://github.com/dotnet/command-line-api
-        static IEnumerable<string> SplitCommandLine(string commandLine)
+        internal static IEnumerable<string> SplitCommandLine(string commandLine)
         {
             var memory = commandLine.AsMemory();
 
@@ -366,6 +366,8 @@ namespace NeoExpress.Commands
                     {
                         case Boundary.TokenStart:
                             break;
+                        case Boundary.QuoteEnd:
+                            throw new FormatException("Unbalanced quote in batch command line.");
                         default:
                             yield return CurrentToken();
                             break;

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// BatchCommandParserTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class BatchCommandParserTests
+{
+    [Fact]
+    public void SplitCommandLine_reports_unbalanced_quotes()
+    {
+        var act = () => BatchCommand.SplitCommandLine("wallet create \"alice").ToArray();
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("Unbalanced quote in batch command line.");
+    }
+
+    [Fact]
+    public void SplitCommandLine_preserves_balanced_quoted_tokens()
+    {
+        BatchCommand.SplitCommandLine("wallet create \"alice bob\"").Should()
+            .Equal("wallet", "create", "alice bob");
+    }
+}


### PR DESCRIPTION
## Summary
- Treats the batch parser fuzzer finding as a valid low-severity UX issue.
- Reports an explicit parse error when a batch command line ends inside a quoted token.
- Adds focused parser tests for the malformed and still-valid quoted-token cases.

## Fuzzer issue
- Partially fixes BATCH from the fuzzer findings: unbalanced quotes are no longer silently consumed.
- This intentionally does not redesign escaping or argument length policy in the same PR.

## Validation
- Red test first: `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter BatchCommandParserTests --no-restore` initially failed because the parser had no test-visible seam.
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter BatchCommandParserTests --no-restore`
- `dotnet build src/neoxp/neoxp.csproj --no-restore`
- `dotnet format neo-express.sln --verify-no-changes --no-restore`
