### PR TITLE
Write transaction hashes as JSON strings

### DIFF
--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -239,8 +239,7 @@ namespace NeoExpress
         {
             if (json)
             {
-                using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(writer);
-                await jsonWriter.WriteValueAsync(txHash.ToString()).ConfigureAwait(false);
+                await writer.WriteAsync($"\"{txHash}\"").ConfigureAwait(false);
             }
             else
             {

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -239,7 +239,8 @@ namespace NeoExpress
         {
             if (json)
             {
-                await writer.WriteLineAsync($"{txHash}").ConfigureAwait(false);
+                using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(writer);
+                await jsonWriter.WriteValueAsync(txHash.ToString()).ConfigureAwait(false);
             }
             else
             {

--- a/test/test.workflowvalidation/TextWriterExtensionsTests.cs
+++ b/test/test.workflowvalidation/TextWriterExtensionsTests.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TextWriterExtensionsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using NeoExpress;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class TextWriterExtensionsTests
+{
+    [Fact]
+    public async Task WriteTxHashAsync_writes_valid_json_string()
+    {
+        var hash = UInt256.Parse("0x0101010101010101010101010101010101010101010101010101010101010101");
+        using var writer = new StringWriter();
+
+        await writer.WriteTxHashAsync(hash, json: true);
+
+        var token = JToken.Parse(writer.ToString());
+        token.Type.Should().Be(JTokenType.String);
+        token.Value<string>().Should().Be(hash.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- Make JSON transaction hash output valid JSON by writing it through `JsonTextWriter`.
- Keep the non-JSON transaction message unchanged.
- Add a regression test that parses the JSON transaction hash output.

## Validation
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-restore --verbosity minimal --filter TextWriterExtensionsTests`
- `dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"`
- `git diff --check`