### PR TITLE
Include script hash in missing contract errors

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -32,6 +32,8 @@ namespace NeoExpress.Node
 {
     internal class NodeUtility
     {
+        internal static string ContractNotFoundMessage(UInt160 scriptHash) => $"Contract {scriptHash} not found";
+
         public static Block CreateSignedBlock(Header prevHeader, IReadOnlyList<KeyPair> keyPairs, uint network, Transaction[]? transactions = null, ulong timestamp = 0)
         {
             transactions ??= Array.Empty<Transaction>();
@@ -487,7 +489,7 @@ namespace NeoExpress.Node
             if (localContract is null)
             {
                 // if localContract is null, the contract does not exist in the local Express chain
-                throw new Exception("Contract not found");
+                throw new Exception(ContractNotFoundMessage(state.Hash));
             }
 
             var overwriteStorage = force switch

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -419,7 +419,7 @@ namespace NeoExpress.Node
                 var state = NativeContract.ContractManagement.GetContract(neoSystem.StoreView, scripthash);
                 if (state is null)
                 {
-                    throw new Exception("Contract not found");
+                    throw new Exception(NodeUtility.ContractNotFoundMessage(scripthash));
                 }
 
                 return NodeUtility.PersistStorageKeyValuePair(neoSystem, state, storagePair, ContractCommand.OverwriteForce.None);

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -282,7 +282,7 @@ namespace NeoExpress.Node
             var state = await rpcClient.GetContractStateAsync(scripthash.ToString()).ConfigureAwait(false);
             if (state is null)
             {
-                throw new Exception("Contract not found");
+                throw new Exception(NodeUtility.ContractNotFoundMessage(scripthash));
             }
 
             JObject o = new JObject();

--- a/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
+++ b/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
@@ -24,6 +24,7 @@ using Neo.Wallets;
 using NeoExpress;
 using NeoExpress.Commands;
 using NeoExpress.Models;
+using NeoExpress.Node;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -111,6 +112,14 @@ public class ExpressNodeExtensionsTests
     {
         var token = TokenIdParser.Parse("0x0A0B0C");
         token.ToArray().Should().Equal(new byte[] { 0x0A, 0x0B, 0x0C });
+    }
+
+    [Fact]
+    public void ContractNotFoundMessage_includes_script_hash()
+    {
+        var scriptHash = UInt160.Parse("0x0101010101010101010101010101010101010101");
+
+        NodeUtility.ContractNotFoundMessage(scriptHash).Should().Be($"Contract {scriptHash} not found");
     }
 
     static bool ContainsSequence(ReadOnlySpan<byte> haystack, ReadOnlySpan<byte> needle)


### PR DESCRIPTION
## Summary
- include the target script hash when storage update cannot find a contract
- use the same message for offline, online, and local persistence paths
- add focused coverage for the formatted missing-contract message

## Validation
- `git diff --check`
- GitHub Actions `test / format`
- GitHub Actions `test / build (macos-latest)`, `test / build (ubuntu-latest)`, `test / build (windows-latest)`
