### PR TITLE
Fix branch coverage counter key mismatch in TestApplicationEngine

### DIFF
--- a/src/bctklib/smart-contract/TestApplicationEngine.cs
+++ b/src/bctklib/smart-contract/TestApplicationEngine.cs
@@ -273,7 +273,7 @@ namespace Neo.BlockchainToolkit.SmartContract
                 branchMaps.Add(branchInstructionInfo.ContractHash, branchMap);
             }
 
-            var (branchCount, continueCount) = branchMap.TryGetValue(offsetIP, out var value)
+            var (branchCount, continueCount) = branchMap.TryGetValue(branchIP, out var value)
                 ? value : (0, 0);
 
             if (currentIP == offsetIP)

--- a/test/test.bctklib/BranchCoverageTests.cs
+++ b/test/test.bctklib/BranchCoverageTests.cs
@@ -1,0 +1,73 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// BranchCoverageTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.VM;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class BranchCoverageTests : IClassFixture<DeployedContractFixture>
+    {
+        readonly DeployedContractFixture deployedContractFixture;
+
+        public BranchCoverageTests(DeployedContractFixture deployedContractFixture)
+        {
+            this.deployedContractFixture = deployedContractFixture;
+        }
+
+        // Builds a small loop whose single conditional branch is taken more than once:
+        //
+        //         push 3
+        //   loop: dec                 ; counter = counter - 1
+        //         dup
+        //         push 0
+        //         jmpgt loop          ; if counter > 0 goto loop (taken while counter > 0)
+        //         drop
+        //         ret
+        //
+        // Starting from 3 the branch instruction is evaluated three times and taken
+        // twice (counter 2 and 1) before falling through at counter 0. The recorded
+        // branch-taken count must therefore accumulate to 2.
+        [Fact]
+        public void Branch_taken_count_accumulates_across_iterations()
+        {
+            using var sb = new ScriptBuilder();
+            sb.EmitPush(3);
+            var loop = sb.Length;
+            sb.Emit(OpCode.DEC);
+            sb.Emit(OpCode.DUP);
+            sb.EmitPush(0);
+            var branchIP = sb.Length;
+            sb.EmitJump(OpCode.JMPGT_L, loop - branchIP);
+            sb.Emit(OpCode.DROP);
+            sb.Emit(OpCode.RET);
+            var script = sb.ToArray();
+
+            // Pass a mock file system so the test is unaffected by the process-global
+            // coverage path environment variable that other engine tests may set.
+            using var snapshot = new StoreCache(deployedContractFixture.Store.GetSnapshot());
+            using var engine = new TestApplicationEngine(snapshot, fileSystem: new MockFileSystem());
+
+            engine.LoadScript(script);
+            engine.Execute().Should().Be(VMState.HALT);
+
+            var scriptHash = Neo.SmartContract.Helper.ToScriptHash(script);
+            var branchMap = engine.GetBranchMap(scriptHash);
+
+            branchMap.Should().ContainKey(branchIP);
+            branchMap[branchIP].branchCount.Should().Be(2);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`TestApplicationEngine.PostExecuteInstruction` records conditional-branch coverage into a per-contract `Dictionary<int, (int branchCount, int continueCount)>`, but it **reads** and **writes** that dictionary with different keys:

```csharp
var (hash, branchIP, offsetIP) = branchInstructionInfo;
...
// read uses offsetIP (the branch *target* address)
var (branchCount, continueCount) = branchMap.TryGetValue(offsetIP, out var value)
    ? value : (0, 0);

if (currentIP == offsetIP)
    branchMap[branchIP] = (branchCount + 1, continueCount);   // write uses branchIP
else if (currentIP == branchIP)
    branchMap[branchIP] = (branchCount, continueCount + 1);   // write uses branchIP
```

Because the read key (`offsetIP`) never matches the write key (`branchIP`), the read-modify-write never accumulates: every branch event reads a default `(0, 0)` from the unrelated `offsetIP` slot and overwrites the `branchIP` slot, so the stored tuple only ever reflects the **last** event rather than the running total. The coverage consumer (`ContractCoverageCollector.RecordBranch` / the raw coverage format) keys branch hits by the branch instruction address, matching the write side — so the emitted branch-coverage counts are wrong.

## Fix

Read the accumulator with `branchIP`, so the read and write operate on the same key and the counters accumulate correctly.

## Verification

- New regression test `BranchCoverageTests` executes a loop whose single conditional branch is taken twice and asserts the recorded branch-taken count is `2`. With the bug present the test fails (`found 0`); with the fix it passes.
- `dotnet test test/test.bctklib` — all 253 tests pass (ran 3× to confirm no flakiness).
- `dotnet format --verify-no-changes` passes for the changed files.

The test passes a `MockFileSystem` to the engine so it is unaffected by the process-global coverage-path environment variable other engine tests set.