### PR TITLE
Resolve batch contract update NEF path against the batch file directory

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -181,7 +181,7 @@ namespace NeoExpress.Commands
                         {
                             await txExec.ContractUpdateAsync(
                                 cmd.Model.Contract,
-                                cmd.Model.NefFile,
+                                root.Resolve(cmd.Model.NefFile),
                                 cmd.Model.Account,
                                 cmd.Model.Password,
                                 cmd.Model.WitnessScope).ConfigureAwait(false);


### PR DESCRIPTION
## Problem

In a batch file, handlers that take a file path resolve it against the batch file's directory using `root.Resolve(...)`:

```csharp
// contract deploy
await txExec.ContractDeployAsync(root.Resolve(cmd.Model.Contract), ...);
// contract invoke
var script = await txExec.LoadInvocationScriptAsync(root.Resolve(cmd.Model.InvocationFile));
```

The `contract update` handler passed the NEF path through unresolved:

```csharp
await txExec.ContractUpdateAsync(cmd.Model.Contract, cmd.Model.NefFile, ...);
```

`ContractUpdateAsync` ultimately loads the file via `fileSystem.LoadContractAsync(nefFilePath)`, so an unresolved relative path is interpreted relative to the current working directory rather than the batch file's directory. Running the batch from any other directory therefore breaks `contract update`, inconsistent with `deploy`/`invoke`.

## Fix

Resolve the NEF path with `root.Resolve(cmd.Model.NefFile)`. `root.Resolve` returns fully-qualified paths unchanged and combines relative paths with the batch directory, matching the deploy and invoke handlers.

## Verification

- `dotnet build src/neoxp -c Release` succeeds.
- `dotnet test` (CI-filtered) passes, including the batch-parser tests.
- `dotnet format --verify-no-changes` passes for the changed file.

Note: end-to-end batch dispatch constructs a live offline node, so it is exercised by the integration suites; this change mirrors the already-established `root.Resolve` pattern used by the sibling handlers in the same switch.