### PR TITLE
Release resources in RestoreCheckpoint

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -248,7 +248,7 @@ namespace NeoExpress
 
             var checkpointTempPath = fileSystem.GetTempFolder();
             var nodePath = fileSystem.GetNodePath(node);
-            var nodePathBackup = string.Concat(nodePath, ".backup-", Guid.NewGuid().ToString().AsSpan(0, 8));
+            var nodePathBackup = string.Concat(nodePath, ".backup-", Guid.NewGuid().ToString("N"));
 
             // Step 1: Restore checkpoint to temp location
             var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -248,24 +248,15 @@ namespace NeoExpress
 
             var checkpointTempPath = fileSystem.GetTempFolder();
             var nodePath = fileSystem.GetNodePath(node);
-            var nodePathBackup = nodePath + ".backup-" + Guid.NewGuid().ToString().Substring(0, 8);
+            var nodePathBackup = string.Concat(nodePath, ".backup-", Guid.NewGuid().ToString().AsSpan(0, 8));
+
+            // Step 1: Restore checkpoint to temp location
+            var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);
+            var multiSigAccount = wallet.GetMultiSigAccounts().Single();
+            RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath, ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
 
             try
             {
-                // Step 1: Restore checkpoint to temp location
-                using var folderCleanup = AnonymousDisposable.Create(() =>
-                {
-                    if (fileSystem.Directory.Exists(checkpointTempPath))
-                    {
-                        fileSystem.Directory.Delete(checkpointTempPath, true);
-                    }
-                });
-
-                var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);
-                var multiSigAccount = wallet.GetMultiSigAccounts().Single();
-                RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
-                    ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
-
                 // Step 2: Backup existing node directory (if exists)
                 if (fileSystem.Directory.Exists(nodePath))
                 {
@@ -287,7 +278,9 @@ namespace NeoExpress
                     if (fileSystem.Directory.Exists(nodePathBackup))
                     {
                         if (fileSystem.Directory.Exists(nodePath))
+                        {
                             fileSystem.Directory.Delete(nodePath, true);
+                        }
                         fileSystem.Directory.Move(nodePathBackup, nodePath);
                     }
                     throw;
@@ -299,14 +292,13 @@ namespace NeoExpress
                     fileSystem.Directory.Delete(nodePathBackup, true);
                 }
             }
-            catch
+            finally
             {
-                // Ensure backup is cleaned up on other errors
-                if (fileSystem.Directory.Exists(nodePathBackup))
+                // Clean up temp folder if it still exists
+                if (fileSystem.Directory.Exists(checkpointTempPath))
                 {
-                    fileSystem.Directory.Delete(nodePathBackup, true);
+                    fileSystem.Directory.Delete(checkpointTempPath, true);
                 }
-                throw;
             }
         }
 

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -247,30 +247,67 @@ namespace NeoExpress
             }
 
             var checkpointTempPath = fileSystem.GetTempFolder();
-            using var folderCleanup = AnonymousDisposable.Create(() =>
-            {
-                if (fileSystem.Directory.Exists(checkpointTempPath))
-                {
-                    fileSystem.Directory.Delete(checkpointTempPath, true);
-                }
-            });
-
             var nodePath = fileSystem.GetNodePath(node);
-            if (fileSystem.Directory.Exists(nodePath))
+            var nodePathBackup = nodePath + ".backup-" + Guid.NewGuid().ToString().Substring(0, 8);
+
+            try
             {
-                if (!force)
+                // Step 1: Restore checkpoint to temp location
+                using var folderCleanup = AnonymousDisposable.Create(() =>
                 {
-                    throw new Exception("You must specify force to restore a checkpoint to an existing blockchain.");
+                    if (fileSystem.Directory.Exists(checkpointTempPath))
+                    {
+                        fileSystem.Directory.Delete(checkpointTempPath, true);
+                    }
+                });
+
+                var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);
+                var multiSigAccount = wallet.GetMultiSigAccounts().Single();
+                RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
+                    ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
+
+                // Step 2: Backup existing node directory (if exists)
+                if (fileSystem.Directory.Exists(nodePath))
+                {
+                    if (!force)
+                    {
+                        throw new Exception("You must specify force to restore a checkpoint to an existing blockchain.");
+                    }
+                    fileSystem.Directory.Move(nodePath, nodePathBackup);
                 }
 
-                fileSystem.Directory.Delete(nodePath, true);
-            }
+                // Step 3: Move restored checkpoint to node path
+                try
+                {
+                    fileSystem.Directory.Move(checkpointTempPath, nodePath);
+                }
+                catch
+                {
+                    // If move failed, restore the backup
+                    if (fileSystem.Directory.Exists(nodePathBackup))
+                    {
+                        if (fileSystem.Directory.Exists(nodePath))
+                            fileSystem.Directory.Delete(nodePath, true);
+                        fileSystem.Directory.Move(nodePathBackup, nodePath);
+                    }
+                    throw;
+                }
 
-            var wallet = DevWallet.FromExpressWallet(ProtocolSettings, node.Wallet);
-            var multiSigAccount = wallet.GetMultiSigAccounts().Single();
-            RocksDbUtility.RestoreCheckpoint(checkPointArchive, checkpointTempPath,
-                ProtocolSettings.Network, ProtocolSettings.AddressVersion, multiSigAccount.ScriptHash);
-            fileSystem.Directory.Move(checkpointTempPath, nodePath);
+                // Step 4: Clean up backup if successful
+                if (fileSystem.Directory.Exists(nodePathBackup))
+                {
+                    fileSystem.Directory.Delete(nodePathBackup, true);
+                }
+            }
+            catch
+            {
+                // Ensure backup is cleaned up on other errors
+                if (fileSystem.Directory.Exists(nodePathBackup))
+                {
+                    fileSystem.Directory.Delete(nodePathBackup, true);
+                }
+                throw;
+            }
         }
 
         public void SaveChain(string path)

--- a/test/test.workflowvalidation/ExpressChainManagerCheckpointTests.cs
+++ b/test/test.workflowvalidation/ExpressChainManagerCheckpointTests.cs
@@ -77,9 +77,21 @@ public class ExpressChainManagerCheckpointTests
         directoryMock.Setup(d => d.Exists(It.IsAny<string>()))
             .Returns((string path) =>
             {
-                if (path == nodePath) return nodeExists;
-                if (path == oldNodePath) return false;
-                if (nodePathBackup is not null && path == nodePathBackup) return backupExists;
+                if (path == nodePath)
+                {
+                    return nodeExists;
+                }
+
+                if (path == oldNodePath)
+                {
+                    return false;
+                }
+
+                if (nodePathBackup is not null && path == nodePathBackup)
+                {
+                    return backupExists;
+                }
+
                 return false;
             });
 
@@ -172,9 +184,21 @@ public class ExpressChainManagerCheckpointTests
         directoryMock.Setup(d => d.Exists(It.IsAny<string>()))
             .Returns((string path) =>
             {
-                if (path == nodePath) return nodeExists;
-                if (path == oldNodePath) return false;
-                if (nodePathBackup is not null && path == nodePathBackup) return backupExists;
+                if (path == nodePath)
+                {
+                    return nodeExists;
+                }
+
+                if (path == oldNodePath)
+                {
+                    return false;
+                }
+
+                if (nodePathBackup is not null && path == nodePathBackup)
+                {
+                    return backupExists;
+                }
+
                 return false;
             });
 

--- a/test/test.workflowvalidation/ExpressChainManagerCheckpointTests.cs
+++ b/test/test.workflowvalidation/ExpressChainManagerCheckpointTests.cs
@@ -9,8 +9,13 @@
 // modifications are permitted.
 
 using FluentAssertions;
+using Moq;
+using Neo.BlockchainToolkit.Models;
 using NeoExpress;
+using Newtonsoft.Json;
+using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using System.IO.Compression;
 using Xunit;
 
 namespace test.workflowvalidation;
@@ -27,6 +32,198 @@ public class ExpressChainManagerCheckpointTests
         checkpointPath.Should().Be(fileSystem.Path.Combine("/work", "checkpoints", "init.neoxp-checkpoint"));
     }
 
+    [Fact]
+    public void RestoreCheckpoint_RecoveryOnMoveFail_RestoresBackup()
+    {
+        var chain = CreateSingleNodeChain();
+        var (checkpointPath, checkpointRoot) = CreateCheckpointArchive(chain);
+        var currentDirectory = Path.GetDirectoryName(checkpointPath)!;
+        var nodeScriptHash = chain.ConsensusNodes[0].Wallet.DefaultAccount?.ScriptHash
+            ?? throw new InvalidOperationException("Expected default account script hash");
+        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify);
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+        var nodePath = Path.Combine(homeDir, ".neo-express", "blockchain-nodes", nodeScriptHash);
+        var oldNodePath = Path.Combine(appData, "Neo-Express", "blockchain-nodes", nodeScriptHash);
+
+        var fileSystemMock = new Mock<IFileSystem>();
+        var fileMock = new Mock<IFile>();
+        var directoryMock = new Mock<IDirectory>();
+        var pathMock = new Mock<IPath>();
+
+        fileSystemMock.SetupGet(f => f.File).Returns(fileMock.Object);
+        fileSystemMock.SetupGet(f => f.Directory).Returns(directoryMock.Object);
+        fileSystemMock.SetupGet(f => f.Path).Returns(pathMock.Object);
+
+        pathMock.SetupGet(p => p.DirectorySeparatorChar).Returns(Path.DirectorySeparatorChar);
+        pathMock.SetupGet(p => p.AltDirectorySeparatorChar).Returns(Path.AltDirectorySeparatorChar);
+        pathMock.Setup(p => p.IsPathFullyQualified(It.IsAny<string>())).Returns((string p) => Path.IsPathFullyQualified(p));
+        pathMock.Setup(p => p.Combine(It.IsAny<string>(), It.IsAny<string>())).Returns((string a, string b) => Path.Combine(a, b));
+        pathMock.Setup(p => p.Combine(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns((string a, string b, string c, string d) => Path.Combine(a, b, c, d));
+        pathMock.Setup(p => p.GetExtension(It.IsAny<string>())).Returns((string p) => Path.GetExtension(p));
+        pathMock.Setup(p => p.GetFullPath(It.IsAny<string>())).Returns((string p) => Path.GetFullPath(p));
+        pathMock.Setup(p => p.GetTempPath()).Returns(currentDirectory);
+        pathMock.Setup(p => p.GetRandomFileName()).Returns("restore-temp");
+
+        fileMock.Setup(f => f.Exists(checkpointPath)).Returns(true);
+
+        directoryMock.Setup(d => d.GetCurrentDirectory()).Returns(currentDirectory);
+
+        var nodeExists = true;
+        var backupExists = false;
+        string? nodePathBackup = null;
+        var moveCalls = new List<(string source, string destination)>();
+        var moveFailureInjected = false;
+
+        directoryMock.Setup(d => d.Exists(It.IsAny<string>()))
+            .Returns((string path) =>
+            {
+                if (path == nodePath) return nodeExists;
+                if (path == oldNodePath) return false;
+                if (nodePathBackup is not null && path == nodePathBackup) return backupExists;
+                return false;
+            });
+
+        directoryMock.Setup(d => d.Move(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((source, destination) =>
+            {
+                moveCalls.Add((source, destination));
+
+                if (source == nodePath && destination.StartsWith(nodePath + ".backup-", StringComparison.Ordinal))
+                {
+                    nodeExists = false;
+                    backupExists = true;
+                    nodePathBackup = destination;
+                    return;
+                }
+
+                if (destination == nodePath && source != nodePathBackup && !moveFailureInjected)
+                {
+                    moveFailureInjected = true;
+                    throw new IOException("Simulated move failure");
+                }
+
+                if (nodePathBackup is not null && source == nodePathBackup && destination == nodePath)
+                {
+                    backupExists = false;
+                    nodeExists = true;
+                    return;
+                }
+            });
+
+        var manager = new ExpressChainManager(fileSystemMock.Object, chain);
+
+        try
+        {
+            Action action = () => manager.RestoreCheckpoint(checkpointPath, true);
+
+            action.Should().Throw<IOException>();
+            moveCalls.Should().Contain(call => call.source.StartsWith(nodePath + ".backup-", StringComparison.Ordinal) && call.destination == nodePath);
+            nodeExists.Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(checkpointRoot))
+            {
+                Directory.Delete(checkpointRoot, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void RestoreCheckpoint_CleanupBackupOnSuccess()
+    {
+        var chain = CreateSingleNodeChain();
+        var (checkpointPath, checkpointRoot) = CreateCheckpointArchive(chain);
+        var currentDirectory = Path.GetDirectoryName(checkpointPath)!;
+        var nodeScriptHash = chain.ConsensusNodes[0].Wallet.DefaultAccount?.ScriptHash
+            ?? throw new InvalidOperationException("Expected default account script hash");
+        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify);
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+        var nodePath = Path.Combine(homeDir, ".neo-express", "blockchain-nodes", nodeScriptHash);
+        var oldNodePath = Path.Combine(appData, "Neo-Express", "blockchain-nodes", nodeScriptHash);
+
+        var fileSystemMock = new Mock<IFileSystem>();
+        var fileMock = new Mock<IFile>();
+        var directoryMock = new Mock<IDirectory>();
+        var pathMock = new Mock<IPath>();
+
+        fileSystemMock.SetupGet(f => f.File).Returns(fileMock.Object);
+        fileSystemMock.SetupGet(f => f.Directory).Returns(directoryMock.Object);
+        fileSystemMock.SetupGet(f => f.Path).Returns(pathMock.Object);
+
+        pathMock.SetupGet(p => p.DirectorySeparatorChar).Returns(Path.DirectorySeparatorChar);
+        pathMock.SetupGet(p => p.AltDirectorySeparatorChar).Returns(Path.AltDirectorySeparatorChar);
+        pathMock.Setup(p => p.IsPathFullyQualified(It.IsAny<string>())).Returns((string p) => Path.IsPathFullyQualified(p));
+        pathMock.Setup(p => p.Combine(It.IsAny<string>(), It.IsAny<string>())).Returns((string a, string b) => Path.Combine(a, b));
+        pathMock.Setup(p => p.Combine(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns((string a, string b, string c, string d) => Path.Combine(a, b, c, d));
+        pathMock.Setup(p => p.GetExtension(It.IsAny<string>())).Returns((string p) => Path.GetExtension(p));
+        pathMock.Setup(p => p.GetFullPath(It.IsAny<string>())).Returns((string p) => Path.GetFullPath(p));
+        pathMock.Setup(p => p.GetTempPath()).Returns(currentDirectory);
+        pathMock.Setup(p => p.GetRandomFileName()).Returns("restore-temp-success");
+
+        fileMock.Setup(f => f.Exists(checkpointPath)).Returns(true);
+
+        directoryMock.Setup(d => d.GetCurrentDirectory()).Returns(currentDirectory);
+
+        var nodeExists = true;
+        var backupExists = false;
+        string? nodePathBackup = null;
+
+        directoryMock.Setup(d => d.Exists(It.IsAny<string>()))
+            .Returns((string path) =>
+            {
+                if (path == nodePath) return nodeExists;
+                if (path == oldNodePath) return false;
+                if (nodePathBackup is not null && path == nodePathBackup) return backupExists;
+                return false;
+            });
+
+        directoryMock.Setup(d => d.Move(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((source, destination) =>
+            {
+                if (source == nodePath && destination.StartsWith(nodePath + ".backup-", StringComparison.Ordinal))
+                {
+                    nodeExists = false;
+                    backupExists = true;
+                    nodePathBackup = destination;
+                    return;
+                }
+
+                if (destination == nodePath)
+                {
+                    nodeExists = true;
+                    return;
+                }
+            });
+
+        directoryMock.Setup(d => d.Delete(It.IsAny<string>(), true))
+            .Callback<string, bool>((path, recursive) =>
+            {
+                if (path == nodePathBackup)
+                {
+                    backupExists = false;
+                }
+            });
+
+        var manager = new ExpressChainManager(fileSystemMock.Object, chain);
+
+        try
+        {
+            manager.RestoreCheckpoint(checkpointPath, true);
+
+            directoryMock.Verify(d => d.Delete(It.Is<string>(p => p.StartsWith(nodePath + ".backup-", StringComparison.Ordinal)), true), Times.Once);
+            backupExists.Should().BeFalse();
+            nodeExists.Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(checkpointRoot))
+            {
+                Directory.Delete(checkpointRoot, true);
+            }
+        }
+    }
+
     [Theory]
     [InlineData("../../../../etc/passwd")]
     [InlineData("/tmp/passwd")]
@@ -38,6 +235,51 @@ public class ExpressChainManagerCheckpointTests
 
         action.Should().Throw<ArgumentException>()
             .WithMessage("Checkpoint path must stay within the current directory*");
+    }
+
+    private static (string checkpointPath, string checkpointRoot) CreateCheckpointArchive(ExpressChain chain)
+    {
+        var checkpointRoot = Path.Combine(Path.GetTempPath(), $"neo-express-checkpoint-test-{Guid.NewGuid():N}");
+        var sourcePath = Path.Combine(checkpointRoot, "source");
+        Directory.CreateDirectory(sourcePath);
+
+        var scriptHash = chain.ConsensusNodes[0].Wallet.Accounts.SingleOrDefault(a => !a.IsDefault)?.ScriptHash
+            ?? throw new InvalidOperationException("Expected consensus multisig account script hash");
+
+        File.WriteAllText(Path.Combine(sourcePath, "ADDRESS.neo-express"),
+            $"{chain.Network}{Environment.NewLine}{chain.AddressVersion}{Environment.NewLine}{scriptHash}{Environment.NewLine}");
+        File.WriteAllText(Path.Combine(sourcePath, "CURRENT"), "dummy");
+
+        var checkpointPath = Path.Combine(checkpointRoot, "checkpoint.neoxp-checkpoint");
+        ZipFile.CreateFromDirectory(sourcePath, checkpointPath);
+
+        return (checkpointPath, checkpointRoot);
+    }
+
+    private static ExpressChain CreateSingleNodeChain()
+    {
+        var solutionDir = FindSolutionDirectory(Directory.GetCurrentDirectory());
+        var chainPath = Path.Combine(solutionDir, "test", "test.bctklib", "_testFiles", "default.neo-express.json");
+        var chainJson = File.ReadAllText(chainPath);
+
+        return JsonConvert.DeserializeObject<ExpressChain>(chainJson)
+            ?? throw new InvalidOperationException($"Could not deserialize chain from {chainPath}");
+    }
+
+    private static string FindSolutionDirectory(string startPath)
+    {
+        var current = new DirectoryInfo(startPath);
+        while (current is not null)
+        {
+            if (current.GetFiles("neo-express.sln").Any())
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find neo-express.sln");
     }
 
     private static MockFileSystem CreateFileSystem()

--- a/test/test.workflowvalidation/test.workflowvalidation.csproj
+++ b/test/test.workflowvalidation/test.workflowvalidation.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Summary
Temporary resource not released in `RestoreCheckpoint` if a post-creation exception occurs.

# Problem
The flow does not adequately protect the state if `fileSystem.Directory.Delete(nodePath, true)` or `fileSystem.Directory.Move(checkpointTempPath, nodePath)` fail:

- If `Delete(nodePath, true)` throws an exception after partially deleting files, folderCleanup is caught but nodePath is left in an inconsistent state.

- If `Move(checkpointTempPath, nodePath)` fails (example,  due to permissions) the `checkpointTempPath` folder is properly cleaned up by the disposable but nodePath may have been deleted without being able to restore the checkpoint leaving the blockchain in a corrupted state.

# Tests
- RestoreCheckpoint_RecoveryOnMoveFail_RestoresBackup
- RestoreCheckpoint_CleanupBackupOnSuccess