### PR TITLE
Run fast workflow validation tests in CI

### DIFF
--- a/.github/workflows/pr_cs.yml
+++ b/.github/workflows/pr_cs.yml
@@ -7,6 +7,8 @@ on:
       - development
       - release/*
     paths:
+      - '.github/workflows/pr_cs.yml'
+      - '.github/workflows/test.yml'
       - '**.cs'
       - '**.csproj'
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,8 @@ on:
       - development
       - release/*
     paths:
+      - '.github/workflows/push.yml'
+      - '.github/workflows/test.yml'
       - '**.cs'
       - '**.csproj'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       run: dotnet build neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-restore --verbosity normal
 
     - name: Test
-      run: dotnet test neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal --filter "FullyQualifiedName!~test.workflowvalidation"
+      run: dotnet test neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
 
     - name: Pack for Install
       run: dotnet pack neo-express.sln --configuration ${{ env.CONFIGURATION }} --output ./out --no-build --verbosity normal


### PR DESCRIPTION
## Summary
- Keep the slow workflow validation integration suites excluded from the main CI test step
- Run the fast workflow validation tests instead of excluding the whole test.workflowvalidation project
- Trigger the reusable test workflow when the PR or push workflow definitions change

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-build --filter "FullyQualifiedName!~test.workflowvalidation"
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-build --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- dotnet test neo-express.sln --configuration Release --no-build --verbosity normal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- ruby -e "require 'yaml'; %w[.github/workflows/test.yml .github/workflows/pr_cs.yml .github/workflows/push.yml].each { |f| YAML.load_file(f); puts \"parsed #{f}\" }"
- git diff --check
