### PR TITLE
Avoid null dereference for an unknown contract in worknet prefetch

### DIFF
--- a/src/worknet/Commands/PrefetchCommand.cs
+++ b/src/worknet/Commands/PrefetchCommand.cs
@@ -55,13 +55,13 @@ class PrefetchCommand
             if (!UInt160.TryParse(Contract, out var contractHash))
             {
                 var info = contracts.SingleOrDefault(c => c.Name.Equals(Contract, StringComparison.OrdinalIgnoreCase));
-                contractHash = info!.Hash ?? UInt160.Zero;
+                contractHash = info?.Hash ?? UInt160.Zero;
             }
 
             if (contractHash == UInt160.Zero)
                 throw new Exception("Invalid Contract argument");
 
-            var contractName = contracts.SingleOrDefault(c => c.Hash == contractHash)!.Name;
+            var contractName = contracts.SingleOrDefault(c => c.Hash == contractHash)?.Name;
             if (string.IsNullOrEmpty(contractName))
                 throw new Exception("Invalid Contract argument");
 


### PR DESCRIPTION
## Problem

`PrefetchCommand` resolves the target contract with `SingleOrDefault`, which returns `null` when nothing matches, then dereferences the result unconditionally:

```csharp
var info = contracts.SingleOrDefault(c => c.Name.Equals(Contract, StringComparison.OrdinalIgnoreCase));
contractHash = info!.Hash ?? UInt160.Zero;          // NRE if name not found
...
var contractName = contracts.SingleOrDefault(c => c.Hash == contractHash)!.Name;   // NRE if hash not found
```

`ContractInfo` is a record (reference type), so an unknown contract name or hash makes `SingleOrDefault` return `null`, and the `!` dereference throws a `NullReferenceException` before the intended `"Invalid Contract argument"` error is reached.

## Fix

Use null-conditional access:

- `info?.Hash ?? UInt160.Zero` — an unmatched name resolves to `UInt160.Zero`, which the existing zero check turns into the clear error.
- `SingleOrDefault(...)?.Name` — an unmatched hash resolves to a null name, which the existing `IsNullOrEmpty` check turns into the clear error.

## Verification

- `dotnet build src/worknet -c Release` succeeds with no new warnings on the file.
- `dotnet format --verify-no-changes` passes for the changed file.

Note: worknet has no unit-test project and `OnExecuteAsync` requires a loaded worknet and RocksDB data directory, so this command is covered at the integration level; the change is a localized null-safety fix that routes unknown contracts to the existing validation errors.