### PR TITLE
Honor the because reason in StorageItemAssertions.Be

### DIFF
--- a/src/assertions/StorageItemAssertions.cs
+++ b/src/assertions/StorageItemAssertions.cs
@@ -28,6 +28,7 @@ namespace Neo.Assertions
             where T : IEquatable<T>
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .Given(() => convert(Subject.Value))
                 .ForCondition(subject => subject.Equals(expected))
                 .FailWith("Expected {context:StorageItem} to be {0}{reason}, but was {1}.",

--- a/test/test-assertions/StorageItemAssertionsTests.cs
+++ b/test/test-assertions/StorageItemAssertionsTests.cs
@@ -43,6 +43,17 @@ public class StorageItemAssertionsTests
     }
 
     [Fact]
+    public void Be_includes_the_supplied_reason_in_the_failure_message()
+    {
+        var item = new StorageItem(new BigInteger(1).ToByteArray());
+
+        var act = () => item.Should().Be(new BigInteger(2), "of {0}", "the configured value");
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*because of the configured value*");
+    }
+
+    [Fact]
     public void Be_UInt160_matches_raw_bytes()
     {
         var hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");


### PR DESCRIPTION
## Problem

`StorageItemAssertions.Be<T>` builds a failure message containing the `{reason}` placeholder, but never calls `BecauseOf`:

```csharp
Execute.Assertion
    .Given(() => convert(Subject.Value))
    .ForCondition(subject => subject.Equals(expected))
    .FailWith("Expected {context:StorageItem} to be {0}{reason}, but was {1}.",
        _ => expected, subject => subject);
```

Without `BecauseOf`, the `{reason}` placeholder is always empty, so any `because`/`becauseArgs` a caller passes to `Be(...)` are silently dropped from the failure message. The sibling `StackItemAssertions` applies `BecauseOf` to its assertions.

## Fix

Apply `.BecauseOf(because, becauseArgs)` to the assertion chain so the supplied reason is rendered into the message.

## Verification

- New test `Be_includes_the_supplied_reason_in_the_failure_message` asserts the custom reason appears in the failure message. With `BecauseOf` removed the test fails; with the fix it passes.
- `dotnet test test/test-assertions` — all 18 tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.