### PR TITLE
Limit contract parameter file loads

### DIFF
--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -417,6 +417,10 @@ namespace Neo.BlockchainToolkit
                     throw new System.IO.FileNotFoundException(null, file);
                 }
 
+                var fileInfo = fileSystem.FileInfo.New(file);
+                if (fileInfo.Length > MaxInvocationFileBytes)
+                    throw new Exception($"Parameter file {file} is invalid: file is larger than {MaxInvocationFileBytes} bytes");
+
                 return new ContractParameter(ContractParameterType.ByteArray)
                 {
                     Value = fileSystem.File.ReadAllBytes(file)

--- a/test/test.bctklib/ContractParameterParserTest.cs
+++ b/test/test.bctklib/ContractParameterParserTest.cs
@@ -273,6 +273,21 @@ namespace test.bctklib
             Assert.Equal(someFakePathFile, exception.FileName);
         }
 
+        [Fact]
+        public void TestParseStringParameter_file_uri_rejects_oversized_file()
+        {
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePathFile = fileSystem.Path.Combine(rootPath, "some", "fake", "path", "file.txt");
+            fileSystem.AddFile(someFakePathFile, new MockFileData(new string(' ', (int)ContractParameterParser.MaxInvocationFileBytes + 1)));
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var action = () => parser.ParseStringParameter($"file://{someFakePathFile}");
+
+            var exception = action.Should().Throw<Exception>();
+            exception.Which.Message.Should().Be($"Parameter file {someFakePathFile} is invalid: file is larger than {ContractParameterParser.MaxInvocationFileBytes} bytes");
+        }
+
         [Theory]
         [InlineData("NaN")]
         [InlineData("\"not an invocation\"")]


### PR DESCRIPTION
## Summary
- Reject oversized file:// contract parameter inputs before reading them into memory
- Reuse the existing invocation file size limit for parameter file inputs
- Add coverage for oversized parameter files

## Testing
- dotnet test test/test.bctklib/test.bctklib.csproj --filter TestParseStringParameter_file_uri_rejects_oversized_file
- dotnet test test/test.bctklib/test.bctklib.csproj
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal
- git diff --check
- dotnet build neo-express.sln --configuration Release