### PR TITLE
Dispose snapshot cache in NEP compliance RPC methods

### DIFF
--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -684,7 +684,8 @@ namespace NeoExpress.Node
                 throw new NullReferenceException(nameof(neoSystem));
             var nep11Hash = AsScriptHash(@param);
 
-            var nep11 = new Nep11Token(neoSystem.Settings, neoSystem.GetSnapshotCache(), nep11Hash);
+            using var snapshot = neoSystem.GetSnapshotCache();
+            var nep11 = new Nep11Token(neoSystem.Settings, snapshot, nep11Hash);
 
             return nep11.HasValidMethods() &&
                 nep11.IsSymbolValid() &&
@@ -699,7 +700,8 @@ namespace NeoExpress.Node
                 throw new NullReferenceException(nameof(neoSystem));
             var nep17Hash = AsScriptHash(@param);
 
-            var nep17 = new Nep17Token(neoSystem.Settings, neoSystem.GetSnapshotCache(), nep17Hash);
+            using var snapshot = neoSystem.GetSnapshotCache();
+            var nep17 = new Nep17Token(neoSystem.Settings, snapshot, nep17Hash);
 
             return nep17.HasValidMethods() &&
                 nep17.IsSymbolValid() &&

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -440,26 +440,30 @@ namespace NeoExpress.Node
 
         public Task<bool> IsNep17CompliantAsync(UInt160 contractHash)
         {
-            var snapshot = neoSystem.GetSnapshotCache();
+            using var snapshot = neoSystem.GetSnapshotCache();
             var validator = new Nep17Token(ProtocolSettings, snapshot, contractHash);
 
-            return Task.FromResult(
+            var isCompliant =
                 validator.HasValidMethods() &&
                 validator.IsSymbolValid() &&
                 validator.IsDecimalsValid() &&
-                validator.IsBalanceOfValid());
+                validator.IsBalanceOfValid();
+
+            return Task.FromResult(isCompliant);
         }
 
         public Task<bool> IsNep11CompliantAsync(UInt160 contractHash)
         {
-            var snapshot = neoSystem.GetSnapshotCache();
+            using var snapshot = neoSystem.GetSnapshotCache();
             var validator = new Nep11Token(ProtocolSettings, snapshot, contractHash);
 
-            return Task.FromResult(
+            var isCompliant =
                 validator.HasValidMethods() &&
                 validator.IsSymbolValid() &&
                 validator.IsDecimalsValid() &&
-                validator.IsBalanceOfValid());
+                validator.IsBalanceOfValid();
+
+            return Task.FromResult(isCompliant);
         }
     }
 }


### PR DESCRIPTION
## Problem

`ExpressIsNep11Compliant` and `ExpressIsNep17Compliant` created a snapshot cache and passed it directly into the token validator without disposing it:

```csharp
var nep11 = new Nep11Token(neoSystem.Settings, neoSystem.GetSnapshotCache(), nep11Hash);
```

`GetSnapshotCache()` returns a `StoreCache` that owns an underlying RocksDB snapshot and must be disposed. `Nep11Token`/`Nep17Token` (via `TokenBase`) are not disposable and only hold the snapshot for the duration of the synchronous validity checks. Every other RPC method in this plugin acquires the snapshot as `using var snapshot = neoSystem.GetSnapshotCache();`. These two methods did not, so each call leaked a `StoreCache` and its native snapshot.

## Fix

Capture the snapshot in a `using`-scoped local and pass that to the validator, matching the eight sibling RPC methods. `TokenBase` uses the snapshot only inside the synchronous `HasValidMethods`/`IsSymbolValid`/`IsDecimalsValid`/`IsBalanceOfValid` calls, all of which complete before the method returns, so the `using` scope is safe.

## Verification

- `dotnet build src/neoxp -c Release` succeeds.
- `dotnet test` (CI-filtered) passes (test.workflowvalidation 60).
- `dotnet format --verify-no-changes` passes for the changed file.

Note: these handlers require a live `NeoSystem`/RPC server, so they are covered by the integration suites rather than the fast unit tests; the change mirrors the established `using var snapshot` idiom used throughout the same plugin.