### PR TITLE
Fix contract storage equality check

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -452,28 +452,29 @@ namespace NeoExpress.Node
                     && a.Manifest.ToJson().ToByteArray(false).SequenceEqual(b.Manifest.ToJson().ToByteArray(false));
             }
 
-            static bool ContractStorageEquals(int contractId, DataCache snapshot, IReadOnlyList<(string key, string value)> storagePairs)
+        }
+
+        internal static bool ContractStorageEquals(int contractId, DataCache snapshot, IReadOnlyList<(string key, string value)> storagePairs)
+        {
+            IReadOnlyDictionary<string, string> storagePairMap = storagePairs.ToDictionary(p => p.key, p => p.value);
+            var storageCount = 0;
+
+            byte[] prefixKey = StorageKey.CreateSearchPrefix(contractId, default);
+            foreach (var (k, v) in snapshot.Find(prefixKey))
             {
-                IReadOnlyDictionary<string, string> storagePairMap = storagePairs.ToDictionary(p => p.key, p => p.value);
-                var storageCount = 0;
-
-                byte[] prefixKey = StorageKey.CreateSearchPrefix(contractId, default);
-                foreach (var (k, v) in snapshot.Find(prefixKey))
+                var storageKey = Convert.ToBase64String(k.Key.Span);
+                if (storagePairMap.TryGetValue(storageKey, out var storageValue)
+                    && storageValue.Equals(Convert.ToBase64String(v.Value.Span)))
                 {
-                    var storageKey = Convert.ToBase64String(k.Key.Span);
-                    if (storagePairMap.TryGetValue(storageKey, out var storageValue)
-                        && storageValue.Equals(Convert.ToBase64String(v.Value.Span)))
-                    {
-                        storageCount++;
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    storageCount++;
                 }
-
-                return storageCount != storagePairs.Count;
+                else
+                {
+                    return false;
+                }
             }
+
+            return storageCount == storagePairs.Count;
         }
 
         public static int PersistStorageKeyValuePair(NeoSystem neoSystem, ContractState state,

--- a/test/test.workflowvalidation/ContractStorageEqualityTests.cs
+++ b/test/test.workflowvalidation/ContractStorageEqualityTests.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractStorageEqualityTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract;
+using NeoExpress.Node;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractStorageEqualityTests
+{
+    const int ContractId = 1;
+
+    [Fact]
+    public void ContractStorageEquals_returns_true_for_identical_storage()
+    {
+        var storagePairs = new[]
+        {
+            CreateStoragePair([0x01], [0x02]),
+            CreateStoragePair([0x03], [0x04]),
+        };
+
+        using var store = new MemoryStore();
+        using var snapshot = new StoreCache(store.GetSnapshot());
+        PersistStoragePairs(snapshot, ContractId, storagePairs);
+
+        NodeUtility.ContractStorageEquals(ContractId, snapshot, storagePairs)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContractStorageEquals_returns_false_when_downloaded_storage_has_extra_entries()
+    {
+        var localStoragePairs = new[]
+        {
+            CreateStoragePair([0x01], [0x02]),
+        };
+        var downloadedStoragePairs = new[]
+        {
+            CreateStoragePair([0x01], [0x02]),
+            CreateStoragePair([0x03], [0x04]),
+        };
+
+        using var store = new MemoryStore();
+        using var snapshot = new StoreCache(store.GetSnapshot());
+        PersistStoragePairs(snapshot, ContractId, localStoragePairs);
+
+        NodeUtility.ContractStorageEquals(ContractId, snapshot, downloadedStoragePairs)
+            .Should().BeFalse();
+    }
+
+    static (string key, string value) CreateStoragePair(byte[] key, byte[] value)
+    {
+        return (Convert.ToBase64String(key), Convert.ToBase64String(value));
+    }
+
+    static void PersistStoragePairs(DataCache snapshot, int contractId, IReadOnlyList<(string key, string value)> storagePairs)
+    {
+        foreach (var (key, value) in storagePairs)
+        {
+            snapshot.Add(
+                new StorageKey { Id = contractId, Key = Convert.FromBase64String(key) },
+                new StorageItem(Convert.FromBase64String(value)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix contract download storage equality so identical storage is accepted without force
- Reject downloaded storage when the local contract is missing storage entries
- Add workflow validation coverage for matching and missing storage cases

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter ContractStorageEqualityTests
- dotnet build src/neoxp/neoxp.csproj -c Release
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter NeoxpToolIntegrationTests

Note: the first full workflow validation run failed because the Release build output was missing for the --no-build tool packaging tests. After building Release, the affected NeoxpToolIntegrationTests passed.