### PR TITLE
Accept all WIF private key prefixes

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -331,7 +331,7 @@ namespace NeoExpress.Commands
                     [Option(Description = "Overwrite existing data")]
                     internal bool Force { get; }
 
-                    [Option(Description = "Private key for account (Format: HEX or WIF)\nDefault: Random")]
+                    [Option(Description = "Private key for account (Format: HEX, Base64, or WIF)\nDefault: Random")]
                     internal string PrivateKey { get; set; } = string.Empty;
                 }
             }

--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -60,17 +60,7 @@ namespace NeoExpress.Commands
                 byte[]? priKey = null;
                 if (string.IsNullOrEmpty(PrivateKey) == false)
                 {
-                    try
-                    {
-                        if (PrivateKey.StartsWith('L'))
-                            priKey = Neo.Wallets.Wallet.GetPrivateKeyFromWIF(PrivateKey);
-                        else
-                            priKey = Convert.FromHexString(PrivateKey);
-                    }
-                    catch (FormatException)
-                    {
-                        throw new FormatException("Private key must be in HEX or WIF format.");
-                    }
+                    priKey = ExpressChainManager.ParsePrivateKey(PrivateKey);
                 }
 
                 var (chainManager, outputPath) = chainManagerFactory.CreateChain(Count, AddressVersion, Output, Force, privateKey: priKey);

--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -42,7 +42,7 @@ namespace NeoExpress.Commands
         [Option(Description = "Overwrite existing data")]
         internal bool Force { get; set; }
 
-        [Option(Description = "Private key for default dev account (Format: HEX or WIF)\nDefault: Random")]
+        [Option(Description = "Private key for default dev account (Format: HEX, Base64, or WIF)\nDefault: Random")]
         internal string PrivateKey { get; set; } = string.Empty;
 
         [Option(Description = "Use a batch file to initialize the blockchain after creation.")]

--- a/src/neoxp/Commands/WalletCommand.Create.cs
+++ b/src/neoxp/Commands/WalletCommand.Create.cs
@@ -37,7 +37,7 @@ namespace NeoExpress.Commands
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
-            [Option(Description = "Private key for account (Format: HEX or WIF)\nDefault: Random")]
+            [Option(Description = "Private key for account (Format: HEX, Base64, or WIF)\nDefault: Random")]
             internal string PrivateKey { get; set; } = string.Empty;
 
             internal int OnExecute(CommandLineApplication app, IConsole console)

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -105,6 +105,7 @@ namespace NeoExpress
 
         static bool TryParseHexPrivateKey(string text, [NotNullWhen(true)] out byte[]? privateKey)
         {
+            text = TrimHexPrefix(text);
             if (text.Length != PrivateKeyLength * 2)
             {
                 privateKey = null;
@@ -123,6 +124,9 @@ namespace NeoExpress
             privateKey = null;
             return false;
         }
+
+        static string TrimHexPrefix(string text)
+            => text.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? text[2..] : text;
 
         private string ResolveCheckpointFileName(string path) => ResolveCheckpointFileName(fileSystem, path);
 

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -50,6 +50,25 @@ namespace NeoExpress
 
         public ExpressChain Chain => chain;
 
+        internal static byte[] ParsePrivateKey(string privateKey)
+        {
+            try
+            {
+                return Neo.Wallets.Wallet.GetPrivateKeyFromWIF(privateKey);
+            }
+            catch (FormatException)
+            {
+                try
+                {
+                    return Convert.FromHexString(privateKey);
+                }
+                catch (FormatException)
+                {
+                    throw new FormatException("Private key must be in HEX or WIF format.");
+                }
+            }
+        }
+
         private string ResolveCheckpointFileName(string path) => ResolveCheckpointFileName(fileSystem, path);
 
         internal static string ResolveCheckpointFileName(IFileSystem fileSystem, string path)
@@ -424,17 +443,7 @@ namespace NeoExpress
             byte[]? priKey = null;
             if (string.IsNullOrEmpty(privateKey) == false)
             {
-                try
-                {
-                    if (privateKey.StartsWith('L'))
-                        priKey = Neo.Wallets.Wallet.GetPrivateKeyFromWIF(privateKey);
-                    else
-                        priKey = Convert.FromHexString(privateKey);
-                }
-                catch (FormatException)
-                {
-                    throw new FormatException("Private key must be in HEX or WIF format.");
-                }
+                priKey = ParsePrivateKey(privateKey);
             }
 
             var wallet = new DevWallet(ProtocolSettings, name);

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -20,6 +20,7 @@ using Neo.Plugins.RpcServer;
 using NeoExpress.Models;
 using NeoExpress.Node;
 using Nito.Disposables;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using System.Net;
 
@@ -50,23 +51,77 @@ namespace NeoExpress
 
         public ExpressChain Chain => chain;
 
+        private const int PrivateKeyLength = 32;
+
         internal static byte[] ParsePrivateKey(string privateKey)
         {
+            if (TryParseBase64PrivateKey(privateKey, out var privateKeyBytes)
+                || TryParseWifPrivateKey(privateKey, out privateKeyBytes)
+                || TryParseHexPrivateKey(privateKey, out privateKeyBytes))
+            {
+                return privateKeyBytes;
+            }
+
+            throw new FormatException("Private key must be in HEX, Base64, or WIF format.");
+        }
+
+        static bool TryParseBase64PrivateKey(string text, [NotNullWhen(true)] out byte[]? privateKey)
+        {
+            var buffer = new byte[PrivateKeyLength];
+            if (Convert.TryFromBase64String(text, buffer, out var bytesWritten)
+                && bytesWritten == PrivateKeyLength)
+            {
+                privateKey = buffer;
+                return true;
+            }
+
+            privateKey = null;
+            return false;
+        }
+
+        static bool TryParseWifPrivateKey(string text, [NotNullWhen(true)] out byte[]? privateKey)
+        {
+            if (text.Length is not (51 or 52))
+            {
+                privateKey = null;
+                return false;
+            }
+
             try
             {
-                return Neo.Wallets.Wallet.GetPrivateKeyFromWIF(privateKey);
+                privateKey = Neo.Wallets.Wallet.GetPrivateKeyFromWIF(text);
+                if (privateKey.Length == PrivateKeyLength)
+                {
+                    return true;
+                }
             }
             catch (FormatException)
             {
-                try
-                {
-                    return Convert.FromHexString(privateKey);
-                }
-                catch (FormatException)
-                {
-                    throw new FormatException("Private key must be in HEX or WIF format.");
-                }
             }
+
+            privateKey = null;
+            return false;
+        }
+
+        static bool TryParseHexPrivateKey(string text, [NotNullWhen(true)] out byte[]? privateKey)
+        {
+            if (text.Length != PrivateKeyLength * 2)
+            {
+                privateKey = null;
+                return false;
+            }
+
+            try
+            {
+                privateKey = Convert.FromHexString(text);
+                return true;
+            }
+            catch (FormatException)
+            {
+            }
+
+            privateKey = null;
+            return false;
         }
 
         private string ResolveCheckpointFileName(string path) => ResolveCheckpointFileName(fileSystem, path);

--- a/test/test.workflowvalidation/PrivateKeyParsingTests.cs
+++ b/test/test.workflowvalidation/PrivateKeyParsingTests.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// PrivateKeyParsingTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.Extensions;
+using Neo.Wallets;
+using NeoExpress;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class PrivateKeyParsingTests
+{
+    [Fact]
+    public void CreateWallet_accepts_k_prefixed_wif_private_key()
+    {
+        var wif = CreateWifWithPrefix('K', out var privateKey);
+        var chain = ExpressChainManagerFactory.CreateChain(1, null);
+        var manager = new ExpressChainManager(new MockFileSystem(), chain);
+
+        var wallet = manager.CreateWallet("alice", wif);
+
+        wallet.Accounts.Should().ContainSingle();
+        wallet.Accounts[0].PrivateKey.HexToBytes().Should().Equal(privateKey);
+    }
+
+    static string CreateWifWithPrefix(char prefix, out byte[] privateKey)
+    {
+        for (var seed = 1; seed < byte.MaxValue; seed++)
+        {
+            privateKey = Enumerable.Repeat((byte)seed, 32).ToArray();
+            var wif = new KeyPair(privateKey).Export();
+            if (wif[0] == prefix)
+            {
+                return wif;
+            }
+        }
+
+        throw new InvalidOperationException($"Could not create a WIF key with {prefix} prefix");
+    }
+}

--- a/test/test.workflowvalidation/PrivateKeyParsingTests.cs
+++ b/test/test.workflowvalidation/PrivateKeyParsingTests.cs
@@ -36,7 +36,6 @@ public class PrivateKeyParsingTests
     {
         var privateKey = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
         var text = Convert.ToBase64String(privateKey);
-
         var parsed = ExpressChainManager.ParsePrivateKey(text);
 
         parsed.Should().Equal(privateKey);
@@ -48,7 +47,6 @@ public class PrivateKeyParsingTests
     public void ParsePrivateKeyRejectsWrongLengthBase64PrivateKey(int length)
     {
         var text = Convert.ToBase64String(Enumerable.Repeat((byte)1, length).ToArray());
-
         var parse = () => ExpressChainManager.ParsePrivateKey(text);
 
         parse.Should().Throw<FormatException>();
@@ -60,7 +58,6 @@ public class PrivateKeyParsingTests
     public void ParsePrivateKeyRejectsWrongLengthHexPrivateKey(int length)
     {
         var text = Convert.ToHexString(Enumerable.Repeat((byte)1, length).ToArray());
-
         var parse = () => ExpressChainManager.ParsePrivateKey(text);
 
         parse.Should().Throw<FormatException>();

--- a/test/test.workflowvalidation/PrivateKeyParsingTests.cs
+++ b/test/test.workflowvalidation/PrivateKeyParsingTests.cs
@@ -25,7 +25,6 @@ public class PrivateKeyParsingTests
         var wif = CreateWifWithPrefix('K', out var privateKey);
         var chain = ExpressChainManagerFactory.CreateChain(1, null);
         var manager = new ExpressChainManager(new MockFileSystem(), chain);
-
         var wallet = manager.CreateWallet("alice", wif);
 
         wallet.Accounts.Should().ContainSingle();

--- a/test/test.workflowvalidation/PrivateKeyParsingTests.cs
+++ b/test/test.workflowvalidation/PrivateKeyParsingTests.cs
@@ -42,6 +42,19 @@ public class PrivateKeyParsingTests
     }
 
     [Theory]
+    [InlineData("")]
+    [InlineData("0x")]
+    [InlineData("0X")]
+    public void ParsePrivateKeyAcceptsHexPrivateKeyWithOptionalPrefix(string prefix)
+    {
+        var privateKey = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+        var text = $"{prefix}{Convert.ToHexString(privateKey)}";
+        var parsed = ExpressChainManager.ParsePrivateKey(text);
+
+        parsed.Should().Equal(privateKey);
+    }
+
+    [Theory]
     [InlineData(31)]
     [InlineData(33)]
     public void ParsePrivateKeyRejectsWrongLengthBase64PrivateKey(int length)

--- a/test/test.workflowvalidation/PrivateKeyParsingTests.cs
+++ b/test/test.workflowvalidation/PrivateKeyParsingTests.cs
@@ -20,7 +20,7 @@ namespace test.workflowvalidation;
 public class PrivateKeyParsingTests
 {
     [Fact]
-    public void CreateWallet_accepts_k_prefixed_wif_private_key()
+    public void CreateWalletAcceptsKPrefixedWifPrivateKey()
     {
         var wif = CreateWifWithPrefix('K', out var privateKey);
         var chain = ExpressChainManagerFactory.CreateChain(1, null);
@@ -29,6 +29,41 @@ public class PrivateKeyParsingTests
 
         wallet.Accounts.Should().ContainSingle();
         wallet.Accounts[0].PrivateKey.HexToBytes().Should().Equal(privateKey);
+    }
+
+    [Fact]
+    public void ParsePrivateKeyAcceptsBase64PrivateKey()
+    {
+        var privateKey = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+        var text = Convert.ToBase64String(privateKey);
+
+        var parsed = ExpressChainManager.ParsePrivateKey(text);
+
+        parsed.Should().Equal(privateKey);
+    }
+
+    [Theory]
+    [InlineData(31)]
+    [InlineData(33)]
+    public void ParsePrivateKeyRejectsWrongLengthBase64PrivateKey(int length)
+    {
+        var text = Convert.ToBase64String(Enumerable.Repeat((byte)1, length).ToArray());
+
+        var parse = () => ExpressChainManager.ParsePrivateKey(text);
+
+        parse.Should().Throw<FormatException>();
+    }
+
+    [Theory]
+    [InlineData(31)]
+    [InlineData(33)]
+    public void ParsePrivateKeyRejectsWrongLengthHexPrivateKey(int length)
+    {
+        var text = Convert.ToHexString(Enumerable.Repeat((byte)1, length).ToArray());
+
+        var parse = () => ExpressChainManager.ParsePrivateKey(text);
+
+        parse.Should().Throw<FormatException>();
     }
 
     static string CreateWifWithPrefix(char prefix, out byte[] privateKey)


### PR DESCRIPTION
## Summary
- Parse private key options as WIF before falling back to HEX
- Share private key parsing between create and wallet create flows
- Add coverage for K-prefixed WIF private keys

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter PrivateKeyParsingTests
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal
- dotnet build neo-express.sln --configuration Release