### PR TITLE
Pass sync write options through PersistentTrackingStore.Put

### DIFF
--- a/src/bctklib/persistence/PersistentTrackingStore.cs
+++ b/src/bctklib/persistence/PersistentTrackingStore.cs
@@ -222,7 +222,7 @@ namespace Neo.BlockchainToolkit.Persistence
             key ??= Array.Empty<byte>();
             using var batch = new WriteBatch();
             batch.PutVector(columnFamily, key.AsMemory(), UPDATED_PREFIX, value);
-            db.Write(batch);
+            db.Write(batch, writeOptions);
         }
 
         public void Delete(byte[]? key)


### PR DESCRIPTION
## Problem

`PersistentTrackingStore`'s private `Put(byte[] key, byte[] value, WriteOptions? writeOptions)` overload accepts a `WriteOptions` argument but never forwards it:

```csharp
void Put(byte[]? key, byte[] value, WriteOptions? writeOptions)
{
    ...
    using var batch = new WriteBatch();
    batch.PutVector(columnFamily, key.AsMemory(), UPDATED_PREFIX, value);
    db.Write(batch);   // writeOptions ignored
}
```

Because the parameter is dropped, `PutSync()` — which passes `RocksDbUtility.WriteSyncOptions` specifically to request a synchronous (fsync) write — behaves identically to `Put()`. Neither performs a synchronous write, so the durability guarantee callers expect from `PutSync` is silently lost.

This diverges from `RocksDbStore.PutSync`, which correctly passes `RocksDbUtility.WriteSyncOptions` to its write call.

## Fix

Forward the `writeOptions` argument to `db.Write`:

```csharp
db.Write(batch, writeOptions);
```

`PutSync` now performs a synchronous write; the regular `Put` path passes `null` and keeps its existing asynchronous-write behavior.

## Verification

- `dotnet build neo-express.sln -c Release` succeeds.
- `dotnet test test/test.bctklib` — all 252 tests pass.
- `dotnet format --verify-no-changes` passes for the changed file.

Note: the fsync flag is internal to RocksDB and not observable through the public store API, so this is a wiring fix without a dedicated behavioral test; the change mirrors the established `RocksDbStore.PutSync` pattern.