### PR TITLE
Limit contract file load sizes

### DIFF
--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -19,6 +19,8 @@ namespace NeoExpress
 {
     static class FileSystemExtensions
     {
+        internal const int MaxContractFileBytes = 4 * 1024 * 1024;
+
         public static string ResolveFileName(this IFileSystem fileSystem, string fileName, string extension, Func<string> getDefaultFileName)
         {
             if (string.IsNullOrEmpty(fileName))
@@ -77,7 +79,7 @@ namespace NeoExpress
 
             static async Task<NefFile> LoadNefAsync(IFileSystem fileSystem, string contractPath)
             {
-                var buffer = await fileSystem.File.ReadAllBytesAsync(contractPath).ConfigureAwait(false);
+                var buffer = await ReadContractFileAsync(fileSystem, contractPath, "Contract file").ConfigureAwait(false);
                 try
                 {
                     return LoadNef(buffer);
@@ -98,7 +100,7 @@ namespace NeoExpress
             static async Task<ContractManifest> LoadManifestAsync(IFileSystem fileSystem, string contractPath)
             {
                 var path = fileSystem.Path.ChangeExtension(contractPath, ".manifest.json");
-                var buffer = await fileSystem.File.ReadAllBytesAsync(path).ConfigureAwait(false);
+                var buffer = await ReadContractFileAsync(fileSystem, path, "Contract manifest").ConfigureAwait(false);
                 try
                 {
                     return ContractManifest.Parse(buffer);
@@ -107,6 +109,15 @@ namespace NeoExpress
                 {
                     throw new Exception($"Contract manifest '{path}' is invalid: {ex.Message}");
                 }
+            }
+
+            static async Task<byte[]> ReadContractFileAsync(IFileSystem fileSystem, string path, string description)
+            {
+                var fileInfo = fileSystem.FileInfo.New(path);
+                if (fileInfo.Length > MaxContractFileBytes)
+                    throw new Exception($"{description} '{path}' is invalid: file is larger than {MaxContractFileBytes} bytes");
+
+                return await fileSystem.File.ReadAllBytesAsync(path).ConfigureAwait(false);
             }
         }
     }

--- a/test/test.workflowvalidation/FileSystemExtensionsTests.cs
+++ b/test/test.workflowvalidation/FileSystemExtensionsTests.cs
@@ -1,0 +1,92 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// FileSystemExtensionsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class FileSystemExtensionsTests
+{
+    [Fact]
+    public async Task LoadContractAsync_rejects_oversized_nef_file()
+    {
+        var fileSystem = CreateFileSystem();
+        var contractPath = "/work/contract.nef";
+        var manifestPath = "/work/contract.manifest.json";
+        fileSystem.AddFile(contractPath, new MockFileData(new byte[FileSystemExtensions.MaxContractFileBytes + 1]));
+        fileSystem.AddFile(manifestPath, new MockFileData(ValidManifestJson));
+
+        Func<Task> action = () => fileSystem.LoadContractAsync(contractPath);
+
+        var exception = await action.Should().ThrowAsync<Exception>();
+        exception.Which.Message.Should().Be($"Contract file '{contractPath}' is invalid: file is larger than {FileSystemExtensions.MaxContractFileBytes} bytes");
+    }
+
+    [Fact]
+    public async Task LoadContractAsync_rejects_oversized_manifest_file()
+    {
+        var fileSystem = CreateFileSystem();
+        var contractPath = "/work/contract.nef";
+        var manifestPath = "/work/contract.manifest.json";
+        fileSystem.AddFile(contractPath, new MockFileData(ValidNefBytes()));
+        fileSystem.AddFile(manifestPath, new MockFileData(new string(' ', (int)FileSystemExtensions.MaxContractFileBytes + 1)));
+
+        Func<Task> action = () => fileSystem.LoadContractAsync(contractPath);
+
+        var exception = await action.Should().ThrowAsync<Exception>();
+        exception.Which.Message.Should().Be($"Contract manifest '{manifestPath}' is invalid: file is larger than {FileSystemExtensions.MaxContractFileBytes} bytes");
+    }
+
+    private static MockFileSystem CreateFileSystem()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), "/work");
+        fileSystem.Directory.CreateDirectory("/work");
+        return fileSystem;
+    }
+
+    private static byte[] ValidNefBytes()
+    {
+        var solutionDir = FindSolutionDirectory(Directory.GetCurrentDirectory());
+        return File.ReadAllBytes(Path.Combine(solutionDir, "test", "test.bctklib", "_testFiles", "registrar.nef"));
+    }
+
+    private static string FindSolutionDirectory(string startPath)
+    {
+        var directory = new DirectoryInfo(startPath);
+        while (directory != null)
+        {
+            if (directory.GetFiles("neo-express.sln").Any())
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find neo-express.sln");
+    }
+
+    private const string ValidManifestJson = """
+        {
+          "name":"SampleContract",
+          "groups":[],
+          "features":{},
+          "supportedstandards":[],
+          "abi":{
+            "methods":[{"name":"dummy","parameters":[],"returntype":"Void","offset":0,"safe":false}],
+            "events":[]
+          },
+          "permissions":[],
+          "trusts":[],
+          "extra":{}
+        }
+        """;
+}


### PR DESCRIPTION
## Summary
- Reject oversized .nef and contract manifest files before loading them into memory
- Add coverage for oversized contract artifacts during contract loading

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter FileSystemExtensionsTests
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal
- git diff --check
- dotnet build neo-express.sln --configuration Release