### PR TITLE
Note the default block time in the readme quick start

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ neoxp run
 neoxp show balances genesis
 ```
 
-> **Tip:** While the blockchain is running it mints a new block every 15 seconds by
+> **Tip:** While the blockchain is running it mints a new block every 3 seconds by
 > default, so a transaction is not reflected in queries such as `show balances` until the
 > next block is produced. For faster local iteration, start the chain with a shorter block
 > time, for example `neoxp run --seconds-per-block 1`.

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,11 @@ neoxp run
 neoxp show balances genesis
 ```
 
+> **Tip:** While the blockchain is running it mints a new block every 15 seconds by
+> default, so a transaction is not reflected in queries such as `show balances` until the
+> next block is produced. For faster local iteration, start the chain with a shorter block
+> time, for example `neoxp run --seconds-per-block 1`.
+
 ### Neo-Express
 
 - Create a new local Neo network:


### PR DESCRIPTION
## Problem

The readme quick start starts a chain with `neoxp run` and immediately queries balances, but never mentions that a running chain mints a new block every 15 seconds by default (documented only in the command reference). A developer coming from an instant-mining tool runs a command, immediately queries, sees no change, and concludes the tool is broken — a common first-run abandonment trigger.

## Fix

Add a short tip after the quick start: a running chain mints a block every 15 seconds by default, so state is not visible until the next block, and `neoxp run --seconds-per-block 1` produces faster blocks for local iteration.

## Verification

- Documentation-only change. The 15-second default and the `--seconds-per-block` option are both as documented in `docs/command-reference.md` and implemented by `RunCommand`.