### PR TITLE
Return JSON array for empty storage results

### DIFF
--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -45,13 +45,20 @@ namespace NeoExpress.Commands
                 internal string Input { get; init; } = string.Empty;
 
                 [Option(Description = "Output as JSON")]
-                internal bool Json { get; }
+                internal bool Json { get; init; } = false;
 
                 internal async Task WriteStoragesAsync(IExpressNode expressNode, TextWriter writer, IReadOnlyList<(UInt160 hash, ContractManifest)> contracts)
                 {
                     if (Json)
                     {
                         using var jsonWriter = new JsonTextWriter(writer);
+
+                        if (contracts.Count == 0)
+                        {
+                            await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);
+                            await jsonWriter.WriteEndArrayAsync().ConfigureAwait(false);
+                            return;
+                        }
 
                         if (contracts.Count > 1)
                             await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);

--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -53,15 +53,7 @@ namespace NeoExpress.Commands
                     {
                         using var jsonWriter = new JsonTextWriter(writer);
 
-                        if (contracts.Count == 0)
-                        {
-                            await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);
-                            await jsonWriter.WriteEndArrayAsync().ConfigureAwait(false);
-                            return;
-                        }
-
-                        if (contracts.Count > 1)
-                            await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);
+                        await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);
 
                         for (int i = 0; i < contracts.Count; i++)
                         {
@@ -87,8 +79,7 @@ namespace NeoExpress.Commands
                             await jsonWriter.WriteEndObjectAsync().ConfigureAwait(false);
                         }
 
-                        if (contracts.Count > 1)
-                            await jsonWriter.WriteEndArrayAsync().ConfigureAwait(false);
+                        await jsonWriter.WriteEndArrayAsync().ConfigureAwait(false);
                     }
                     else
                     {

--- a/test/test.workflowvalidation/ContractStorageCommandTests.cs
+++ b/test/test.workflowvalidation/ContractStorageCommandTests.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractStorageCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractStorageCommandTests
+{
+    [Fact]
+    public async Task WriteStoragesAsync_writes_empty_json_array_when_no_contracts_match()
+    {
+        using var writer = new StringWriter();
+        var command = new ContractCommand.Storage.StorageGet(null!) { Json = true };
+
+        await command.WriteStoragesAsync(null!, writer, []);
+
+        writer.ToString().Should().Be("[]");
+    }
+}


### PR DESCRIPTION
## Summary
- Return an empty JSON array when `contract storage get --json` finds no matching contracts
- Make the storage command JSON option settable like the other JSON command options
- Add workflow validation coverage for the empty JSON result

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-restore --verbosity minimal --filter ContractStorageCommandTests
- dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- git diff --check
