### PR TITLE
Resolve bundled neoxp target framework at runtime

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpress.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpress.ts
@@ -1,4 +1,5 @@
 import * as childProcess from "child_process";
+import * as fs from "fs";
 import * as vscode from "vscode";
 import * as which from "which";
 
@@ -30,18 +31,35 @@ export default class NeoExpress {
   private checkForDotNetPassedAt: number;
 
   constructor(private readonly context: vscode.ExtensionContext) {
-    this.binaryPath = posixPath(
-      this.context.extensionPath,
-      "deps",
-      "nxp",
-      "tools",
-      "net6.0",
-      "any",
-      "neoxp.dll"
-    );
+    this.binaryPath = NeoExpress.resolveBinaryPath(this.context.extensionPath);
     this.dotnetPath = which.sync("dotnet", { nothrow: true }) || "dotnet";
     this.runLock = false;
     this.checkForDotNetPassedAt = 0;
+  }
+
+  // A packed .NET tool places its assemblies under tools/<target-framework>/any/.
+  // Resolve the framework folder at runtime so the path tracks the bundled
+  // Neo.Express target framework instead of a hardcoded value that breaks
+  // whenever the tool is repacked for a newer framework.
+  private static resolveBinaryPath(extensionPath: string): string {
+    const toolsRoot = posixPath(extensionPath, "deps", "nxp", "tools");
+    try {
+      const framework = fs
+        .readdirSync(toolsRoot)
+        .find((tfm) =>
+          fs.existsSync(posixPath(toolsRoot, tfm, "any", "neoxp.dll"))
+        );
+      if (framework) {
+        return posixPath(toolsRoot, framework, "any", "neoxp.dll");
+      }
+    } catch {
+      // toolsRoot is missing or unreadable; fall through to the error below.
+    }
+    Log.error(
+      LOG_PREFIX,
+      `Could not locate bundled neoxp under ${toolsRoot}; the extension package may be incomplete.`
+    );
+    return posixPath(toolsRoot, "neoxp.dll");
   }
 
   async runInTerminal(name: string, command: Command, ...options: string[]) {


### PR DESCRIPTION
## Problem

The extension builds the path to the bundled `neoxp` assembly with a hardcoded `net6.0` framework folder:

```ts
this.binaryPath = posixPath(
  this.context.extensionPath, "deps", "nxp", "tools", "net6.0", "any", "neoxp.dll");
```

`Neo.Express` is packed as a .NET tool (`PackAsTool`) targeting `net10.0`, so the bundled assembly is laid out under `deps/nxp/tools/net10.0/any/neoxp.dll`. The hardcoded `net6.0` path does not exist, so every neoxp invocation from the extension (run/stop/create/checkpoint/contract/transfer/wallet and the invoke-file editor) launches `dotnet <missing path>` and fails. The path has to be updated by hand on every framework bump.

## Fix

Resolve the target-framework folder at runtime: locate the `tools/<tfm>/any` directory that actually contains `neoxp.dll`. The path now tracks whatever framework the bundled tool targets, with no per-bump maintenance. If no bundled assembly is found, a clear error is logged.

## Verification

- `npx tsc --noEmit` passes (exit 0).
- `eslint` reports no new warnings on the changed file (the 4 remaining warnings are pre-existing, outside the changed region).
- `npm run test:quickstart` passes (4/4).
- Validated the resolver against a fixture laid out as `tools/net10.0/any/neoxp.dll`: it resolves that path, and falls back to a logged error when the bundle is absent.