### PR TITLE
Document checkpoint zip-slip guard

### DIFF
--- a/src/bctklib/persistence/RocksDbUtility.cs
+++ b/src/bctklib/persistence/RocksDbUtility.cs
@@ -203,6 +203,8 @@ namespace Neo.BlockchainToolkit.Persistence
 
             static void ExtractCheckpoint(string checkPointArchive, string restorePath)
             {
+                // ZipFile.ExtractToDirectory rejects entries that would escape restorePath.
+                // Keep that runtime guard if this is refactored away from the framework helper.
                 ZipFile.ExtractToDirectory(checkPointArchive, restorePath);
                 var addressFile = GetAddressFilePath(restorePath);
                 if (File.Exists(addressFile))


### PR DESCRIPTION
## Summary
- Documents the runtime path-containment guarantee used when restoring checkpoint archives.
- Keeps the existing `ZipFile.ExtractToDirectory` helper visible as the security boundary for zip-slip attempts.

## Fuzzer issue
- Addresses CP-2, which was confirmed as a security non-finding: .NET rejects archive entries that would escape the destination directory.
- This is intentionally documentation-only so future refactors do not accidentally replace the safe helper with manual extraction.

## Validation
- `dotnet build src/bctklib/bctklib.csproj --no-restore`
- `dotnet format neo-express.sln --verify-no-changes --no-restore`
