### PR TITLE
Report missing checkpoint fixture files clearly

### DIFF
--- a/neo-express.sln
+++ b/neo-express.sln
@@ -38,6 +38,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "test-collector", "test\test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test.workflowvalidation", "test\test.workflowvalidation\test.workflowvalidation.csproj", "{D53F655A-D885-44FE-B3FA-58D2BED980BB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "test.test-harness", "test\test-harness\test-harness.csproj", "{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,10 @@ Global
 		{D53F655A-D885-44FE-B3FA-58D2BED980BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D53F655A-D885-44FE-B3FA-58D2BED980BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D53F655A-D885-44FE-B3FA-58D2BED980BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -114,6 +120,7 @@ Global
 		{366648BC-0003-419F-9C20-2FCD63FF4A77} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
 		{A2003459-18D0-43BD-8CB9-CE3FA497A66B} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
 		{D53F655A-D885-44FE-B3FA-58D2BED980BB} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
+		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {14A0ACFA-EDC0-48D6-9C28-1EBCC3D544A5}

--- a/src/test-harness/CheckpointFixture.cs
+++ b/src/test-harness/CheckpointFixture.cs
@@ -34,14 +34,23 @@ namespace NeoTestHarness
             }
             else
             {
+                var originalCheckpointPath = checkpointPath;
                 var directory = Path.GetFullPath(".");
-                var tempPath = Path.GetFullPath(checkpointPath, directory);
-                while (!File.Exists(tempPath))
+                while (true)
                 {
-                    directory = Path.GetDirectoryName(directory);
-                    tempPath = Path.GetFullPath(checkpointPath, directory!);
+                    var tempPath = Path.GetFullPath(checkpointPath, directory);
+                    if (File.Exists(tempPath))
+                    {
+                        checkpointPath = tempPath;
+                        break;
+                    }
+
+                    var parentDirectory = Path.GetDirectoryName(directory);
+                    if (parentDirectory is null)
+                        throw new FileNotFoundException("couldn't find checkpoint", originalCheckpointPath);
+
+                    directory = parentDirectory;
                 }
-                checkpointPath = tempPath;
             }
 
             checkpointStore = new CheckpointStore(checkpointPath);
@@ -56,4 +65,3 @@ namespace NeoTestHarness
             => (fileSystem ?? defaultFileSystem.Value).FindChain(fileName, searchFolder);
     }
 }
-

--- a/test/test-harness/CheckpointFixtureTests.cs
+++ b/test/test-harness/CheckpointFixtureTests.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CheckpointFixtureTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoTestHarness;
+using Xunit;
+
+namespace test.harness;
+
+public class CheckpointFixtureTests
+{
+    [Fact]
+    public void Constructor_reports_missing_relative_checkpoint_path()
+    {
+        var checkpointPath = Path.Combine(Guid.NewGuid().ToString("N"), "missing.neoxp-checkpoint");
+
+        var action = () => new MissingCheckpointFixture(checkpointPath);
+
+        action.Should().Throw<FileNotFoundException>()
+            .WithMessage("couldn't find checkpoint*")
+            .Where(exception => exception.FileName == checkpointPath);
+    }
+
+    private sealed class MissingCheckpointFixture : CheckpointFixture
+    {
+        public MissingCheckpointFixture(string checkpointPath)
+            : base(checkpointPath)
+        {
+        }
+    }
+}

--- a/test/test-harness/test-harness.csproj
+++ b/test/test-harness/test-harness.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>test.harness</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\test-harness\test-harness.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.8.118" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Stop relative checkpoint lookup before it walks past the filesystem root
- Preserve the requested checkpoint path in the missing-file exception
- Add test coverage for the Neo.Test.Harness checkpoint fixture behavior

## Testing
- dotnet test test/test-harness/test-harness.csproj --configuration Release --verbosity normal
- dotnet test test/test-harness/test-harness.csproj --configuration Release --no-restore --verbosity minimal
- dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation"
- dotnet test neo-express.sln --configuration Release --no-build --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation"
- git diff --check
