### PR TITLE
Throw a clear error when an oracle response references a missing transaction

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -142,6 +142,8 @@ namespace NeoExpress.Node
                 throw new Exception("No oracle nodes available. Have you enabled oracles via the `oracle enable` command?");
 
             var requestTx = NativeContract.Ledger.GetTransactionState(snapshot, request.OriginalTxid);
+            if (requestTx is null)
+                throw new Exception($"Could not find the original transaction {request.OriginalTxid} for the oracle response.");
             var n = oracleNodes.Count;
             var m = n - (n - 1) / 3;
             var oracleSignContract = Contract.CreateMultiSigContract(m, oracleNodes);

--- a/test/test.workflowvalidation/NodeUtilityOracleResponseTests.cs
+++ b/test/test.workflowvalidation/NodeUtilityOracleResponseTests.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NodeUtilityOracleResponseTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Cryptography.ECC;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract.Native;
+using NeoExpress.Node;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class NodeUtilityOracleResponseTests
+{
+    [Fact]
+    public void CreateResponseTx_throws_descriptive_error_when_original_transaction_missing()
+    {
+        // An empty ledger does not contain the request's original transaction, so
+        // GetTransactionState returns null. CreateResponseTx must surface a clear
+        // error rather than dereferencing the null state (NullReferenceException).
+        using var store = new MemoryStore();
+        using var snapshot = new StoreCache(store.GetSnapshot());
+
+        var request = new OracleRequest
+        {
+            OriginalTxid = UInt256.Zero,
+            GasForResponse = 0,
+            Url = string.Empty,
+            Filter = string.Empty,
+            CallbackContract = UInt160.Zero,
+            CallbackMethod = string.Empty,
+            UserData = System.Array.Empty<byte>(),
+        };
+        var response = new OracleResponse
+        {
+            Id = 1,
+            Code = OracleResponseCode.Success,
+            Result = System.Array.Empty<byte>(),
+        };
+        var oracleNodes = new[] { ECCurve.Secp256r1.G };
+
+        var action = () => NodeUtility.CreateResponseTx(snapshot, request, response, oracleNodes, ProtocolSettings.Default);
+
+        action.Should().Throw<System.Exception>()
+            .Which.Should().NotBeOfType<System.NullReferenceException>();
+        action.Should().Throw<System.Exception>()
+            .WithMessage($"*original transaction {UInt256.Zero}*");
+    }
+}


### PR DESCRIPTION
## Problem

`NodeUtility.CreateResponseTx` resolves the oracle request's original transaction and then uses its block index:

```csharp
var requestTx = NativeContract.Ledger.GetTransactionState(snapshot, request.OriginalTxid);
...
ValidUntilBlock = requestTx.BlockIndex + settings.MaxValidUntilBlockIncrement,
```

`LedgerContract.GetTransactionState` returns `null` when the transaction is not present in the ledger. If an oracle response references an original transaction that does not exist, `requestTx.BlockIndex` dereferences `null` and the caller sees an opaque `NullReferenceException` rather than a meaningful error. This path is reachable from both `OfflineNode` and the `ExpressRpcServerPlugin` oracle-response handling.

## Fix

Guard the lookup and throw a descriptive exception that names the missing transaction — consistent with the existing null-guarded lookup in `OfflineNode.GetTransactionHeight` (which already uses `GetTransactionState(...)?.BlockIndex`).

```csharp
if (requestTx is null)
    throw new Exception($"Could not find the original transaction {request.OriginalTxid} for the oracle response.");
```

## Verification

- New regression test `NodeUtilityOracleResponseTests` calls `CreateResponseTx` against an empty ledger and asserts the result is the descriptive error and **not** a `NullReferenceException`. With the guard removed the test fails (the call throws `NullReferenceException`); with the fix it passes.
- `dotnet build neo-express.sln -c Release` succeeds.
- CI-filtered `dotnet test` across the solution passes (test.workflowvalidation 61, all others green).
- `dotnet format --verify-no-changes` passes for the changed files.