### PR TITLE
Add a NeoTrace command reference

### DIFF
--- a/docs/trace-command-reference.md
+++ b/docs/trace-command-reference.md
@@ -1,0 +1,52 @@
+<!-- markdownlint-enable -->
+# NeoTrace Command Reference
+
+NeoTrace generates `.neo-trace` files for transactions on public Neo N3 blockchains. These
+files can be opened in the [Neo Smart Contract Debugger](https://github.com/neo-project/neo-debugger)
+to step through the recorded execution.
+
+> NeoTrace depends on the target node running the StateService plugin module with
+> `FullState` enabled. The official MainNet and TestNet JSON-RPC nodes are configured this
+> way.
+
+Each traced transaction is written to a `<transaction-hash>.neo-trace` file in the current
+directory.
+
+## neotrace block
+
+```
+Usage: neotrace block [Options] <BlockIdentifier>
+
+Arguments:
+  <BlockIdentifier>  Block index or hash
+
+Options:
+  --rpc-uri <RPC_URI>  URL of a Neo JSON-RPC node. Specify MainNet (the default),
+                       TestNet, or a JSON-RPC URL.
+```
+
+Traces every transaction in the specified block. The block can be identified by index or
+by hash.
+
+```shell
+neotrace block 365110 --rpc-uri testnet
+```
+
+## neotrace transaction
+
+```
+Usage: neotrace transaction [Options] <TransactionHash>
+
+Arguments:
+  <TransactionHash>  Transaction hash
+
+Options:
+  --rpc-uri <RPC_URI>  URL of a Neo JSON-RPC node. Specify MainNet (the default),
+                       TestNet, or a JSON-RPC URL.
+```
+
+Traces the specified transaction. `tx` is an alias for `transaction`.
+
+```shell
+neotrace tx 0xef1917b8601828e1d2f3ed0954907ea611cb734771609ce0ce2b654bb5c78005 --rpc-uri testnet
+```

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,8 @@ Please review the [Command Reference](docs/command-reference.md) to get an under
   neotrace tx 0xef1917b8601828e1d2f3ed0954907ea611cb734771609ce0ce2b654bb5c78005 --rpc-uri testnet
   ```
 
+Please review the [NeoTrace Command Reference](docs/trace-command-reference.md) for the full list of commands and options.
+
 > Note: Neo-Trace depends on the [StateService plugin module](https://github.com/neo-project/neo-modules/tree/master/src/StateService) running with `FullState` enabled. The official JSON-RPC nodes for MainNet and TestNet (such as `http://seed1.neo.org:10332` and `http://seed1t5.neo.org:20332`) are configured to run the StateService plugin with `FullState` enabled.
 
 ## New Features or issues


### PR DESCRIPTION
## Problem

NeoTrace is branded co-equally with Neo Express ("Neo-Express and Neo-Trace") and ships its own `neotrace` tool, but it has no command reference. The readme shows two examples; the command surface is otherwise undocumented.

## Fix

Add `docs/trace-command-reference.md` documenting the actual surface:

- `neotrace block <index-or-hash>` — trace all transactions in a block.
- `neotrace transaction <tx-hash>` (alias `tx`) — trace a single transaction.
- The `--rpc-uri` option (MainNet default / TestNet / JSON-RPC URL).
- The StateService `FullState` prerequisite and the `<hash>.neo-trace` output written to the current directory.

Link it from the readme's Neo-Trace section, mirroring how the Neo-Express section links to the command reference.

## Verification

- Commands, alias, option, and examples match the source (`src/trace/Commands/BlockCommand.cs`, `TransactionCommand.cs`, `Program.cs`).
- The relative link target resolves to the new file.