### PR TITLE
Mark the 3.6 changelog entry as released

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@ may not exactly match a publicly released version.
 * Updated to .NET 10.0
 * Updated all dependencies to Neo 3.9.1 compatible versions
 
-## [3.6] - Unreleased
+## [3.6] - 2023-11-15
 
 ### Added
 


### PR DESCRIPTION
## Problem

The `[3.6]` changelog section is still labeled `Unreleased`:

```
## [3.6] - Unreleased
```

3.6 was released long ago — the `release/v3.6.0`–`release/v3.6.7` branches and the `3.6.94` tag exist, and the features listed under the entry (private key on `create`/`wallet create`, `wallet create` in batch files, the global `~/.neo-express` directory, `contract update`, etc.) are all present in the current code. Because the entry sits below the released `3.9.1` and `3.10.0` entries while still marked `Unreleased`, it reads as if long-shipped features were never released.

## Fix

Date the entry to the 3.6.0 release (`2023-11-15`, the finalized `release/v3.6.0` branch). The entry's position is already correct reverse-chronological order, so only the status label changes.

## Verification

- Single-line documentation change; the surrounding entries and ordering are unchanged.