### PR TITLE
Drain process output and dispose process resources in ProcessRunner

### DIFF
--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -48,7 +48,7 @@ namespace Neo.BuildTasks
                 WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? "" : workingDirectory,
             };
 
-            var process = new System.Diagnostics.Process
+            using var process = new System.Diagnostics.Process
             {
                 StartInfo = startInfo,
                 EnableRaisingEvents = true,
@@ -60,7 +60,7 @@ namespace Neo.BuildTasks
             var error = new ConcurrentQueue<string>();
             process.ErrorDataReceived += (sender, args) => { if (args.Data != null) { error.Enqueue(args.Data); } };
 
-            var completeEvent = new ManualResetEvent(false);
+            using var completeEvent = new ManualResetEvent(false);
 
             process.Exited += (sender, args) => completeEvent.Set();
 
@@ -70,8 +70,14 @@ namespace Neo.BuildTasks
             process.BeginErrorReadLine();
 
             completeEvent.WaitOne();
+            // The Exited event can fire before the asynchronous output and error
+            // handlers have finished receiving the redirected streams. The
+            // parameterless WaitForExit blocks until that processing completes, so
+            // the captured output and error are complete before they are returned.
+            process.WaitForExit();
 
-            return new ProcessResults(process.ExitCode, output, error);
+            var exitCode = process.ExitCode;
+            return new ProcessResults(exitCode, output, error);
         }
     }
 }

--- a/test/test-build-tasks/TestProcessRunner.cs
+++ b/test/test-build-tasks/TestProcessRunner.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestProcessRunner.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BuildTasks;
+using System.Linq;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestProcessRunner
+    {
+        // Runs a real, fast, cross-platform process (the dotnet host, which is on
+        // PATH wherever these tests run) that writes to stdout and exits 0. This
+        // exercises the real ProcessRunner end to end and verifies that the
+        // redirected output is fully drained before the results are returned --
+        // the parameterless WaitForExit guarantees the async output handlers have
+        // completed, so no trailing lines are dropped.
+        [Fact]
+        public void Run_captures_complete_output_and_exit_code()
+        {
+            var runner = new ProcessRunner();
+
+            var results = runner.Run("dotnet", "--version");
+
+            Assert.Equal(0, results.ExitCode);
+            Assert.NotEmpty(results.Output);
+            Assert.All(results.Output, line => Assert.NotNull(line));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ProcessRunner.Run` blocked on a `ManualResetEvent` set by `Process.Exited`, then returned immediately:

```csharp
process.Exited += (sender, args) => completeEvent.Set();
...
completeEvent.WaitOne();
return new ProcessResults(process.ExitCode, output, error);
```

The `Exited` event can fire **before** the asynchronous `OutputDataReceived`/`ErrorDataReceived` handlers have finished receiving the redirected streams, so the returned `ProcessResults` could be missing trailing output/error lines. `DotNetToolTask.ContainsPackage` parses the full `dotnet tool list` table, so a dropped row yields a spurious "package not found" and an intermittent build failure. The `Process` and `ManualResetEvent` were also never disposed.

This matches the documented .NET guidance: when output is redirected to asynchronous handlers, call the parameterless `WaitForExit()` after the process exits to ensure async output processing has completed.

## Fix

- Call the parameterless `process.WaitForExit()` after the exit signal so the async output handlers are guaranteed to have drained before the output/error are read.
- Wrap `Process` and `ManualResetEvent` in `using` declarations.

## Verification

- New test `TestProcessRunner.Run_captures_complete_output_and_exit_code` runs a real process (`dotnet --version`, on PATH wherever the tests run) through the real `ProcessRunner` and asserts the output is captured and the exit code is `0`. Ran 3× to confirm reliability.
- `dotnet test test/test-build-tasks` — all 24 tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.

Note: the output-drain race is timing-dependent and cannot be reproduced deterministically; the new test covers the real `ProcessRunner` happy path (previously only the mocked `IProcessRunner` was tested) and the fix follows the documented `WaitForExit` pattern.