### PR TITLE
Enforce the fast-forward block-count cap in batch files

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -189,6 +189,7 @@ namespace NeoExpress.Commands
                         }
                     case CommandLineApplication<BatchFileCommands.FastForward> cmd:
                         {
+                            FastForwardCommand.ValidateCount(cmd.Model.Count);
                             var timestampDelta = FastForwardCommand.ParseTimestampDelta(cmd.Model.TimestampDelta);
                             await txExec.ExpressNode.FastForwardAsync(
                                 cmd.Model.Count,


### PR DESCRIPTION
## Problem

The standalone `fastfwd` command guards against extreme block counts:

```csharp
// FastForwardCommand.OnExecuteAsync
ValidateCount(Count);   // throws if Count > MaxFastForwardCount (100_000)
```

The batch-file `fastfwd` handler in `BatchCommand` called `FastForwardAsync` directly, skipping that check:

```csharp
case CommandLineApplication<BatchFileCommands.FastForward> cmd:
{
    var timestampDelta = FastForwardCommand.ParseTimestampDelta(cmd.Model.TimestampDelta);
    await txExec.ExpressNode.FastForwardAsync(cmd.Model.Count, timestampDelta);
    ...
}
```

`Count` is a `uint`, and `NodeUtility.FastForwardAsync` loops `for (int i = 0; i < blockCount; i++)` minting and persisting a signed block each iteration with no internal upper bound. A batch line like `fastfwd 4294967295` would therefore attempt to mint billions of blocks — effectively an unbounded disk-fill that wedges the dev machine — and is inconsistent with the standalone command's guard.

## Fix

Call `FastForwardCommand.ValidateCount(cmd.Model.Count)` in the batch handler before minting, so both paths enforce the same 100,000-block cap.

## Verification

- `ValidateCount` is already covered by `FastForwardCommandTests.ValidateCount_rejects_extreme_counts`; this change routes the batch path through that same validated guard.
- `dotnet build src/neoxp -c Release` succeeds.
- `dotnet test` (CI-filtered) passes — test.workflowvalidation 60, including the FastForward and batch-parser tests.
- `dotnet format --verify-no-changes` passes for the changed file.

Note: the batch dispatch path constructs a live offline node (RocksDB), so end-to-end batch execution is exercised by the integration suites rather than the fast unit tests; the cap itself is unit-tested via `ValidateCount`.