### PR TITLE
Treat a zero exit code as success in DotNetToolTask regardless of stderr

### DIFF
--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -122,12 +122,9 @@ namespace Neo.BuildTasks
         {
             var results = processRunner.Run(command, arguments, directory?.ItemSpec ?? "");
 
-            if (results.ExitCode != 0 || results.Error.Any())
+            if (results.ExitCode != 0)
             {
-                if (results.ExitCode != 0)
-                    Log.LogError("{0} returned {1}", Command, results.ExitCode);
-                else
-                    Log.LogWarning("{0} returned {1}", Command, results.ExitCode);
+                Log.LogError("{0} returned {1}", Command, results.ExitCode);
 
                 foreach (var err in results.Error)
                 {
@@ -140,6 +137,14 @@ namespace Neo.BuildTasks
 
                 output = Array.Empty<string>();
                 return false;
+            }
+
+            // A zero exit code indicates success even when the tool wrote to
+            // stderr (for example dotnet telemetry or NuGet notices). Surface any
+            // stderr lines as warnings rather than failing the task.
+            foreach (var err in results.Error)
+            {
+                Log.LogWarning(err);
             }
 
             output = results.Output;

--- a/test/test-build-tasks/TestDotNetToolTaskStdErr.cs
+++ b/test/test-build-tasks/TestDotNetToolTaskStdErr.cs
@@ -1,0 +1,71 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestDotNetToolTaskStdErr.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.Build.Framework;
+using Moq;
+using Neo.BuildTasks;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestDotNetToolTaskStdErr
+    {
+        class StubTask : DotNetToolTask
+        {
+            protected override string Command => "nccs";
+            protected override string PackageId => "Neo.Compiler.CSharp";
+            protected override string GetArguments() => string.Empty;
+
+            public StubTask(IProcessRunner processRunner) : base(processRunner) { }
+        }
+
+        // A zero exit code is success even if the tool wrote to stderr (dotnet
+        // telemetry, NuGet notices, etc.). Previously TryExecute treated any
+        // stderr output as a failure, which produced spurious build failures.
+        [Fact]
+        public void TryExecute_succeeds_on_exit_code_zero_with_stderr_output()
+        {
+            var expectedOutput = new[] { "tool output line" };
+            var processRunner = new Mock<IProcessRunner>();
+            processRunner
+                .Setup(r => r.Run("dotnet", "tool list --local", It.IsAny<string>()))
+                .Returns(new ProcessResults(0, expectedOutput, new[] { "a benign stderr notice" }));
+
+            var task = new StubTask(processRunner.Object)
+            {
+                BuildEngine = new Mock<IBuildEngine>().Object,
+            };
+
+            var success = task.TryExecute("dotnet", "tool list --local", null, out var output);
+
+            Assert.True(success);
+            Assert.Equal(expectedOutput, output);
+        }
+
+        [Fact]
+        public void TryExecute_fails_on_nonzero_exit_code()
+        {
+            var processRunner = new Mock<IProcessRunner>();
+            processRunner
+                .Setup(r => r.Run("dotnet", "tool list --local", It.IsAny<string>()))
+                .Returns(new ProcessResults(1, new[] { "output" }, new[] { "an error" }));
+
+            var task = new StubTask(processRunner.Object)
+            {
+                BuildEngine = new Mock<IBuildEngine>().Object,
+            };
+
+            var success = task.TryExecute("dotnet", "tool list --local", null, out var output);
+
+            Assert.False(success);
+            Assert.Empty(output);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`DotNetToolTask.TryExecute` failed whenever the process wrote anything to stderr, even on a successful (exit code 0) run:

```csharp
if (results.ExitCode != 0 || results.Error.Any())
{
    ...
    output = Array.Empty<string>();
    return false;
}
```

`dotnet` and the tools it invokes routinely write to stderr on success — first-run telemetry notices, NuGet messages, etc. So a perfectly successful `dotnet tool list` could be treated as a failure, producing spurious build errors.

## Fix

Base success on the exit code alone:

- Non-zero exit code: unchanged — log the error (plus stderr/stdout) and return `false`.
- Zero exit code: surface any stderr lines as warnings and return the output (`true`).

## Verification

- New tests in `TestDotNetToolTaskStdErr`: a zero exit code with stderr output now **succeeds** (with the old condition this test fails), and a non-zero exit code still **fails**.
- `dotnet test test/test-build-tasks` — all 25 tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.