### PR TITLE
Update workflow validation README to .NET 10 SDK

### DIFF
--- a/test/test.workflowvalidation/README.md
+++ b/test/test.workflowvalidation/README.md
@@ -33,7 +33,7 @@ Advanced neoxp tool functionality tests:
 
 ### Prerequisites
 
-- .NET 9.0 SDK installed
+- .NET 10.0 SDK installed
 - Git repository with neo-express solution
 - All dependencies restored (`dotnet restore`)
 


### PR DESCRIPTION
## Summary
- The workflow validation project targets \`net10.0\` (via the shared \`Directory.Build.props\`) and the GitHub Actions workflow installs the \`10.0.x\` SDK, but the README still listed .NET 9.0 SDK as a prerequisite.
- Update the documented prerequisite so contributors install the SDK version that the project actually builds against.

## Test plan
- [x] Documentation-only change — no code touched, build and tests unchanged from master.