### PR TITLE
Clear persistent tracking changes on reset

### DIFF
--- a/src/bctklib/persistence/PersistentTrackingStore.cs
+++ b/src/bctklib/persistence/PersistentTrackingStore.cs
@@ -23,7 +23,8 @@ namespace Neo.BlockchainToolkit.Persistence
         readonly static ReadOnlyMemory<byte> DELETED_PREFIX = (new byte[] { DELETED_KEY }).AsMemory();
 
         readonly RocksDb db;
-        readonly ColumnFamilyHandle columnFamily;
+        ColumnFamilyHandle columnFamily;
+        readonly string? columnFamilyName;
         readonly IReadOnlyStore<byte[], byte[]> store;
         readonly bool shared;
         bool disposed;
@@ -31,14 +32,15 @@ namespace Neo.BlockchainToolkit.Persistence
         public event IStore.OnNewSnapshotDelegate? OnNewSnapshot;
 
         public PersistentTrackingStore(RocksDb db, IReadOnlyStore<byte[], byte[]> store, bool shared = false, string familyName = nameof(PersistentTrackingStore))
-            : this(db, db.GetOrCreateColumnFamily(familyName), store, shared)
+            : this(db, db.GetOrCreateColumnFamily(familyName), store, shared, string.IsNullOrEmpty(familyName) ? null : familyName)
         {
         }
 
-        internal PersistentTrackingStore(RocksDb db, ColumnFamilyHandle columnFamily, IReadOnlyStore<byte[], byte[]> store, bool shared = false)
+        internal PersistentTrackingStore(RocksDb db, ColumnFamilyHandle columnFamily, IReadOnlyStore<byte[], byte[]> store, bool shared = false, string? columnFamilyName = null)
         {
             this.db = db;
             this.columnFamily = columnFamily;
+            this.columnFamilyName = columnFamilyName;
             this.store = store;
             this.shared = shared;
         }
@@ -57,11 +59,27 @@ namespace Neo.BlockchainToolkit.Persistence
             disposed = true;
         }
 
+        /// <summary>
+        /// Discards persisted tracking changes so reads return to the backing store state.
+        /// </summary>
         public void Reset()
         {
             if (disposed || db.Handle == IntPtr.Zero)
                 throw new ObjectDisposedException(nameof(RocksDbStore));
 
+            // PersistentTrackingStore owns this column family, not the whole database.
+            if (columnFamilyName is not null)
+            {
+                db.DropColumnFamily(columnFamilyName);
+                columnFamily = db.CreateColumnFamily(new ColumnFamilyOptions(), columnFamilyName);
+                return;
+            }
+
+            ClearTrackedKeys();
+        }
+
+        void ClearTrackedKeys()
+        {
             using var iterator = db.NewIterator(columnFamily);
             using var batch = new WriteBatch();
             for (iterator.SeekToFirst(); iterator.Valid(); iterator.Next())

--- a/src/bctklib/persistence/PersistentTrackingStore.cs
+++ b/src/bctklib/persistence/PersistentTrackingStore.cs
@@ -61,7 +61,14 @@ namespace Neo.BlockchainToolkit.Persistence
         {
             if (disposed || db.Handle == IntPtr.Zero)
                 throw new ObjectDisposedException(nameof(RocksDbStore));
+
             using var iterator = db.NewIterator(columnFamily);
+            using var batch = new WriteBatch();
+            for (iterator.SeekToFirst(); iterator.Valid(); iterator.Next())
+            {
+                batch.Delete(iterator.Key(), columnFamily);
+            }
+            db.Write(batch);
         }
 
         [Obsolete("use TryGet(byte[] key, out byte[]? value) instead.")]

--- a/test/test.bctklib/TrackingStoreTests.cs
+++ b/test/test.bctklib/TrackingStoreTests.cs
@@ -214,7 +214,7 @@ public class TrackingStoreTests : IDisposable
     }
 
     [Fact]
-    public void persistent_tracking_reset_discards_tracked_changes()
+    public void PersistentTrackingResetDiscardsTrackedChanges()
     {
         var existingKey = Bytes(0);
         var existingValue = Bytes("existing-value");

--- a/test/test.bctklib/TrackingStoreTests.cs
+++ b/test/test.bctklib/TrackingStoreTests.cs
@@ -213,6 +213,42 @@ public class TrackingStoreTests : IDisposable
         test_delete_missing_value_no_effect(store);
     }
 
+    [Fact]
+    public void persistent_tracking_reset_discards_tracked_changes()
+    {
+        var existingKey = Bytes(0);
+        var existingValue = Bytes("existing-value");
+        var deletedKey = Bytes(1);
+        var deletedValue = Bytes("deleted-value");
+        var newKey = Bytes(2);
+        var newValue = Bytes("new-value");
+
+        var memoryStore = new MemoryStore();
+        memoryStore.Put(existingKey, existingValue);
+        memoryStore.Put(deletedKey, deletedValue);
+        using var store = new PersistentTrackingStore(RocksDbUtility.OpenDb(path), memoryStore);
+
+        store.Put(existingKey, Bytes("updated-value"));
+        store.Put(newKey, newValue);
+        store.Delete(deletedKey);
+
+        store.TryGet(existingKey, out var trackedExistingValue).Should().BeTrue();
+        trackedExistingValue.Should().BeEquivalentTo(Bytes("updated-value"));
+        store.TryGet(newKey, out var trackedNewValue).Should().BeTrue();
+        trackedNewValue.Should().BeEquivalentTo(newValue);
+        store.TryGet(deletedKey, out var trackedDeletedValue).Should().BeFalse();
+        trackedDeletedValue.Should().BeNull();
+
+        store.Reset();
+
+        store.TryGet(existingKey, out var resetExistingValue).Should().BeTrue();
+        resetExistingValue.Should().BeEquivalentTo(existingValue);
+        store.TryGet(newKey, out var resetNewValue).Should().BeFalse();
+        resetNewValue.Should().BeNull();
+        store.TryGet(deletedKey, out var resetDeletedValue).Should().BeTrue();
+        resetDeletedValue.Should().BeEquivalentTo(deletedValue);
+    }
+
     internal IStore GetStore(StoreType type)
     {
         var memoryStore = new MemoryStore();


### PR DESCRIPTION
## Summary
- Delete all persisted tracking entries when PersistentTrackingStore.Reset is called
- Add coverage that reset restores underlying values, removes added entries, and clears deletions

## Testing
- dotnet test test/test.bctklib/test.bctklib.csproj --filter persistent_tracking_reset_discards_tracked_changes
- dotnet test test/test.bctklib/test.bctklib.csproj
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal
- dotnet build neo-express.sln --configuration Release