### PR TITLE
Fix VSCode extension release workflow

### DIFF
--- a/.github/workflows/vse-release.yml
+++ b/.github/workflows/vse-release.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v5.2.0
@@ -26,7 +28,7 @@ jobs:
     - name: Setup NodeJS
       uses: actions/setup-node@v6.4.0
       with:
-        node-version: '16'
+        node-version: '22'
 
     - name: Build + Package extension
       run: |


### PR DESCRIPTION
## Problem

`.github/workflows/vse-release.yml` (the workflow that packages and publishes the extension to the VS Code Marketplace) has two defects:

1. **Shallow checkout breaks versioning.** `actions/checkout` runs with no `fetch-depth`, then `dotnet/nbgv` runs in the next step. Nerdbank.GitVersioning needs full git history to compute the version, which feeds both the release tag and the published `.vsix` version. A shallow clone produces a wrong or unstable version. The other workflows (e.g. `standalone.yml`) already set `fetch-depth: 0`.

2. **Build runs on EOL Node 16.** The toolchain in `devDependencies` (eslint, gulp, typescript, webpack, `@types/node`) targets Node >= 18, and PR CI (`pr_extension.yml`) already runs on Node 22. Publishing from an unsupported Node version produces the marketplace artifact with an untested toolchain.

## Fix

- Add `fetch-depth: 0` to the checkout so nbgv computes the correct version.
- Set `node-version: '22'` to match PR CI.

## Verification

- The workflow YAML parses and the two values resolve as expected (`fetch-depth: 0`, `node-version: 22`).