### PR TITLE
Harden file input validation

### DIFF
--- a/src/neoxp/Commands/ExecuteCommand.cs
+++ b/src/neoxp/Commands/ExecuteCommand.cs
@@ -26,6 +26,7 @@ namespace NeoExpress.Commands
     [Command(Name = "execute", Description = "Invoke a custom script, the input text will be converted to script with a priority: hex, base64, file path.")]
     class ExecuteCommand
     {
+        internal const long MaxExecuteScriptFileBytes = 4 * 1024 * 1024;
 
         readonly ExpressChainManagerFactory chainManagerFactory;
         readonly TransactionExecutorFactory txExecutorFactory;
@@ -110,22 +111,30 @@ namespace NeoExpress.Commands
 
         private static Script? LoadFileScript(string fileName)
         {
-            var fileText = File.ReadAllText(fileName);
-            var txScript = ConvertTextToScript(fileText);
-            if (txScript != null)
-            {
-                return txScript;
-
-            }
-            var file = File.ReadAllBytes(fileName);
             try
             {
+                if (!File.Exists(fileName))
+                    return null;
+
+                var fileInfo = new FileInfo(fileName);
+                if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory ||
+                    fileInfo.Length > MaxExecuteScriptFileBytes)
+                    return null;
+
+                var fileText = File.ReadAllText(fileName);
+                var txScript = ConvertTextToScript(fileText);
+                if (txScript != null)
+                {
+                    return txScript;
+                }
+                var file = File.ReadAllBytes(fileName);
                 var nef = file.AsSerializable<NefFile>();
                 return nef?.Script;
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or FormatException or InvalidOperationException)
             {
             }
+
             return null;
         }
 

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -34,6 +34,8 @@ namespace NeoExpress
 
     class TransactionExecutor : IDisposable
     {
+        internal const long MaxOracleResponseFileBytes = 4 * 1024 * 1024;
+
         readonly ExpressChainManager chainManager;
         readonly IExpressNode expressNode;
         readonly IFileSystem fileSystem;
@@ -417,23 +419,7 @@ namespace NeoExpress
 
         public async Task OracleResponseAsync(string url, string responsePath, ulong? requestId = null)
         {
-            if (!fileSystem.File.Exists(responsePath))
-                throw new Exception($"Response File {responsePath} couldn't be found");
-
-            JObject responseJson;
-            {
-                using var stream = fileSystem.File.OpenRead(responsePath);
-                using var reader = new System.IO.StreamReader(stream);
-                using var jsonReader = new Newtonsoft.Json.JsonTextReader(reader);
-                try
-                {
-                    responseJson = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
-                }
-                catch (JsonException ex)
-                {
-                    throw new Exception($"Oracle response file {responsePath} is invalid JSON: {ex.Message}");
-                }
-            }
+            var responseJson = await LoadOracleResponseJsonAsync(fileSystem, responsePath).ConfigureAwait(false);
 
             var txHashes = await expressNode.SubmitOracleResponseAsync(url, OracleResponseCode.Success, responseJson, requestId).ConfigureAwait(false);
 
@@ -461,6 +447,61 @@ namespace NeoExpress
                         await writer.WriteLineAsync($"    {txHashes[i]}").ConfigureAwait(false);
                     }
                 }
+            }
+        }
+
+        internal static async Task<JObject> LoadOracleResponseJsonAsync(IFileSystem fileSystem, string responsePath, CancellationToken token = default)
+        {
+            if (!fileSystem.File.Exists(responsePath))
+                throw new Exception($"Response File {responsePath} couldn't be found");
+
+            var fileInfo = fileSystem.FileInfo.New(responsePath);
+            if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                throw new Exception($"Oracle response file {responsePath} is invalid: path is a directory");
+
+            if (fileInfo.Length > MaxOracleResponseFileBytes)
+                throw new Exception($"Oracle response file {responsePath} is invalid: file is larger than {MaxOracleResponseFileBytes} bytes");
+
+            try
+            {
+                using var stream = fileSystem.File.OpenRead(responsePath);
+                using var memory = new MemoryStream();
+                var buffer = new byte[8192];
+                long bytesRead = 0;
+
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                    if (read == 0)
+                        break;
+
+                    bytesRead += read;
+                    if (bytesRead > MaxOracleResponseFileBytes)
+                        throw new IOException($"file is larger than {MaxOracleResponseFileBytes} bytes");
+
+                    memory.Write(buffer, 0, read);
+                }
+
+                memory.Position = 0;
+                using var reader = new StreamReader(memory);
+                using var jsonReader = new JsonTextReader(reader);
+                return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+            }
+            catch (JsonException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid JSON: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
+            {
+                throw new Exception($"Oracle response file {responsePath} is invalid: {ex.Message}");
             }
         }
 

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -466,22 +466,8 @@ namespace NeoExpress
             {
                 using var stream = fileSystem.File.OpenRead(responsePath);
                 using var memory = new MemoryStream();
-                var buffer = new byte[8192];
-                long bytesRead = 0;
 
-                while (true)
-                {
-                    var read = await stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
-                    if (read == 0)
-                        break;
-
-                    bytesRead += read;
-                    if (bytesRead > MaxOracleResponseFileBytes)
-                        throw new IOException($"file is larger than {MaxOracleResponseFileBytes} bytes");
-
-                    memory.Write(buffer, 0, read);
-                }
-
+                await stream.CopyToAsync(memory, 81920, token).ConfigureAwait(false);
                 memory.Position = 0;
                 using var reader = new StreamReader(memory);
                 using var jsonReader = new JsonTextReader(reader);

--- a/test/test.workflowvalidation/ExecuteCommandTests.cs
+++ b/test/test.workflowvalidation/ExecuteCommandTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExecuteCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using System.Reflection;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ExecuteCommandTests
+{
+    [Fact]
+    public void LoadFileScript_returns_null_for_long_non_file_input()
+    {
+        var method = typeof(ExecuteCommand).GetMethod("LoadFileScript", BindingFlags.NonPublic | BindingFlags.Static);
+        var longInput = $"0x{new string('b', 1026)}";
+
+        var result = method!.Invoke(null, [longInput]);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void LoadFileScript_returns_null_for_oversized_file()
+    {
+        var method = typeof(ExecuteCommand).GetMethod("LoadFileScript", BindingFlags.NonPublic | BindingFlags.Static);
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.nef");
+        try
+        {
+            using (var file = File.Create(path))
+            {
+                file.SetLength(ExecuteCommand.MaxExecuteScriptFileBytes + 1);
+            }
+
+            var result = method!.Invoke(null, [path]);
+
+            result.Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/test/test.workflowvalidation/TransactionExecutorOracleResponseTests.cs
+++ b/test/test.workflowvalidation/TransactionExecutorOracleResponseTests.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TransactionExecutorOracleResponseTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class TransactionExecutorOracleResponseTests
+{
+    [Fact]
+    public async Task LoadOracleResponseJsonAsync_rejects_oversized_response_file()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), "/work");
+        fileSystem.Directory.CreateDirectory("/work");
+        var responsePath = fileSystem.Path.Combine("/work", "response.json");
+        fileSystem.AddFile(responsePath, new MockFileData(new string(' ', (int)TransactionExecutor.MaxOracleResponseFileBytes + 1)));
+
+        Func<Task> action = () => TransactionExecutor.LoadOracleResponseJsonAsync(fileSystem, responsePath, CancellationToken.None);
+
+        var exception = await action.Should().ThrowAsync<Exception>();
+        exception.Which.Message.Should().Be($"Oracle response file {responsePath} is invalid: file is larger than {TransactionExecutor.MaxOracleResponseFileBytes} bytes");
+    }
+}


### PR DESCRIPTION
## Summary
- Treat unreadable or oversized execute input files as invalid scripts instead of loading them or throwing raw file errors.
- Bound oracle response file reads before parsing local response JSON.
- Add targeted workflow validation coverage for both cases.

## Validation
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter "FullyQualifiedName~ExecuteCommandTests|FullyQualifiedName~TransactionExecutorOracleResponseTests"

Supersedes #564 and #567.