### PR TITLE
Dispose the express node in contract get/storage and oracle list commands

### DIFF
--- a/src/neoxp/Commands/ContractCommand.Get.cs
+++ b/src/neoxp/Commands/ContractCommand.Get.cs
@@ -52,7 +52,7 @@ namespace NeoExpress.Commands
             internal async Task ExecuteAsync(TextWriter writer)
             {
                 var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                var expressNode = chainManager.GetExpressNode();
+                using var expressNode = chainManager.GetExpressNode();
 
                 using var jsonWriter = new JsonTextWriter(writer) { Formatting = Formatting.Indented };
                 if (UInt160.TryParse(Contract, out var contractHash))

--- a/src/neoxp/Commands/ContractCommand.Storage.cs
+++ b/src/neoxp/Commands/ContractCommand.Storage.cs
@@ -106,7 +106,7 @@ namespace NeoExpress.Commands
                 internal async Task ExecuteAsync(TextWriter writer)
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                    var expressNode = chainManager.GetExpressNode();
+                    using var expressNode = chainManager.GetExpressNode();
 
                     if (UInt160.TryParse(Contract, out var hash))
                     {
@@ -161,7 +161,7 @@ namespace NeoExpress.Commands
 
                 internal static async Task ExecuteAsync(ExpressChainManager chainManager, string contract, string key, string value, TextWriter writer)
                 {
-                    var expressNode = chainManager.GetExpressNode();
+                    using var expressNode = chainManager.GetExpressNode();
                     ContractParameterParser parser = await expressNode.GetContractParameterParserAsync(chainManager.Chain).ConfigureAwait(false);
                     var scriptHash = parser.TryLoadScriptHash(contract, out var hash)
                         ? hash

--- a/src/neoxp/Commands/OracleCommand.List.cs
+++ b/src/neoxp/Commands/OracleCommand.List.cs
@@ -30,7 +30,7 @@ namespace NeoExpress.Commands
             internal async Task ExecuteAsync(TextWriter writer)
             {
                 var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                var expressNode = chainManager.GetExpressNode();
+                using var expressNode = chainManager.GetExpressNode();
                 var oracleNodes = await expressNode.ListOracleNodesAsync();
 
                 await writer.WriteLineAsync($"Oracle Nodes ({oracleNodes.Count}): ").ConfigureAwait(false);


### PR DESCRIPTION
## Problem

Commands acquire the offline express node with a `using` declaration so it is disposed when the command finishes, e.g.:

```csharp
using var expressNode = chainManager.GetExpressNode();
```

Four sites omitted `using` and leaked the node:

- `ContractCommand.Get.ExecuteAsync` (line 55)
- `ContractCommand.Storage` — `get` (line 109) and `update` (line 164)
- `OracleCommand.List.ExecuteAsync` (line 33)

`GetExpressNode()` returns an `OfflineNode` whose `Dispose()` unsubscribes the process-global `ApplicationEngine.InstanceHandler` event and disposes the `NeoSystem` (which closes the underlying RocksDB-backed store). Skipping disposal leaks the native store handle and leaves the static event subscription alive.

## Fix

Add the `using` declaration at the four sites so they match the disposal idiom used by the ~14 sibling command sites. In each case `expressNode` is a method-local that is not returned or captured, so the `using` scope cleanly spans its usage.

## Verification

- `dotnet build neo-express.sln -c Release` succeeds.
- `dotnet test` (CI-filtered) passes across the solution (workflowvalidation 60, bctklib 252, all others green).
- `dotnet format --verify-no-changes` passes for the changed files.
- A repo-wide grep confirms no remaining `GetExpressNode()` call site lacks `using`.