### PR TITLE
Copy snapshot pending write buffers

### DIFF
--- a/src/bctklib/persistence/PersistentTrackingStore.Snapshot.cs
+++ b/src/bctklib/persistence/PersistentTrackingStore.Snapshot.cs
@@ -125,8 +125,7 @@ namespace Neo.BlockchainToolkit.Persistence
             {
                 if (snapshot.Handle == IntPtr.Zero)
                     throw new ObjectDisposedException(nameof(Snapshot));
-                if (value is null)
-                    throw new NullReferenceException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value, nameof(value));
 
                 var keyBytes = key?.AsSpan().ToArray() ?? Array.Empty<byte>();
                 var valueBytes = value.AsSpan().ToArray();

--- a/src/bctklib/persistence/PersistentTrackingStore.Snapshot.cs
+++ b/src/bctklib/persistence/PersistentTrackingStore.Snapshot.cs
@@ -128,30 +128,31 @@ namespace Neo.BlockchainToolkit.Persistence
                 if (value is null)
                     throw new NullReferenceException(nameof(value));
 
-                key ??= Array.Empty<byte>();
+                var keyBytes = key?.AsSpan().ToArray() ?? Array.Empty<byte>();
+                var valueBytes = value.AsSpan().ToArray();
 
                 // Track the change in uncommitted changes
-                uncommittedChanges = uncommittedChanges.SetItem(key, (ReadOnlyMemory<byte>)value);
+                uncommittedChanges = uncommittedChanges.SetItem(keyBytes, (ReadOnlyMemory<byte>)valueBytes);
 
-                writeBatch.PutVector(columnFamily, key, UPDATED_PREFIX, value);
+                writeBatch.PutVector(columnFamily, keyBytes, UPDATED_PREFIX, valueBytes);
             }
 
             public void Delete(byte[]? key)
             {
                 if (snapshot.Handle == IntPtr.Zero)
                     throw new ObjectDisposedException(nameof(Snapshot));
-                key ??= Array.Empty<byte>();
+                var keyBytes = key?.AsSpan().ToArray() ?? Array.Empty<byte>();
 
                 // Track the deletion in uncommitted changes
-                uncommittedChanges = uncommittedChanges.SetItem(key, default(None));
+                uncommittedChanges = uncommittedChanges.SetItem(keyBytes, default(None));
 
-                if (store.Contains(key))
+                if (store.Contains(keyBytes))
                 {
-                    writeBatch.Put(key.AsSpan(), DELETED_PREFIX.Span, columnFamily);
+                    writeBatch.Put(keyBytes.AsSpan(), DELETED_PREFIX.Span, columnFamily);
                 }
                 else
                 {
-                    writeBatch.Delete(key, columnFamily);
+                    writeBatch.Delete(keyBytes, columnFamily);
                 }
             }
 

--- a/src/bctklib/persistence/RocksDbStore.Snapshot.cs
+++ b/src/bctklib/persistence/RocksDbStore.Snapshot.cs
@@ -102,16 +102,19 @@ namespace Neo.BlockchainToolkit.Persistence
             {
                 if (snapshot.Handle == IntPtr.Zero)
                     throw new ObjectDisposedException(nameof(Snapshot));
-                var keyBytes = key ?? Array.Empty<byte>();
-                writeBatch.Put(keyBytes, value, columnFamily);
-                pendingWrites[keyBytes] = value;
+                ArgumentNullException.ThrowIfNull(value, nameof(value));
+
+                var keyBytes = key?.AsSpan().ToArray() ?? Array.Empty<byte>();
+                var valueBytes = value.AsSpan().ToArray();
+                writeBatch.Put(keyBytes, valueBytes, columnFamily);
+                pendingWrites[keyBytes] = valueBytes;
             }
 
             public void Delete(byte[]? key)
             {
                 if (snapshot.Handle == IntPtr.Zero)
                     throw new ObjectDisposedException(nameof(Snapshot));
-                var keyBytes = key ?? Array.Empty<byte>();
+                var keyBytes = key?.AsSpan().ToArray() ?? Array.Empty<byte>();
                 writeBatch.Delete(keyBytes, columnFamily);
                 pendingWrites[keyBytes] = null; // null indicates deletion
             }

--- a/test/test.bctklib/ReadWriteStoreTests.cs
+++ b/test/test.bctklib/ReadWriteStoreTests.cs
@@ -255,6 +255,79 @@ public class ReadWriteStoreTests : IDisposable
         retrievedValue.Should().BeEquivalentTo(Bytes("test-value"));
     }
 
+    [Fact]
+    public void rocksdb_snapshot_key_instance_isolation()
+    {
+        using var store = GetStore(StoreType.RocksDb);
+        test_snapshot_key_instance_isolation(store);
+    }
+
+    internal static void test_snapshot_key_instance_isolation(IStore store)
+    {
+        var key = Bytes(0);
+        var value = Bytes("test-value");
+
+        using var snapshot = store.GetSnapshot();
+        snapshot.Put(key, value);
+
+        key[0] = 0xff;
+        snapshot.TryGet(Bytes(0), out var snapshotValue).Should().BeTrue();
+        snapshotValue.Should().BeEquivalentTo(value);
+
+        snapshot.Commit();
+        store.TryGet(Bytes(0), out var committedValue).Should().BeTrue();
+        committedValue.Should().BeEquivalentTo(value);
+    }
+
+    [Fact]
+    public void rocksdb_snapshot_value_instance_isolation()
+    {
+        using var store = GetStore(StoreType.RocksDb);
+        test_snapshot_value_instance_isolation(store);
+    }
+
+    internal static void test_snapshot_value_instance_isolation(IStore store)
+    {
+        var key = Bytes(0);
+        var value = Bytes("test-value");
+        var expected = Bytes("test-value");
+
+        using var snapshot = store.GetSnapshot();
+        snapshot.Put(key, value);
+
+        value[0] = 0xff;
+        snapshot.TryGet(key, out var snapshotValue).Should().BeTrue();
+        snapshotValue.Should().BeEquivalentTo(expected);
+
+        snapshot.Commit();
+        store.TryGet(key, out var committedValue).Should().BeTrue();
+        committedValue.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void rocksdb_snapshot_delete_key_instance_isolation()
+    {
+        using var store = GetStore(StoreType.RocksDb);
+        test_snapshot_delete_key_instance_isolation(store);
+    }
+
+    internal static void test_snapshot_delete_key_instance_isolation(IStore store, int index = 0)
+    {
+        var (key, _) = TestData.ElementAt(index);
+        var expectedKey = key.ToArray();
+
+        using var snapshot = store.GetSnapshot();
+        snapshot.Delete(key);
+
+        key[0] = 0xff;
+        snapshot.TryGet(expectedKey, out var snapshotValue).Should().BeFalse();
+        snapshotValue.Should().BeNull();
+
+        snapshot.Commit();
+        store.TryGet(expectedKey, out var committedValue).Should().BeFalse();
+        committedValue.Should().BeNull();
+    }
+
     [Theory, CombinatorialData]
     public void put_null_value_throws(StoreType storeType)
     {

--- a/test/test.bctklib/ReadWriteStoreTests.cs
+++ b/test/test.bctklib/ReadWriteStoreTests.cs
@@ -256,13 +256,13 @@ public class ReadWriteStoreTests : IDisposable
     }
 
     [Fact]
-    public void rocksdb_snapshot_key_instance_isolation()
+    public void RocksDbSnapshotKeyInstanceIsolation()
     {
         using var store = GetStore(StoreType.RocksDb);
-        test_snapshot_key_instance_isolation(store);
+        TestSnapshotKeyInstanceIsolation(store);
     }
 
-    internal static void test_snapshot_key_instance_isolation(IStore store)
+    internal static void TestSnapshotKeyInstanceIsolation(IStore store)
     {
         var key = Bytes(0);
         var value = Bytes("test-value");
@@ -280,13 +280,13 @@ public class ReadWriteStoreTests : IDisposable
     }
 
     [Fact]
-    public void rocksdb_snapshot_value_instance_isolation()
+    public void RocksDbSnapshotValueInstanceIsolation()
     {
         using var store = GetStore(StoreType.RocksDb);
-        test_snapshot_value_instance_isolation(store);
+        TestSnapshotValueInstanceIsolation(store);
     }
 
-    internal static void test_snapshot_value_instance_isolation(IStore store)
+    internal static void TestSnapshotValueInstanceIsolation(IStore store)
     {
         var key = Bytes(0);
         var value = Bytes("test-value");
@@ -305,13 +305,13 @@ public class ReadWriteStoreTests : IDisposable
     }
 
     [Fact]
-    public void rocksdb_snapshot_delete_key_instance_isolation()
+    public void RocksDbSnapshotDeleteKeyInstanceIsolation()
     {
         using var store = GetStore(StoreType.RocksDb);
-        test_snapshot_delete_key_instance_isolation(store);
+        TestSnapshotDeleteKeyInstanceIsolation(store);
     }
 
-    internal static void test_snapshot_delete_key_instance_isolation(IStore store, int index = 0)
+    internal static void TestSnapshotDeleteKeyInstanceIsolation(IStore store, int index = 0)
     {
         var (key, _) = TestData.ElementAt(index);
         var expectedKey = key.ToArray();

--- a/test/test.bctklib/TrackingStoreTests.cs
+++ b/test/test.bctklib/TrackingStoreTests.cs
@@ -193,24 +193,24 @@ public class TrackingStoreTests : IDisposable
     }
 
     [Theory, CombinatorialData]
-    public void snapshot_key_instance_isolation(StoreType storeType)
+    public void SnapshotKeyInstanceIsolation(StoreType storeType)
     {
         using var store = GetStore(storeType);
-        test_snapshot_key_instance_isolation(store);
+        TestSnapshotKeyInstanceIsolation(store);
     }
 
     [Theory, CombinatorialData]
-    public void snapshot_value_instance_isolation(StoreType storeType)
+    public void SnapshotValueInstanceIsolation(StoreType storeType)
     {
         using var store = GetStore(storeType);
-        test_snapshot_value_instance_isolation(store);
+        TestSnapshotValueInstanceIsolation(store);
     }
 
     [Theory, CombinatorialData]
-    public void snapshot_delete_key_instance_isolation(StoreType storeType, [CombinatorialValues(0, 1, 5)] int index)
+    public void SnapshotDeleteKeyInstanceIsolation(StoreType storeType, [CombinatorialValues(0, 1, 5)] int index)
     {
         using var store = GetStore(storeType);
-        test_snapshot_delete_key_instance_isolation(store, index);
+        TestSnapshotDeleteKeyInstanceIsolation(store, index);
     }
 
     [Theory, CombinatorialData]

--- a/test/test.bctklib/TrackingStoreTests.cs
+++ b/test/test.bctklib/TrackingStoreTests.cs
@@ -193,6 +193,27 @@ public class TrackingStoreTests : IDisposable
     }
 
     [Theory, CombinatorialData]
+    public void snapshot_key_instance_isolation(StoreType storeType)
+    {
+        using var store = GetStore(storeType);
+        test_snapshot_key_instance_isolation(store);
+    }
+
+    [Theory, CombinatorialData]
+    public void snapshot_value_instance_isolation(StoreType storeType)
+    {
+        using var store = GetStore(storeType);
+        test_snapshot_value_instance_isolation(store);
+    }
+
+    [Theory, CombinatorialData]
+    public void snapshot_delete_key_instance_isolation(StoreType storeType, [CombinatorialValues(0, 1, 5)] int index)
+    {
+        using var store = GetStore(storeType);
+        test_snapshot_delete_key_instance_isolation(store, index);
+    }
+
+    [Theory, CombinatorialData]
     public void put_null_value_throws(StoreType storeType)
     {
         using var store = GetStore(storeType);


### PR DESCRIPTION
## Summary
- Copy keys and values stored in RocksDbStore snapshot pending writes
- Copy keys and values stored in PersistentTrackingStore snapshot changes
- Add snapshot key, value, and delete isolation coverage

## Testing
- dotnet test test/test.bctklib/test.bctklib.csproj --filter "snapshot_key_instance_isolation|snapshot_value_instance_isolation|snapshot_delete_key_instance_isolation"
- dotnet test test/test.bctklib/test.bctklib.csproj
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal
- dotnet build neo-express.sln --configuration Release