### PR TITLE
Preserve NFT token id byte order in hex output

### DIFF
--- a/src/neoxp/Commands/ShowCommand.NFT.cs
+++ b/src/neoxp/Commands/ShowCommand.NFT.cs
@@ -66,7 +66,7 @@ namespace NeoExpress.Commands
                     if (list.Count == 0)
                         await console.Out.WriteLineAsync($"No NFT yet. (Contract:{scriptHash}, Account:{accountHash.ToAddress(ProtocolSettings.Default.AddressVersion)})");
                     else
-                        list.ForEach(p => console.Out.WriteLine($"TokenId(Base64): {p}, TokenId(Hex): 0x{Convert.FromBase64String(p).Reverse().ToArray().ToHexString()}"));
+                        list.ForEach(p => console.Out.WriteLine(FormatTokenId(p)));
                     return 0;
                 }
                 catch (Exception ex)
@@ -75,6 +75,9 @@ namespace NeoExpress.Commands
                     return 1;
                 }
             }
+
+            internal static string FormatTokenId(string tokenId)
+                => $"TokenId(Base64): {tokenId}, TokenId(Hex): 0x{Convert.FromBase64String(tokenId).ToHexString()}";
         }
     }
 }

--- a/test/test.workflowvalidation/ShowNftCommandTests.cs
+++ b/test/test.workflowvalidation/ShowNftCommandTests.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ShowNftCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ShowNftCommandTests
+{
+    [Fact]
+    public void FormatTokenId_preserves_byte_order_for_hex_display()
+    {
+        var tokenId = Convert.ToBase64String([0x0a, 0x0b, 0x0c]);
+
+        var result = ShowCommand.NFT.FormatTokenId(tokenId);
+
+        result.Should().Be($"TokenId(Base64): {tokenId}, TokenId(Hex): 0x0a0b0c");
+    }
+}


### PR DESCRIPTION
## Summary
- Stop reversing NFT token id bytes when displaying the hex form in `show nft`.
- Keep the existing base64 display and lowercase hex formatting.
- Add a focused regression test for the displayed token id byte order.

## Validation
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-restore --verbosity minimal --filter ShowNftCommandTests`
- `dotnet test neo-express.sln --configuration Release --no-restore --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"`
- `git diff --check`