### PR TITLE
Use default C# language version

### DIFF
--- a/.github/workflows/pr_cs.yml
+++ b/.github/workflows/pr_cs.yml
@@ -11,6 +11,8 @@ on:
       - '.github/workflows/test.yml'
       - '**.cs'
       - '**.csproj'
+      - '**.props'
+      - '**.targets'
 
 # Cancel old test actions when new commits are pushed
 concurrency:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,6 @@
         <Company>The Neo Project</Company>
         <Copyright>2015-2026 The Neo Project</Copyright>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <PackageIcon>neo-logo-72.png</PackageIcon>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Remove the explicit C# 10 language version override from src/Directory.Build.props.
- Let the net10.0 target framework and SDK select the default C# language version.
- Include props and targets files in the C# PR workflow path filters so build configuration changes are validated.

## Validation
- dotnet build src/neoxp/neoxp.csproj --no-restore --verbosity minimal
- dotnet msbuild src/neoxp/neoxp.csproj -getProperty:LangVersion -> 14.0
- dotnet msbuild src/bctklib/bctklib.csproj -getProperty:LangVersion -> 14.0