### PR TITLE
Wrap corrupt checkpoint archives in RocksDbUtility

### DIFF
--- a/src/bctklib/persistence/RocksDbUtility.cs
+++ b/src/bctklib/persistence/RocksDbUtility.cs
@@ -177,15 +177,22 @@ namespace Neo.BlockchainToolkit.Persistence
         public static (uint network, byte addressVersion, UInt160 scriptHash) RestoreCheckpoint(string checkPointArchive, string restorePath,
             uint? network = null, byte? addressVersion = null, UInt160? scriptHash = null)
         {
-            var metadata = GetCheckpointMetadata(checkPointArchive);
-            if (network.HasValue && network.Value != metadata.network)
-                throw new Exception($"checkpoint network ({metadata.network}) doesn't match ({network.Value})");
-            if (addressVersion.HasValue && addressVersion.Value != metadata.addressVersion)
-                throw new Exception($"checkpoint address version ({metadata.addressVersion}) doesn't match ({addressVersion.Value})");
-            if (scriptHash != null && scriptHash != metadata.scriptHash)
-                throw new Exception($"checkpoint script hash ({metadata.scriptHash}) doesn't match ({scriptHash})");
-            ExtractCheckpoint(checkPointArchive, restorePath);
-            return metadata;
+            try
+            {
+                var metadata = GetCheckpointMetadata(checkPointArchive);
+                if (network.HasValue && network.Value != metadata.network)
+                    throw new Exception($"checkpoint network ({metadata.network}) doesn't match ({network.Value})");
+                if (addressVersion.HasValue && addressVersion.Value != metadata.addressVersion)
+                    throw new Exception($"checkpoint address version ({metadata.addressVersion}) doesn't match ({addressVersion.Value})");
+                if (scriptHash != null && scriptHash != metadata.scriptHash)
+                    throw new Exception($"checkpoint script hash ({metadata.scriptHash}) doesn't match ({scriptHash})");
+                ExtractCheckpoint(checkPointArchive, restorePath);
+                return metadata;
+            }
+            catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException)
+            {
+                throw new Exception($"Checkpoint {checkPointArchive} is not a valid checkpoint archive: {ex.Message}");
+            }
 
 
             static (uint network, byte addressVersion, UInt160 scriptHash) GetCheckpointMetadata(string checkPointArchive)

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -190,15 +190,8 @@ namespace NeoExpress
 
             var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);
             var multiSigAccount = wallet.GetMultiSigAccounts().Single();
-            try
-            {
-                RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
-                    ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
-            }
-            catch (Exception ex) when (ex is System.IO.InvalidDataException or System.IO.EndOfStreamException)
-            {
-                throw new Exception($"Checkpoint {checkPointArchive} is not a valid checkpoint archive: {ex.Message}");
-            }
+            RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
+                ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
             fileSystem.Directory.Move(checkpointTempPath, nodePath);
         }
 

--- a/test/test.bctklib/ReadOnlyStoreTests.cs
+++ b/test/test.bctklib/ReadOnlyStoreTests.cs
@@ -68,6 +68,20 @@ public class ReadOnlyStoreTests : IClassFixture<CheckpointFixture>, IClassFixtur
     }
 
     [Fact]
+    public void restore_checkpoint_wraps_corrupt_archive_errors()
+    {
+        System.IO.Directory.CreateDirectory(path);
+        var checkpointPath = System.IO.Path.Combine(path, "corrupt.neoxp-checkpoint");
+        var restorePath = System.IO.Path.Combine(path, "restore");
+        System.IO.File.WriteAllText(checkpointPath, "not a zip archive");
+
+        Action restore = () => RocksDbUtility.RestoreCheckpoint(checkpointPath, restorePath);
+
+        restore.Should().Throw<Exception>()
+            .WithMessage($"Checkpoint {checkpointPath} is not a valid checkpoint archive:*");
+    }
+
+    [Fact]
     public void readonly_rocksdb_store_throws_on_write_operations()
     {
         using (var popDB = RocksDbUtility.OpenDb(path))


### PR DESCRIPTION
## Summary
- move corrupt checkpoint archive wrapping into `RocksDbUtility.RestoreCheckpoint`
- keep the restore caller focused on path and node-state checks
- add coverage for corrupt archive errors at the RocksDbUtility boundary

## Validation
- `git diff --check`
- GitHub Actions `test / format`
- GitHub Actions `test / build (macos-latest)`, `test / build (ubuntu-latest)`, `test / build (windows-latest)`
