### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -84,12 +84,12 @@ jobs:
 
       - name: Setup .NET Core
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Nerdbank.GitVersioning
-        uses: dotnet/nbgv@v0.4.2
+        uses: dotnet/nbgv@v0.5.1
         id: nbgv
 
       - name: Restore dependencies

--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v6.0.2
 
     - name: Setup Node
-      uses: actions/setup-node@v6.2.0
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: '22'
         cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: '10.0.x'
 
     - name: Nerdbank.GitVersioning
-      uses: dotnet/nbgv@v0.4.2
+      uses: dotnet/nbgv@v0.5.1
       id: nbgv
 
     - name: Install dependencies
@@ -42,43 +42,43 @@ jobs:
     #     path: ./out
 
     - name: Get Cache Files (osx-x64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: osx-x64
 
     - name: Get Cache Files (osx-arm64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: osx-arm64
 
     - name: Get Cache Files (linux-x64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: linux-x64
 
     - name: Get Cache Files (linux-arm64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: linux-arm64
 
     - name: Get Cache Files (linux-musl-arm64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: linux-musl-arm64
 
     - name: Get Cache Files (win-x64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: win-x64
 
     - name: Get Cache Files (win-arm64)
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: /tmp/dist/*
         key: win-arm64

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -24,12 +24,12 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Nerdbank.GitVersioning
-      uses: dotnet/nbgv@v0.4.2
+      uses: dotnet/nbgv@v0.5.1
       id: nbgv
 
     - name: Build (${{ matrix.runtime }})
@@ -80,7 +80,7 @@ jobs:
 
     - name: Cache Files
       id: cache
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5.0.5
       with:
         path: ${{ env.DIST_PATH }}/*
         key: ${{ matrix.runtime }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -45,12 +45,12 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Nerdbank.GitVersioning
-      uses: dotnet/nbgv@v0.4.2
+      uses: dotnet/nbgv@v0.5.1
       id: nbgv
 
     - name: Restore

--- a/.github/workflows/vse-release.yml
+++ b/.github/workflows/vse-release.yml
@@ -15,16 +15,16 @@ jobs:
     - uses: actions/checkout@v6.0.2
 
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: '10.0.x'
 
     - name: Setup Nerdbank.GitVersioning
-      uses: dotnet/nbgv@v0.4.2
+      uses: dotnet/nbgv@v0.5.1
       id: nbgv
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v6.2.0
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: '16'
 
@@ -36,7 +36,7 @@ jobs:
         EXTENSION_VERSION: ${{ steps.nbgv.outputs.NpmPackageVersion }}
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         prerelease: ${{ contains(steps.nbgv.outputs.NpmPackageVersion, '-preview') }}


### PR DESCRIPTION
## Summary

Updates GitHub Actions

## Changes

- Updated `actions/setup-dotnet` from `v5.1.0` to `v5.2.0`.
- Updated `dotnet/nbgv` from `v0.4.2` to `v0.5.1`.
- Updated `actions/setup-node` from `v6.2.0` to `v6.4.0`.
- Updated `actions/cache` from `v5.0.3` to `v5.0.5`.
- Updated `softprops/action-gh-release` from `v2` to `v3`.