### PR TITLE
Validate extension server list entries

### DIFF
--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -343,7 +343,8 @@
     "watch": "concurrently -r npm:watch-*",
     "watch-ext": "webpack --config src/extension/webpack.config.js --mode development --watch --stats-error-details",
     "watch-panel": "webpack --config src/panel/webpack.config.js --mode development --watch --stats-error-details",
-    "test:quickstart": "node --test -r ts-node/register src/panel/components/views/quickStartActions.test.ts"
+    "test:quickstart": "node --test -r ts-node/register src/panel/components/views/quickStartActions.test.ts",
+    "test:server-list": "node --test -r ts-node/register src/extension/fileDetectors/serverListConfig.test.ts"
   },
   "devDependencies": {
     "@cityofzion/neon-core": "^5.8.1",

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListConfig.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListConfig.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import parseServerListConfig from "./serverListConfig";
+
+test("parseServerListConfig keeps only string blockchain names and RPC URLs", () => {
+  const parsed = parseServerListConfig({
+    "neo-blockchain-names": {
+      " 0xABC123 ": " MainNet ",
+      "0xdef456": { label: "TestNet" },
+      "0x789": 42,
+    },
+    "neo-rpc-uris": [
+      " https://rpc.example/ ",
+      { network: "testnet", rpcUris: ["https://test.example/"] },
+      9007199254740992,
+      "",
+      null,
+    ],
+  });
+
+  assert.deepEqual(parsed.blockchainNames, { "0xabc123": "MainNet" });
+  assert.deepEqual(parsed.rpcUrls, ["https://rpc.example/"]);
+});
+
+test("parseServerListConfig tolerates non-object top-level values", () => {
+  assert.deepEqual(parseServerListConfig(null), {
+    blockchainNames: {},
+    rpcUrls: [],
+  });
+  assert.deepEqual(parseServerListConfig(9007199254740992), {
+    blockchainNames: {},
+    rpcUrls: [],
+  });
+});

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListConfig.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListConfig.ts
@@ -1,0 +1,44 @@
+type ServerListConfig = {
+  blockchainNames: { [genesisHash: string]: string };
+  rpcUrls: string[];
+};
+
+function isRecord(value: unknown): value is { [key: string]: unknown } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim() : undefined;
+}
+
+export default function parseServerListConfig(contents: unknown): ServerListConfig {
+  const blockchainNames: { [genesisHash: string]: string } = {};
+  const rpcUrls: string[] = [];
+
+  if (!isRecord(contents)) {
+    return { blockchainNames, rpcUrls };
+  }
+
+  const configuredNames = contents["neo-blockchain-names"];
+  if (isRecord(configuredNames)) {
+    for (const [genesisHash, rawName] of Object.entries(configuredNames)) {
+      const normalizedHash = genesisHash.toLowerCase().trim();
+      const name = normalizeString(rawName);
+      if (normalizedHash && name) {
+        blockchainNames[normalizedHash] = name;
+      }
+    }
+  }
+
+  const configuredRpcUrls = contents["neo-rpc-uris"];
+  if (Array.isArray(configuredRpcUrls)) {
+    for (const rawUrl of configuredRpcUrls) {
+      const url = normalizeString(rawUrl);
+      if (url) {
+        rpcUrls.push(url);
+      }
+    }
+  }
+
+  return { blockchainNames, rpcUrls };
+}

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
@@ -8,6 +8,7 @@ import IoHelpers from "../util/ioHelpers";
 import JSONC from "../util/JSONC";
 import Log from "../util/log";
 import posixPath from "../util/posixPath";
+import parseServerListConfig from "./serverListConfig";
 import getTrustedWorkspaceServerListFiles from "./serverListWorkspaceTrust";
 
 const LOG_PREFIX = "ServerListDetector";
@@ -121,41 +122,36 @@ export default class ServerListDetector extends DetectorBase {
         const contents = JSONC.parse(
           (await fs.promises.readFile(file)).toString()
         );
-        const blockchainNamesThisFile = contents["neo-blockchain-names"];
-        if (blockchainNamesThisFile) {
-          for (let gensisBlockHash of Object.getOwnPropertyNames(
-            blockchainNamesThisFile
-          )) {
-            gensisBlockHash = gensisBlockHash.toLowerCase().trim();
-            const name = blockchainNamesThisFile[gensisBlockHash]?.trim();
-            if (!blockchainNames[gensisBlockHash] && name) {
-              blockchainNames[gensisBlockHash] = name;
-            }
+        const serverListConfig = parseServerListConfig(contents);
+        for (const gensisBlockHash of Object.getOwnPropertyNames(
+          serverListConfig.blockchainNames
+        )) {
+          if (!blockchainNames[gensisBlockHash]) {
+            blockchainNames[gensisBlockHash] =
+              serverListConfig.blockchainNames[gensisBlockHash];
           }
         }
-        const rpcUrlsThisFile = contents["neo-rpc-uris"];
-        if (rpcUrlsThisFile && Array.isArray(rpcUrlsThisFile)) {
-          for (const url of rpcUrlsThisFile) {
-            try {
-              const parsedUrl = vscode.Uri.parse(url, true);
-              if (parsedUrl.scheme === "http" || parsedUrl.scheme === "https") {
-                rpcUrls[url] = true;
-              } else {
-                Log.log(
-                  LOG_PREFIX,
-                  "Ignoring malformed URL (bad scheme)",
-                  url,
-                  file
-                );
-              }
-            } catch (e : any) {
+
+        for (const url of serverListConfig.rpcUrls) {
+          try {
+            const parsedUrl = vscode.Uri.parse(url, true);
+            if (parsedUrl.scheme === "http" || parsedUrl.scheme === "https") {
+              rpcUrls[url] = true;
+            } else {
               Log.log(
                 LOG_PREFIX,
-                "Ignoring malformed URL (parse error)",
+                "Ignoring malformed URL (bad scheme)",
                 url,
                 file
               );
             }
+          } catch (e : any) {
+            Log.log(
+              LOG_PREFIX,
+              "Ignoring malformed URL (parse error)",
+              url,
+              file
+            );
           }
         }
       } catch (e : any) {


### PR DESCRIPTION
## Summary
- Ignore malformed neo-servers.json blockchain names and RPC URLs instead of letting them break extension startup.
- Keep valid configured entries and built-in seed URLs available.
- Add focused server-list parsing coverage.

## Validation
- npm run typecheck
- npm run compile
- npm run lint
- npm run test:quickstart
- npm run test:server-list
- node --test -r ts-node/register src/extension/fileDetectors/serverListWorkspaceTrust.test.ts

Supersedes #569.