### PR TITLE
Decode binary contract parameters on the heap

### DIFF
--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -519,10 +519,13 @@ namespace Neo.BlockchainToolkit
             static byte[] ParseBinary(JToken json)
             {
                 var value = json.Value<string>() ?? "";
-                Span<byte> span = stackalloc byte[value.Length / 4 * 3];
-                if (Convert.TryFromBase64String(value, span, out var written))
+                // Decode on the heap rather than via stackalloc: the buffer length is
+                // derived from the (untrusted) input string, so a large value would
+                // overflow the stack with an uncatchable StackOverflowException.
+                var buffer = new byte[value.Length / 4 * 3];
+                if (Convert.TryFromBase64String(value, buffer, out var written))
                 {
-                    return span.Slice(0, written).ToArray();
+                    return buffer[..written];
                 }
 
                 if (TryParseHexString(value, out var byteArray))

--- a/test/test.bctklib/ContractParameterParserTest.cs
+++ b/test/test.bctklib/ContractParameterParserTest.cs
@@ -48,6 +48,26 @@ namespace test.bctklib
         }
 
         [Fact]
+        public void ParseObjectParameter_bytearray_large_base64()
+        {
+            // The decode buffer is sized from the input string length. A large value
+            // must be decoded on the heap; the previous stackalloc overflowed the stack.
+            var expected = new byte[4 * 1024 * 1024];
+            var value = Convert.ToBase64String(expected);
+            var json = new JObject()
+            {
+                ["type"] = "ByteArray",
+                ["value"] = value
+            };
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION);
+            var param = parser.ParseObjectParameter(json);
+            param.Type.Should().Be(ContractParameterType.ByteArray);
+            param.Value.Should().BeOfType<byte[]>();
+            ((byte[])param.Value).Length.Should().Be(expected.Length);
+            ((byte[])param.Value).AsSpan().SequenceEqual(expected).Should().BeTrue();
+        }
+
+        [Fact]
         public void ParseObjectParameter_bytearray_hex()
         {
             var value = "0xbcbbcd38fb0c097be28e6aef0177f5d65534eb3b";


### PR DESCRIPTION
## Problem

`ContractParameterParser.ParseBinary` sizes a `stackalloc` buffer from the length of the input string:

```csharp
var value = json.Value<string>() ?? "";
Span<byte> span = stackalloc byte[value.Length / 4 * 3];
```

`value` comes from a parameter or invocation file (reachable via `LoadInvocationScriptAsync` / `ParseObjectParameter`). The whole-file 4 MiB cap does not bound an individual string value, so a value of a few hundred KB or more produces a multi-hundred-KB+ `stackalloc` and overflows the stack. `StackOverflowException` is uncatchable — it crashes the process — and the surrounding `try/catch` only filters `JsonException`/`FormatException`.

## Fix

Allocate the decode buffer on the heap (`new byte[...]`). Behavior is otherwise unchanged: base64 is attempted first, then hex.

## Verification

- New regression test `ParseObjectParameter_bytearray_large_base64` parses a 4 MiB byte array encoded as base64. With the previous `stackalloc` the test process crashes (stack overflow, exit code 134); with the heap buffer it passes.
- `dotnet test test/test.bctklib` — all 253 tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.