### PR TITLE
Add correctly spelled DEFAULT_POLICY_FILENAME constant

### DIFF
--- a/src/bctklib/Constants.cs
+++ b/src/bctklib/Constants.cs
@@ -21,7 +21,10 @@ namespace Neo.BlockchainToolkit
         public const string DEFAULT_BATCH_FILENAME = "default" + EXPRESS_BATCH_EXTENSION;
         public const string DEFAULT_SETUP_BATCH_FILENAME = "setup" + EXPRESS_BATCH_EXTENSION;
 
-        public const string DEAULT_POLICY_FILENAME = "default-policy" + JSON_EXTENSION;
+        public const string DEFAULT_POLICY_FILENAME = "default-policy" + JSON_EXTENSION;
+
+        [Obsolete("Use " + nameof(DEFAULT_POLICY_FILENAME) + " instead. This misspelled constant is retained for backward compatibility.")]
+        public const string DEAULT_POLICY_FILENAME = DEFAULT_POLICY_FILENAME;
 
         public const string WORKNET_EXTENSION = ".neo-worknet";
         public const string DEFAULT_WORKNET_FILENAME = "default" + WORKNET_EXTENSION;

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -666,7 +666,7 @@ namespace NeoExpress
 
         public async Task<OneOf<PolicyValues, None>> TryLoadPolicyFromFileSystemAsync(string filename)
         {
-            filename = fileSystem.ResolveFileName(filename, JSON_EXTENSION, () => DEAULT_POLICY_FILENAME);
+            filename = fileSystem.ResolveFileName(filename, JSON_EXTENSION, () => DEFAULT_POLICY_FILENAME);
             if (fileSystem.File.Exists(filename))
             {
                 using var stream = fileSystem.File.OpenRead(filename);


### PR DESCRIPTION
## Summary
- Add a correctly spelled `DEFAULT_POLICY_FILENAME` public constant in `Neo.BlockchainToolkit.Constants`.
- Keep the existing misspelled `DEAULT_POLICY_FILENAME` as an `[Obsolete]` alias of the new constant so downstream consumers continue to compile without changes.
- Route the only internal caller (`TransactionExecutor.TryLoadPolicyFromFileSystemAsync`) through the new, correctly spelled name.

## Test plan
- [x] \`dotnet build neo-express.sln --configuration Release\` (0 errors)
- [x] \`dotnet format neo-express.sln --verify-no-changes\` (no formatting changes)
- [x] \`dotnet test neo-express.sln --configuration Release\` for the CI test set (324 passed, 0 failed)