### PR TITLE
Fix CS8630

### DIFF
--- a/src/bctklib/bctklib.csproj
+++ b/src/bctklib/bctklib.csproj
@@ -14,7 +14,7 @@
         <InternalsVisibleTo Include="test.bctklib" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MessagePack" Version="2.5.198" />
+        <PackageReference Include="MessagePack" Version="3.1.6" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
         <PackageReference Include="Neo" Version="$(NeoVersion)" />
         <PackageReference Include="Nerdbank.Streams" Version="2.13.16" />

--- a/src/bctklib/bctklib.csproj
+++ b/src/bctklib/bctklib.csproj
@@ -14,7 +14,7 @@
         <InternalsVisibleTo Include="test.bctklib" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MessagePack" Version="3.1.6" />
+        <PackageReference Include="MessagePack" Version="2.5.198" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
         <PackageReference Include="Neo" Version="$(NeoVersion)" />
         <PackageReference Include="Nerdbank.Streams" Version="2.13.16" />

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <AssemblyName>neo-build-tasks</AssemblyName>
@@ -12,6 +12,7 @@
 
         <DevelopmentDependency>true</DevelopmentDependency>
         <NoPackageAnalysis>true</NoPackageAnalysis>
+        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
Fix nullable build for netstandard2.0

- Add <LangVersion>latest</LangVersion> to build-tasks.csproj to resolve CS8630 when using <Nullable>enable</Nullable> targeting netstandard2.0