### PR TITLE
Add test project for Neo.Assertions library

### DIFF
--- a/neo-express.sln
+++ b/neo-express.sln
@@ -42,6 +42,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test.workflowvalidation", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "test.test-harness", "test\test-harness\test-harness.csproj", "{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "test-assertions", "test\test-assertions\test-assertions.csproj", "{48EA5746-5F2E-40C7-8DE8-8F181C67DCE4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48EA5746-5F2E-40C7-8DE8-8F181C67DCE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48EA5746-5F2E-40C7-8DE8-8F181C67DCE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48EA5746-5F2E-40C7-8DE8-8F181C67DCE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48EA5746-5F2E-40C7-8DE8-8F181C67DCE4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,6 +134,7 @@ Global
 		{E5C37B90-5F08-4E7C-9E90-05062393643E} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
 		{D53F655A-D885-44FE-B3FA-58D2BED980BB} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
 		{C2A87806-EA1B-48E0-87D2-5BDA1B2B6B8B} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
+		{48EA5746-5F2E-40C7-8DE8-8F181C67DCE4} = {24ECF210-FA12-4121-98DA-A18BE75219C6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {14A0ACFA-EDC0-48D6-9C28-1EBCC3D544A5}

--- a/test/test-assertions/StackItemAssertionsTests.cs
+++ b/test/test-assertions/StackItemAssertionsTests.cs
@@ -1,0 +1,161 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StackItemAssertionsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Assertions;
+using Neo.Extensions;
+using Neo.VM.Types;
+using System.Numerics;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+
+namespace test.assertions;
+
+public class StackItemAssertionsTests
+{
+    [Fact]
+    public void BeEquivalentTo_string_matches_byte_string_value()
+    {
+        StackItem item = (ByteString)"hello";
+
+        var act = () => item.Should().BeEquivalentTo("hello");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_string_reports_mismatch()
+    {
+        StackItem item = (ByteString)"hello";
+
+        var act = () => item.Should().BeEquivalentTo("world");
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*hello*");
+    }
+
+    [Fact]
+    public void BeEquivalentTo_BigInteger_matches_integer_value()
+    {
+        StackItem item = (Integer)42;
+
+        var act = () => item.Should().BeEquivalentTo(new BigInteger(42));
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_bool_matches_boolean_value()
+    {
+        StackItem item = StackItem.True;
+
+        var act = () => item.Should().BeEquivalentTo(true);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeTrue_and_BeFalse_use_boolean_value()
+    {
+        StackItem t = StackItem.True;
+        StackItem f = StackItem.False;
+
+        t.Should().BeTrue();
+        f.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_null_matches_null_stack_item()
+    {
+        StackItem item = StackItem.Null;
+
+        var act = () => item.Should().BeEquivalentTo((object?)null);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_null_reports_non_null_subject()
+    {
+        StackItem item = (Integer)1;
+
+        var act = () => item.Should().BeEquivalentTo((object?)null);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_UInt160_matches_byte_string_of_correct_length()
+    {
+        var hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+        StackItem item = (ByteString)hash.ToArray();
+
+        var act = () => item.Should().BeEquivalentTo(hash);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_UInt160_reports_length_mismatch()
+    {
+        var hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+        StackItem item = (ByteString)new byte[10];
+
+        var act = () => item.Should().BeEquivalentTo(hash);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_UInt256_matches_byte_string_of_correct_length()
+    {
+        var hash = UInt256.Parse("0x0101010101010101010101010101010101010101010101010101010101010101");
+        StackItem item = (ByteString)hash.ToArray();
+
+        var act = () => item.Should().BeEquivalentTo(hash);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_byte_array_matches_byte_string_contents()
+    {
+        var expected = new byte[] { 0xde, 0xad, 0xbe, 0xef };
+        StackItem item = (ByteString)expected;
+
+        var act = () => item.Should().BeEquivalentTo(expected);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_byte_array_reports_content_mismatch()
+    {
+        StackItem item = (ByteString)new byte[] { 0xde, 0xad };
+        var expected = new byte[] { 0xbe, 0xef };
+
+        var act = () => item.Should().BeEquivalentTo(expected);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_unsupported_type_reports_failure()
+    {
+        StackItem item = (Integer)1;
+        var unsupported = new NeoArray();
+
+        var act = () => item.Should().BeEquivalentTo((object)unsupported);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*Unknown*");
+    }
+}

--- a/test/test-assertions/StorageItemAssertionsTests.cs
+++ b/test/test-assertions/StorageItemAssertionsTests.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StorageItemAssertionsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Assertions;
+using Neo.Extensions;
+using Neo.SmartContract;
+using System.Numerics;
+using Xunit;
+
+namespace test.assertions;
+
+public class StorageItemAssertionsTests
+{
+    [Fact]
+    public void Be_BigInteger_matches_serialized_value()
+    {
+        var expected = new BigInteger(123456);
+        var item = new StorageItem(expected.ToByteArray());
+
+        var act = () => item.Should().Be(expected);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Be_BigInteger_reports_mismatch()
+    {
+        var item = new StorageItem(new BigInteger(1).ToByteArray());
+
+        var act = () => item.Should().Be(new BigInteger(2));
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*2*");
+    }
+
+    [Fact]
+    public void Be_UInt160_matches_raw_bytes()
+    {
+        var hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+        var item = new StorageItem(hash.ToArray());
+
+        var act = () => item.Should().Be(hash);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Be_UInt256_matches_raw_bytes()
+    {
+        var hash = UInt256.Parse("0x0202020202020202020202020202020202020202020202020202020202020202");
+        var item = new StorageItem(hash.ToArray());
+
+        var act = () => item.Should().Be(hash);
+
+        act.Should().NotThrow();
+    }
+}

--- a/test/test-assertions/test-assertions.csproj
+++ b/test/test-assertions/test-assertions.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>test.assertions</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\assertions\assertions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.8.118" />
+  </ItemGroup>
+
+</Project>

--- a/test/test-assertions/test-assertions.csproj
+++ b/test/test-assertions/test-assertions.csproj
@@ -26,8 +26,4 @@
     <ProjectReference Include="..\..\src\assertions\assertions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.8.118" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary
- \`Neo.Assertions\` exposes FluentAssertions-style helpers (\`StackItemAssertions\` / \`StorageItemAssertions\` / \`NotifyEventArgsAssertions\`) but had no test project of its own.
- Add a new \`test-assertions\` xunit project covering the equivalence helpers:
  - \`StackItemAssertions.BeEquivalentTo\` for \`string\`, \`BigInteger\`, \`bool\`, \`UInt160\`, \`UInt256\`, \`byte[]\`, the \`Null\` branch, and the unsupported-type fallback.
  - \`StackItemAssertions.BeTrue\`/\`BeFalse\`.
  - \`StorageItemAssertions.Be\` for \`BigInteger\`, \`UInt160\`, and \`UInt256\`.
- Project mirrors the existing \`test-harness\` test project layout (xUnit v3 + FluentAssertions + coverlet collector) and is wired into \`neo-express.sln\` with the minimum required entries — no other projects touched.
- On the CI test filter the suite goes from 324 to 341 passing tests.

## Test plan
- [x] \`dotnet build neo-express.sln --configuration Release\` (0 errors)
- [x] \`dotnet format neo-express.sln --verify-no-changes\` (no formatting changes)
- [x] \`dotnet test neo-express.sln --configuration Release\` for the CI test set (341 passed, 0 failed)