### PR TITLE
Update Neo Express for Neo 3.10.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,14 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fix releases, but
 may not exactly match a publicly released version.
 
+## [3.10.0] - 2026-06-15
+
+### Changed
+
+* Updated to Neo 3.10.0
+* Updated Neo module dependencies to 3.10.0 where matching packages are available
+* Updated wallet, iterator, serialization, and logging compatibility for Neo 3.10.0
+
 ## [3.9.1] - 2026-01-29
 
 ### Changed

--- a/extentions/neo3-visual-tracker/CHANGELOG.md
+++ b/extentions/neo3-visual-tracker/CHANGELOG.md
@@ -6,6 +6,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [3.10.0] - 2026-06-15
+
+### Changed
+
+* Update Neo Express to 3.10.0 for Neo 3.10.0 compatibility
+* Align extension version with Neo 3.10.0 release
+
 ## [3.9.1] - 2026-01-29
 
 ### Changed

--- a/extentions/neo3-visual-tracker/package-lock.json
+++ b/extentions/neo3-visual-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neo3-visual-tracker",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neo3-visual-tracker",
-      "version": "3.9.1",
+      "version": "3.10.0",
       "dependencies": {
         "@vscode/vsce": "^3.6.2"
       },

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -3,7 +3,7 @@
   "publisher": "ngd-seattle",
   "displayName": "Neo N3 Visual DevTracker",
   "description": "A Neo N3 blockchain explorer that is directly available within Visual Studio Code",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "icon": "resources/neo-logo.png",
   "galleryBanner": {
     "color": "#242424",

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/dotnet-tools.json
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "neo.express": {
-      "version": "3.9.1",
+      "version": "3.10.0",
       "commands": [
         "neoxp"
       ]
     },
     "neo.compiler.csharp": {
-      "version": "3.9.1",
+      "version": "3.10.0",
       "commands": [
         "nccs"
       ]

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.8.1" />
-    <PackageReference Include="Neo.BuildTasks" Version="3.8.2" PrivateAssets="all" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
+    <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
@@ -18,9 +18,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Neo.Assertions" Version="3.8.2" />
-    <PackageReference Include="Neo.BuildTasks" Version="3.8.2" PrivateAssets="all" />
-    <PackageReference Include="Neo.Test.Harness" Version="3.8.2" />
+    <PackageReference Include="Neo.Assertions" Version="3.10.0" />
+    <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Neo.Test.Harness" Version="3.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/extentions/neo3-visual-tracker/version.json
+++ b/extentions/neo3-visual-tracker/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"

--- a/samples/.config/dotnet-tools.json
+++ b/samples/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "neo.express": {
-      "version": "3.9.1",
+      "version": "3.10.0",
       "commands": [
         "neoxp"
       ]
     },
     "neo.compiler.csharp": {
-      "version": "3.9.1",
+      "version": "3.10.0",
       "commands": [
         "nccs"
       ]

--- a/samples/src/contract.csproj
+++ b/samples/src/contract.csproj
@@ -4,10 +4,10 @@
     <NeoExpressBatchFile>../express.batch</NeoExpressBatchFile>
     <Nullable>enable</Nullable>
     <TargetFramework>net10.0</TargetFramework>
-    <NeoTestVersion>3.8.2</NeoTestVersion>
+    <NeoTestVersion>3.10.0</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.9.1" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
     <PackageReference Include="Neo.BuildTasks" Version="$(NeoTestVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/samples/test/contract-test.csproj
+++ b/samples/test/contract-test.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>ContractTests</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
-    <NeoTestVersion>3.8.2</NeoTestVersion>
+    <NeoTestVersion>3.10.0</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
     <NeoContractReference Include="..\src\contract.csproj" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,8 +17,9 @@
         <ApplicationIcon>../neo-cli.ico</ApplicationIcon>
     </PropertyGroup>
     <PropertyGroup>
-        <NeoVersion>3.9.1</NeoVersion>
-        <NeoModuleVersion>3.9.2</NeoModuleVersion>
+        <NeoVersion>3.10.0</NeoVersion>
+        <NeoModuleVersion>3.10.0</NeoModuleVersion>
+        <NeoConsensusDbftVersion>3.9.1</NeoConsensusDbftVersion>
     </PropertyGroup>
     <ItemGroup>
         <None Include="../neo-logo-72.png" Pack="true" Visible="false" PackagePath=""/>

--- a/src/bctklib/models/ToolkitWallet.cs
+++ b/src/bctklib/models/ToolkitWallet.cs
@@ -20,8 +20,9 @@ namespace Neo.BlockchainToolkit.Models
     {
         readonly Dictionary<UInt160, Account> accounts = new();
 
-        public override string Name { get; }
+        public override string Name { get; set; }
         public override Version Version => Version.Parse(ThisAssembly.AssemblyFileVersion);
+        public override bool IsUnlocked => true;
 
         public ToolkitWallet(string name, ProtocolSettings settings) : base(string.Empty, settings)
         {

--- a/src/bctklib/plugins/NotificationRecord.cs
+++ b/src/bctklib/plugins/NotificationRecord.cs
@@ -58,7 +58,7 @@ namespace Neo.BlockchainToolkit.Plugins
         public void Deserialize(ref MemoryReader reader)
         {
             ScriptHash = reader.ReadSerializable<UInt160>();
-            State = (NeoArray)BinarySerializer.Deserialize(ref reader, ExecutionEngineLimits.Default, null);
+            State = (NeoArray)BinarySerializer.Deserialize(ref reader, ExecutionEngineLimits.Default);
             EventName = reader.ReadVarString();
             InventoryHash = reader.ReadSerializable<UInt256>();
             InventoryType = (InventoryType)reader.ReadByte();
@@ -74,4 +74,3 @@ namespace Neo.BlockchainToolkit.Plugins
         }
     }
 }
-

--- a/src/bctklib/plugins/ToolkitRpcServer.cs
+++ b/src/bctklib/plugins/ToolkitRpcServer.cs
@@ -350,7 +350,7 @@ namespace Neo.BlockchainToolkit.Plugins
             {
                 while (iterator.Next())
                 {
-                    var value = iterator.Value(null);
+                    var value = iterator.Value();
                     var byteString = value.Type == StackItemType.ByteString
                         ? (ByteString)value
                         : (ByteString)value.ConvertTo(StackItemType.ByteString);

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -471,7 +471,7 @@ namespace NeoExpress
                 {
                     while (iterator.Next())
                     {
-                        list.Add(Convert.ToBase64String(iterator.Value(null).GetSpan()));
+                        list.Add(Convert.ToBase64String(iterator.Value().GetSpan()));
                     }
                 }
             }

--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -111,7 +111,7 @@ namespace NeoExpress
             {
                 while (iterator.Next())
                 {
-                    var value = iterator.Value(null);
+                    var value = iterator.Value();
                     var byteString = value.Type == StackItemType.ByteString
                         ? (ByteString)value
                         : (ByteString)(value.ConvertTo(StackItemType.ByteString));

--- a/src/neoxp/Models/DevWallet.cs
+++ b/src/neoxp/Models/DevWallet.cs
@@ -21,8 +21,9 @@ namespace NeoExpress.Models
     {
         private readonly Dictionary<UInt160, DevWalletAccount> accounts = new Dictionary<UInt160, DevWalletAccount>();
 
-        public override string Name { get; }
+        public override string Name { get; set; }
         public override Version? Version => null;
+        public override bool IsUnlocked => true;
 
         public DevWallet(ProtocolSettings settings, string name, IEnumerable<DevWalletAccount>? accounts = null) : base(string.Empty, settings)
         {

--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -60,7 +60,7 @@ namespace NeoExpress.Models
         {
             ScriptHash = reader.ReadSerializable<UInt160>();
             State = (Neo.VM.Types.Array)BinarySerializer.Deserialize(
-                ref reader, ExecutionEngineLimits.Default, null);
+                ref reader, ExecutionEngineLimits.Default);
             EventName = reader.ReadVarString();
             InventoryHash = reader.ReadSerializable<UInt256>();
             InventoryType = (InventoryType)reader.ReadByte();
@@ -131,4 +131,3 @@ namespace NeoExpress.Models
         }
     }
 }
-

--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -81,7 +81,8 @@ namespace NeoExpress.Node
             var response = new JObject();
             response["process-id"] = proc.Id;
 
-            Log($"ExpressShutdown requested. Shutting down in {SHUTDOWN_TIME} seconds", LogLevel.Info);
+            Logs.GetLogger(nameof(ExpressRpcServerPlugin))
+                .Information("ExpressShutdown requested. Shutting down in {ShutdownTime} seconds", SHUTDOWN_TIME);
             cancellationToken.CancelAfter(TimeSpan.FromSeconds(SHUTDOWN_TIME));
             return response;
         }

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -383,7 +383,7 @@ namespace NeoExpress
                         {
                             await WriteLineAsync($"{iop.Type}: ({iter.GetType().Name})").ConfigureAwait(false);
                             while (iter.Next())
-                                await WriteStackItemAsync(writer, iter.Value(null), indent + 1).ConfigureAwait(false);
+                                await WriteStackItemAsync(writer, iter.Value(), indent + 1).ConfigureAwait(false);
                         }
                         break;
                 }

--- a/src/neoxp/Validators/Nep11Token.cs
+++ b/src/neoxp/Validators/Nep11Token.cs
@@ -110,10 +110,9 @@ internal class Nep11Token : TokenBase
             var result = appEng.ResultStack.Pop().GetInterface<object>();
             if (result is IIterator iter)
             {
-                var refCounter = new ReferenceCounter();
                 var lstOwners = new List<UInt160>();
                 while (iter.Next())
-                    lstOwners.Add(new UInt160(iter.Value(refCounter).GetSpan()));
+                    lstOwners.Add(new UInt160(iter.Value().GetSpan()));
                 return lstOwners;
             }
             return Array.Empty<UInt160>();
@@ -151,10 +150,9 @@ internal class Nep11Token : TokenBase
             var result = appEng.ResultStack.Pop().GetInterface<object>();
             if (result is IIterator iter)
             {
-                var refCounter = new ReferenceCounter();
                 var lstTokenIds = new List<byte[]>();
                 while (iter.Next())
-                    lstTokenIds.Add(iter.Value(refCounter).GetSpan().ToArray());
+                    lstTokenIds.Add(iter.Value().GetSpan().ToArray());
                 return lstTokenIds;
             }
             return Array.Empty<byte[]>();
@@ -173,10 +171,9 @@ internal class Nep11Token : TokenBase
             var result = appEng.ResultStack.Pop().GetInterface<object>();
             if (result is IIterator iter)
             {
-                var refCounter = new ReferenceCounter();
                 var lstTokenIds = new List<byte[]>();
                 while (iter.Next())
-                    lstTokenIds.Add(iter.Value(refCounter).GetSpan().ToArray());
+                    lstTokenIds.Add(iter.Value().GetSpan().ToArray());
                 return lstTokenIds;
             }
             return Array.Empty<byte[]>();

--- a/src/neoxp/neoxp.csproj
+++ b/src/neoxp/neoxp.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Nito.Disposables" Version="2.5.0" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-        <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoVersion)" />
+        <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoConsensusDbftVersion)" />
         <PackageReference Include="Neo.Plugins.RpcServer" Version="$(NeoVersion)" />
     </ItemGroup>
 

--- a/src/runner/JsonWriterExtensions.cs
+++ b/src/runner/JsonWriterExtensions.cs
@@ -137,7 +137,7 @@ namespace Neo.Test.Runner
                         await writer.WriteStartArrayAsync();
                         while (maxIteratorCount-- > 0 && iterator.Next())
                         {
-                            await writer.WriteStackItemAsync(iterator.Value(null), maxIteratorCount, context);
+                            await writer.WriteStackItemAsync(iterator.Value(), maxIteratorCount, context);
                         }
                         await writer.WriteEndArrayAsync();
                         await writer.WritePropertyNameAsync("truncated");

--- a/src/trace/neotrace.csproj
+++ b/src/trace/neotrace.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-        <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoVersion)" />
+        <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoConsensusDbftVersion)" />
         <PackageReference Include="Neo.Plugins.RpcServer" Version="$(NeoVersion)" />
     </ItemGroup>
     <ItemGroup>

--- a/src/worknet/Commands/WorknetRpcServerPlugin.cs
+++ b/src/worknet/Commands/WorknetRpcServerPlugin.cs
@@ -63,7 +63,8 @@ class WorknetRpcServerPlugin : Plugin
         var response = new JObject();
         response["process-id"] = proc.Id;
 
-        Neo.Utility.Log(nameof(WorknetRpcServerPlugin), LogLevel.Info, $"ExpressShutdown requested. Shutting down in {SHUTDOWN_TIME} seconds");
+        Logs.GetLogger(nameof(WorknetRpcServerPlugin))
+            .Information("ExpressShutdown requested. Shutting down in {ShutdownTime} seconds", SHUTDOWN_TIME);
         cancellationToken.CancelAfter(TimeSpan.FromSeconds(SHUTDOWN_TIME));
         return response;
     }

--- a/src/worknet/neoworknet.csproj
+++ b/src/worknet/neoworknet.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Crayon" Version="2.0.69" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-        <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoVersion)" />
+        <PackageReference Include="Neo.Consensus.DBFT" Version="$(NeoConsensusDbftVersion)" />
         <PackageReference Include="Neo.Plugins.RpcServer" Version="$(NeoVersion)" />
     </ItemGroup>
 

--- a/test/test-runner/JsonWriterExtensionsTests.cs
+++ b/test/test-runner/JsonWriterExtensionsTests.cs
@@ -63,7 +63,7 @@ public class JsonWriterExtensionsTests
             return true;
         }
 
-        public StackItem Value(IReferenceCounter? referenceCounter)
+        public StackItem Value()
             => value;
 
         public void Dispose()

--- a/test/test.bctklib/ToolkitWalletTests.cs
+++ b/test/test.bctklib/ToolkitWalletTests.cs
@@ -47,6 +47,7 @@ public class ToolkitWalletTests
         var wallet = GetWallet(walletName);
 
         Assert.Equal(walletName, wallet.Name);
+        Assert.True(wallet.IsUnlocked);
         Assert.Single(wallet.GetAccounts());
         Assert.NotNull(wallet.GetDefaultAccount());
 
@@ -59,6 +60,16 @@ public class ToolkitWalletTests
         Assert.NotNull(account.Contract);
         var contract = account.Contract;
         Assert.True(expectedScript.Span.SequenceEqual(contract.Script));
+    }
+
+    [Fact]
+    public void NameCanBeUpdated()
+    {
+        var wallet = GetWallet("devhawk");
+
+        wallet.Name = "updated";
+
+        Assert.Equal("updated", wallet.Name);
     }
 
     // [Fact]

--- a/test/test.bctklib/test.bctklib.csproj
+++ b/test/test.bctklib/test.bctklib.csproj
@@ -16,7 +16,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="Neo.Plugins.Storage.RocksDBStore" Version="3.9.2" />
+        <PackageReference Include="Neo.Plugins.Storage.RocksDBStore" Version="3.10.0" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
         <PackageReference Include="Xunit.Combinatorial" Version="2.0.24" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/test/test.workflowvalidation/DevWalletTests.cs
+++ b/test/test.workflowvalidation/DevWalletTests.cs
@@ -1,0 +1,30 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DevWalletTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo;
+using NeoExpress.Models;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class DevWalletTests
+{
+    [Fact]
+    public void WalletRemainsUnlockedAndRenamable()
+    {
+        var wallet = new DevWallet(ProtocolSettings.Default, "dev");
+
+        Assert.True(wallet.IsUnlocked);
+
+        wallet.Name = "renamed";
+
+        Assert.Equal("renamed", wallet.Name);
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+(?:\\.\\d+)?)$"


### PR DESCRIPTION
## Summary
- update Neo Express and Visual DevTracker versioning to 3.10.0
- update Neo core, module, and devpack references for Neo 3.10.0 compatibility
- adapt wallet, iterator, BinarySerializer, and logging usages for Neo 3.10.0 APIs
- keep Neo.Consensus.DBFT pinned to 3.9.1 because Neo.Consensus.DBFT 3.10.0 depends on Neo.ConsoleService 3.10.0, which is not available on NuGet yet

## Testing
- dotnet build neo-express.sln --configuration Debug --no-restore -m:1
- dotnet test test/test.bctklib/test.bctklib.csproj --filter ToolkitWalletTests --configuration Debug --no-restore --verbosity minimal
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter DevWalletTests --configuration Debug --no-restore --verbosity minimal
- dotnet build neo-express.sln --configuration Release --no-restore -m:1
- dotnet test neo-express.sln --configuration Release --no-build --verbosity minimal -m:1
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal