### PR TITLE
Emit JSON for candidate list

### DIFF
--- a/src/neoxp/Commands/CandidateCommand.List.cs
+++ b/src/neoxp/Commands/CandidateCommand.List.cs
@@ -9,6 +9,8 @@
 // modifications are permitted.
 
 using McMaster.Extensions.CommandLineUtils;
+using Newtonsoft.Json;
+using System.Globalization;
 
 namespace NeoExpress.Commands
 {
@@ -42,13 +44,39 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
                     var list = await txExec.ListCandidatesAsync().ConfigureAwait(false);
-                    list.ForEach(x => console.Out.WriteLine(x));
+                    await WriteCandidatesAsync(console.Out, list, Json).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)
                 {
                     app.WriteException(ex, true);
                     return 1;
+                }
+            }
+
+            internal static async Task WriteCandidatesAsync(TextWriter writer, IReadOnlyList<TransactionExecutor.CandidateInfo> candidates, bool json)
+            {
+                if (json)
+                {
+                    using var jsonWriter = new JsonTextWriter(writer) { Formatting = Formatting.Indented };
+                    await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);
+                    foreach (var candidate in candidates)
+                    {
+                        await jsonWriter.WriteStartObjectAsync().ConfigureAwait(false);
+                        await jsonWriter.WritePropertyNameAsync("public-key").ConfigureAwait(false);
+                        await jsonWriter.WriteValueAsync(candidate.PublicKey).ConfigureAwait(false);
+                        await jsonWriter.WritePropertyNameAsync("votes").ConfigureAwait(false);
+                        await jsonWriter.WriteValueAsync(candidate.Votes.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+                        await jsonWriter.WriteEndObjectAsync().ConfigureAwait(false);
+                    }
+                    await jsonWriter.WriteEndArrayAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    foreach (var candidate in candidates)
+                    {
+                        await writer.WriteLineAsync($"{candidate.PublicKey,-67}{candidate.Votes.ToString(CultureInfo.InvariantCulture)}").ConfigureAwait(false);
+                    }
                 }
             }
         }

--- a/src/neoxp/Commands/CandidateCommand.List.cs
+++ b/src/neoxp/Commands/CandidateCommand.List.cs
@@ -9,8 +9,9 @@
 // modifications are permitted.
 
 using McMaster.Extensions.CommandLineUtils;
-using Newtonsoft.Json;
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace NeoExpress.Commands
 {
@@ -58,18 +59,10 @@ namespace NeoExpress.Commands
             {
                 if (json)
                 {
-                    using var jsonWriter = new JsonTextWriter(writer) { Formatting = Formatting.Indented };
-                    await jsonWriter.WriteStartArrayAsync().ConfigureAwait(false);
-                    foreach (var candidate in candidates)
-                    {
-                        await jsonWriter.WriteStartObjectAsync().ConfigureAwait(false);
-                        await jsonWriter.WritePropertyNameAsync("public-key").ConfigureAwait(false);
-                        await jsonWriter.WriteValueAsync(candidate.PublicKey).ConfigureAwait(false);
-                        await jsonWriter.WritePropertyNameAsync("votes").ConfigureAwait(false);
-                        await jsonWriter.WriteValueAsync(candidate.Votes.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
-                        await jsonWriter.WriteEndObjectAsync().ConfigureAwait(false);
-                    }
-                    await jsonWriter.WriteEndArrayAsync().ConfigureAwait(false);
+                    var output = candidates.Select(candidate => new CandidateJson(
+                        candidate.PublicKey,
+                        candidate.Votes.ToString(CultureInfo.InvariantCulture)));
+                    await writer.WriteAsync(JsonSerializer.Serialize(output, JsonOptions)).ConfigureAwait(false);
                 }
                 else
                 {
@@ -79,6 +72,12 @@ namespace NeoExpress.Commands
                     }
                 }
             }
+
+            private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+            private sealed record CandidateJson(
+                [property: JsonPropertyName("public-key")] string PublicKey,
+                [property: JsonPropertyName("votes")] string Votes);
         }
     }
 }

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -36,6 +36,8 @@ namespace NeoExpress
     {
         internal const long MaxOracleResponseFileBytes = 4 * 1024 * 1024;
 
+        internal readonly record struct CandidateInfo(string PublicKey, BigInteger Votes);
+
         readonly ExpressChainManager chainManager;
         readonly IExpressNode expressNode;
         readonly IFileSystem fileSystem;
@@ -620,14 +622,13 @@ namespace NeoExpress
             await writer.WriteTxHashAsync(txHash, $"Vote/Unvote", json).ConfigureAwait(false);
         }
 
-        public async Task<List<string>> ListCandidatesAsync()
+        public async Task<List<CandidateInfo>> ListCandidatesAsync()
         {
             using var builder = new ScriptBuilder();
             builder.EmitDynamicCall(NativeContract.NEO.Hash, "getCandidates");
 
             var result = await expressNode.InvokeAsync(builder.ToArray()).ConfigureAwait(false);
-            var stack = result.Stack;
-            var list = new List<string>();
+            var list = new List<CandidateInfo>();
             try
             {
                 if (result.State != VMState.FAULT
@@ -637,7 +638,11 @@ namespace NeoExpress
                     for (var i = 0; i < array.Count; i++)
                     {
                         var value = (Neo.VM.Types.Array)array[i];
-                        list.Add($"{((Neo.VM.Types.ByteString?)value?[0])?.GetSpan().ToHexString(),-67}{((Neo.VM.Types.Integer?)value?[1])?.GetInteger()}");
+                        var publicKey = ((Neo.VM.Types.ByteString?)value?[0])?.GetSpan().ToHexString()
+                            ?? throw new InvalidOperationException();
+                        var votes = ((Neo.VM.Types.Integer?)value?[1])?.GetInteger()
+                            ?? throw new InvalidOperationException();
+                        list.Add(new CandidateInfo(publicKey, votes));
                     }
                 }
             }

--- a/test/test.workflowvalidation/CandidateListCommandTests.cs
+++ b/test/test.workflowvalidation/CandidateListCommandTests.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CandidateListCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using NeoExpress.Commands;
+using Newtonsoft.Json.Linq;
+using System.Numerics;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class CandidateListCommandTests
+{
+    [Fact]
+    public async Task WriteCandidatesAsync_writes_json_when_requested()
+    {
+        var candidates = new[]
+        {
+            new TransactionExecutor.CandidateInfo(
+                "031111111111111111111111111111111111111111111111111111111111111111",
+                BigInteger.Parse("12345678901234567890"))
+        };
+        using var writer = new StringWriter();
+
+        await CandidateCommand.List.WriteCandidatesAsync(writer, candidates, json: true);
+
+        var json = JArray.Parse(writer.ToString());
+        json.Should().HaveCount(1);
+        json[0]!.Value<string>("public-key").Should().Be(candidates[0].PublicKey);
+        json[0]!.Value<string>("votes").Should().Be(candidates[0].Votes.ToString());
+    }
+
+    [Fact]
+    public async Task WriteCandidatesAsync_preserves_text_output()
+    {
+        var candidates = new[]
+        {
+            new TransactionExecutor.CandidateInfo(
+                "031111111111111111111111111111111111111111111111111111111111111111",
+                new BigInteger(42))
+        };
+        using var writer = new StringWriter();
+
+        await CandidateCommand.List.WriteCandidatesAsync(writer, candidates, json: false);
+
+        writer.ToString().Should().Be($"{candidates[0].PublicKey,-67}{candidates[0].Votes}{Environment.NewLine}");
+    }
+}


### PR DESCRIPTION
## Summary
- Return structured candidate records from `ListCandidatesAsync` instead of preformatted text.
- Make `neoxp candidate list --json` emit a JSON array with public keys and votes.
- Preserve the existing text output layout when `--json` is not set.

## Validation
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-build --no-restore --verbosity minimal --filter CandidateListCommandTests`
- `dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"`
- `git diff --check`