### PR TITLE
Assign a random nonce to offline-minted blocks

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -39,11 +39,21 @@ namespace NeoExpress.Node
             transactions ??= Array.Empty<Transaction>();
 
             var blockHeight = prevHeader.Index + 1;
+
+            // dBFT assigns each block a random nonce. Mirror that here so the block
+            // nonce contribution to System.Runtime.GetRandom varies per block instead
+            // of being a constant 0, which otherwise makes on-chain randomness behave
+            // differently from a real network.
+            Span<byte> nonceBuffer = stackalloc byte[sizeof(ulong)];
+            System.Security.Cryptography.RandomNumberGenerator.Fill(nonceBuffer);
+            var nonce = BitConverter.ToUInt64(nonceBuffer);
+
             var block = new Block
             {
                 Header = new Header
                 {
                     Version = 0,
+                    Nonce = nonce,
                     PrevHash = prevHeader.Hash,
                     MerkleRoot = MerkleTree.ComputeRoot(transactions.Select(t => t.Hash).ToArray()),
                     Timestamp = timestamp > prevHeader.Timestamp


### PR DESCRIPTION
## Problem

`NodeUtility.CreateSignedBlock` builds the block header without setting `Nonce`, so every block minted by the offline node — `transfer`, `contract invoke/run`, `batch`, `checkpoint`, and `fastfwd` — has `Nonce = 0`.

The Neo VM mixes the persisting block's nonce into the `System.Runtime.GetRandom` seed. A constant `0` nonce makes that contribution a no-op, so contracts that rely on `GetRandom` (lotteries, random NFT traits, games) observe a frozen nonce component on a local chain. On a real network dBFT assigns each block a random nonce, so this is a silent divergence in exactly the randomness path developers need to trust.

## Fix

Generate a random nonce per block, mirroring dBFT:

```csharp
Span<byte> nonceBuffer = stackalloc byte[sizeof(ulong)];
System.Security.Cryptography.RandomNumberGenerator.Fill(nonceBuffer);
var nonce = BitConverter.ToUInt64(nonceBuffer);
```

Offline block timestamps already come from the wall clock (`DateTime.UtcNow`), so offline-minted blocks were never byte-reproducible across runs; assigning a random nonce changes no existing reproducibility guarantee.

## Verification

- `dotnet build neo-express.sln -c Release` succeeds.
- `dotnet test` (CI-filtered) passes across the solution — 361 tests, including the checkpoint create/restore tests that mint blocks.
- `dotnet format --verify-no-changes` passes for the changed file.