### PR TITLE
Complete contract get JSON output

### DIFF
--- a/src/neoxp/Commands/ContractCommand.Get.cs
+++ b/src/neoxp/Commands/ContractCommand.Get.cs
@@ -55,22 +55,26 @@ namespace NeoExpress.Commands
                 var expressNode = chainManager.GetExpressNode();
 
                 using var jsonWriter = new JsonTextWriter(writer) { Formatting = Formatting.Indented };
-                jsonWriter.WriteStartArray();
-
                 if (UInt160.TryParse(Contract, out var contractHash))
                 {
                     var manifest = await expressNode.GetContractAsync(contractHash).ConfigureAwait(false);
-                    WriteContract(jsonWriter, contractHash, manifest);
+                    WriteContracts(jsonWriter, new[] { (contractHash, manifest) });
                 }
                 else
                 {
                     var contracts = await expressNode.ListContractsAsync(Contract).ConfigureAwait(false);
-
-                    foreach (var (hash, manifest) in contracts)
-                    {
-                        WriteContract(jsonWriter, hash, manifest);
-                    }
+                    WriteContracts(jsonWriter, contracts);
                 }
+            }
+
+            internal static void WriteContracts(JsonWriter writer, IEnumerable<(UInt160 hash, ContractManifest manifest)> contracts)
+            {
+                writer.WriteStartArray();
+                foreach (var (hash, manifest) in contracts)
+                {
+                    WriteContract(writer, hash, manifest);
+                }
+                writer.WriteEndArray();
 
                 static void WriteContract(JsonWriter writer, UInt160 hash, ContractManifest manifest)
                 {

--- a/test/test.workflowvalidation/ContractGetCommandTests.cs
+++ b/test/test.workflowvalidation/ContractGetCommandTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractGetCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.SmartContract.Manifest;
+using NeoExpress.Commands;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractGetCommandTests
+{
+    [Fact]
+    public void WriteContracts_writes_complete_json_array()
+    {
+        var manifest = ContractManifest.Parse("""
+        {
+          "name":"SampleContract",
+          "groups":[],
+          "features":{},
+          "supportedstandards":[],
+          "abi":{
+            "methods":[{"name":"dummy","parameters":[],"returntype":"Void","offset":0,"safe":false}],
+            "events":[]
+          },
+          "permissions":[],
+          "trusts":[],
+          "extra":{}
+        }
+        """);
+        var hash = UInt160.Parse("0x0101010101010101010101010101010101010101");
+        using var stringWriter = new StringWriter();
+        using var jsonWriter = new JsonTextWriter(stringWriter);
+
+        ContractCommand.Get.WriteContracts(jsonWriter, [(hash, manifest)]);
+
+        var json = JArray.Parse(stringWriter.ToString());
+        json.Should().HaveCount(1);
+        json[0]!.Value<string>("name").Should().Be("SampleContract");
+        json[0]!.Value<string>("hash").Should().Be(hash.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- Close the JSON array emitted by `contract get`.
- Share the contract JSON array writer between hash and name lookups.
- Add a focused regression test that parses the emitted output as a JSON array.

## Validation
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-restore --verbosity minimal --filter ContractGetCommandTests`
- `dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"`
- `git diff --check`