### PR TITLE
Preserve UTF-8 storage update arguments

### DIFF
--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -172,54 +172,56 @@ namespace NeoExpress.Commands
                             : throw new InvalidOperationException($"contract \"{contract}\" not found");
 
                     var internalPair = (
-                        ConvertArg(parser, key),
-                        ConvertArg(parser, value)
+                        ConvertStorageArgument(parser, key),
+                        ConvertStorageArgument(parser, value)
                         );
                     await expressNode.PersistStorageKeyValueAsync(scriptHash, internalPair);
+                }
 
-                    static string ConvertArg(ContractParameterParser parser, string arg)
+                internal static string ConvertStorageArgument(ContractParameterParser parser, string arg)
+                {
+                    var parameter = parser.ParseStringParameter(arg);
+                    var paramValue = parameter.Value;
+
+                    byte[] result;
+                    if (paramValue is string strValue)
                     {
-                        var parameter = parser.ParseStringParameter(arg);
-                        var paramValue = parameter.Value;
-
-                        byte[] result;
-                        if (paramValue is string strValue)
+                        try
                         {
-                            try
+                            _ = Convert.FromBase64String(strValue);
+                            return strValue;
+                        }
+                        catch
+                        {
+                            if (BigInteger.TryParse(strValue, out var integerValue))
                             {
-                                var fromBase64 = Convert.FromBase64String(strValue);
-                                return strValue;
+                                result = integerValue.ToByteArray();
                             }
-                            catch
+                            else if (bool.TryParse(strValue, out var boolValue))
                             {
-                                if (BigInteger.TryParse(strValue, out var integerValue))
-                                {
-                                    result = integerValue.ToByteArray();
-                                }
-                                else if (bool.TryParse(strValue, out var boolValue))
-                                {
-                                    result = new byte[] { Convert.ToByte(boolValue) };
-                                }
-                                else
-                                {
-                                    result = Encoding.ASCII.GetBytes(strValue);
-                                }
+                                result = new byte[] { Convert.ToByte(boolValue) };
+                            }
+                            else
+                            {
+                                result = Encoding.UTF8.GetBytes(strValue);
                             }
                         }
-                        else if (paramValue is byte[] value)
-                        {
-                            result = value;
-                        }
-                        else if (paramValue is UInt160 hashValue)
-                        {
-                            result = ((byte[])parser.ParseStringParameter(hashValue.ToString()).Value).Reverse().ToArray();
-                        }
-                        else
-                        {
-                            result = Encoding.ASCII.GetBytes(parameter.ToString());
-                        }
-                        return Convert.ToBase64String(result);
                     }
+                    else if (paramValue is byte[] value)
+                    {
+                        result = value;
+                    }
+                    else if (paramValue is UInt160 hashValue)
+                    {
+                        var hashBytes = parser.ParseStringParameter(hashValue.ToString()).Value as byte[]
+                            ?? throw new InvalidOperationException($"script hash \"{hashValue}\" could not be converted to bytes");
+                        result = hashBytes.Reverse().ToArray();
+                    }
+                    else
+                    {
+                        result = Encoding.UTF8.GetBytes(parameter.ToString());
+                    }
+                    return Convert.ToBase64String(result);
                 }
 
                 internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)

--- a/test/test.workflowvalidation/ContractStorageUpdateCommandTests.cs
+++ b/test/test.workflowvalidation/ContractStorageUpdateCommandTests.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractStorageUpdateCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit;
+using NeoExpress.Commands;
+using System.Text;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractStorageUpdateCommandTests
+{
+    [Fact]
+    public void ConvertStorageArgument_preserves_unicode_text_as_utf8()
+    {
+        var parser = new ContractParameterParser(ProtocolSettings.Default);
+        const string value = "neo-汉字";
+
+        var result = ContractCommand.Storage.StorageUpdateKeyValue.ConvertStorageArgument(parser, value);
+
+        result.Should().Be(Convert.ToBase64String(Encoding.UTF8.GetBytes(value)));
+    }
+
+    [Fact]
+    public void ConvertStorageArgument_preserves_base64_input()
+    {
+        var parser = new ContractParameterParser(ProtocolSettings.Default);
+        var value = Convert.ToBase64String([0xde, 0xad, 0xbe, 0xef]);
+
+        var result = ContractCommand.Storage.StorageUpdateKeyValue.ConvertStorageArgument(parser, value);
+
+        result.Should().Be(value);
+    }
+}

--- a/test/test.workflowvalidation/ContractStorageUpdateCommandTests.cs
+++ b/test/test.workflowvalidation/ContractStorageUpdateCommandTests.cs
@@ -20,7 +20,7 @@ namespace test.workflowvalidation;
 public class ContractStorageUpdateCommandTests
 {
     [Fact]
-    public void ConvertStorageArgument_preserves_unicode_text_as_utf8()
+    public void ConvertStorageArgument_PreservesUnicodeTextAsUtf8()
     {
         var parser = new ContractParameterParser(ProtocolSettings.Default);
         const string value = "neo-汉字";
@@ -31,7 +31,7 @@ public class ContractStorageUpdateCommandTests
     }
 
     [Fact]
-    public void ConvertStorageArgument_preserves_base64_input()
+    public void ConvertStorageArgument_PreservesBase64Input()
     {
         var parser = new ContractParameterParser(ProtocolSettings.Default);
         var value = Convert.ToBase64String([0xde, 0xad, 0xbe, 0xef]);


### PR DESCRIPTION
## Summary
- Convert plain `contract storage update` text arguments to UTF-8 before persisting them.
- Keep existing base64 storage argument handling unchanged.
- Add focused workflow validation tests for Unicode text and base64 inputs.

## Validation
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-restore --verbosity minimal --filter ContractStorageUpdateCommandTests`
- `dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"`
- `git diff --check`