### PR TITLE
Bound StackItem deserialization recursion depth

### DIFF
--- a/src/bctklib/formatters/StackItemFormatter.cs
+++ b/src/bctklib/formatters/StackItemFormatter.cs
@@ -30,70 +30,87 @@ namespace MessagePack.Formatters.Neo.BlockchainToolkit
     {
         public static readonly StackItemFormatter Instance = new StackItemFormatter();
 
+        // Bound on StackItem nesting depth. StackItems are read from (potentially
+        // untrusted) .neo-trace files and Map/Array/Struct recurse, so a deeply nested
+        // payload would otherwise overflow the stack with an uncatchable
+        // StackOverflowException. The standard MessagePack options used for trace files
+        // treat data as trusted and do not enforce a depth limit, so it is enforced here.
+        const int MaxDepth = 500;
+
         public StackItem Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            var count = reader.ReadArrayHeader();
-            if (count != 2)
-                throw new MessagePackSerializationException($"Invalid StackItem Array Header {count}");
-
-            var type = options.Resolver.GetFormatterWithVerify<StackItemType>().Deserialize(ref reader, options);
-            switch (type)
+            if (reader.Depth >= MaxDepth)
+                throw new MessagePackSerializationException($"StackItem nesting exceeds the maximum supported depth of {MaxDepth}");
+            reader.Depth++;
+            try
             {
-                case StackItemType.Any:
-                    reader.ReadNil();
-                    return StackItem.Null;
-                case StackItemType.Boolean:
-                    return reader.ReadBoolean() ? StackItem.True : StackItem.False;
-                case StackItemType.Buffer:
-                    {
-                        var bytes = options.Resolver.GetFormatter<byte[]>()!.Deserialize(ref reader, options);
-                        return new NeoBuffer(bytes);
-                    }
-                case StackItemType.ByteString:
-                    {
-                        var bytes = options.Resolver.GetFormatter<byte[]>()!.Deserialize(ref reader, options);
-                        return new NeoByteString(bytes);
-                    }
-                case StackItemType.Integer:
-                    {
-                        var integer = options.Resolver.GetFormatterWithVerify<BigInteger>().Deserialize(ref reader, options);
-                        return new NeoInteger(integer);
-                    }
-                case StackItemType.InteropInterface:
-                    {
-                        var typeName = options.Resolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
-                        return new TraceInteropInterface(typeName);
-                    }
-                case StackItemType.Pointer:
-                    reader.ReadNil();
-                    return new NeoPointer(Array.Empty<byte>(), 0);
-                case StackItemType.Map:
-                    {
-                        var map = new NeoMap();
-                        var mapCount = reader.ReadMapHeader();
-                        for (int i = 0; i < mapCount; i++)
-                        {
-                            var key = (PrimitiveType)Deserialize(ref reader, options);
-                            map[key] = Deserialize(ref reader, options);
-                        }
-                        return map;
-                    }
-                case StackItemType.Array:
-                case StackItemType.Struct:
-                    {
-                        var array = type == StackItemType.Array
-                            ? new NeoArray()
-                            : new NeoStruct();
-                        var arrayCount = reader.ReadArrayHeader();
-                        for (int i = 0; i < arrayCount; i++)
-                        {
-                            array.Add(Deserialize(ref reader, options));
-                        }
-                        return array;
-                    }
-            }
+                var count = reader.ReadArrayHeader();
+                if (count != 2)
+                    throw new MessagePackSerializationException($"Invalid StackItem Array Header {count}");
 
-            throw new MessagePackSerializationException($"Invalid StackItem {type}");
+                var type = options.Resolver.GetFormatterWithVerify<StackItemType>().Deserialize(ref reader, options);
+                switch (type)
+                {
+                    case StackItemType.Any:
+                        reader.ReadNil();
+                        return StackItem.Null;
+                    case StackItemType.Boolean:
+                        return reader.ReadBoolean() ? StackItem.True : StackItem.False;
+                    case StackItemType.Buffer:
+                        {
+                            var bytes = options.Resolver.GetFormatter<byte[]>()!.Deserialize(ref reader, options);
+                            return new NeoBuffer(bytes);
+                        }
+                    case StackItemType.ByteString:
+                        {
+                            var bytes = options.Resolver.GetFormatter<byte[]>()!.Deserialize(ref reader, options);
+                            return new NeoByteString(bytes);
+                        }
+                    case StackItemType.Integer:
+                        {
+                            var integer = options.Resolver.GetFormatterWithVerify<BigInteger>().Deserialize(ref reader, options);
+                            return new NeoInteger(integer);
+                        }
+                    case StackItemType.InteropInterface:
+                        {
+                            var typeName = options.Resolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                            return new TraceInteropInterface(typeName);
+                        }
+                    case StackItemType.Pointer:
+                        reader.ReadNil();
+                        return new NeoPointer(Array.Empty<byte>(), 0);
+                    case StackItemType.Map:
+                        {
+                            var map = new NeoMap();
+                            var mapCount = reader.ReadMapHeader();
+                            for (int i = 0; i < mapCount; i++)
+                            {
+                                var key = (PrimitiveType)Deserialize(ref reader, options);
+                                map[key] = Deserialize(ref reader, options);
+                            }
+                            return map;
+                        }
+                    case StackItemType.Array:
+                    case StackItemType.Struct:
+                        {
+                            var array = type == StackItemType.Array
+                                ? new NeoArray()
+                                : new NeoStruct();
+                            var arrayCount = reader.ReadArrayHeader();
+                            for (int i = 0; i < arrayCount; i++)
+                            {
+                                array.Add(Deserialize(ref reader, options));
+                            }
+                            return array;
+                        }
+                }
+
+                throw new MessagePackSerializationException($"Invalid StackItem {type}");
+            }
+            finally
+            {
+                reader.Depth--;
+            }
         }
 
         public void Serialize(ref MessagePackWriter writer, StackItem? value, MessagePackSerializerOptions options)

--- a/test/test.bctklib/StackItemFormatterTests.cs
+++ b/test/test.bctklib/StackItemFormatterTests.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StackItemFormatterTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using MessagePack;
+using MessagePack.Formatters.Neo.BlockchainToolkit;
+using MessagePack.Resolvers;
+using System.Buffers;
+using Xunit;
+using StackItemType = Neo.VM.Types.StackItemType;
+
+namespace test.bctklib
+{
+    public class StackItemFormatterTests
+    {
+        [Fact]
+        public void Deserialize_bounds_recursion_depth()
+        {
+            var options = MessagePackSerializerOptions.Standard.WithResolver(TraceDebugResolver.Instance);
+            var typeFormatter = options.Resolver.GetFormatterWithVerify<StackItemType>();
+
+            // Build a StackItem payload nested deeper than the allowed depth with a loop
+            // (not recursion) so constructing the test input cannot itself overflow.
+            var bufferWriter = new ArrayBufferWriter<byte>();
+            var writer = new MessagePackWriter(bufferWriter);
+            // MessagePack's default MaxDepth is 500; nest beyond it to trip the guard.
+            const int depth = 600;
+            for (int i = 0; i < depth; i++)
+            {
+                writer.WriteArrayHeader(2);
+                typeFormatter.Serialize(ref writer, StackItemType.Array, options);
+                writer.WriteArrayHeader(1);
+            }
+            writer.WriteArrayHeader(2);
+            typeFormatter.Serialize(ref writer, StackItemType.Any, options);
+            writer.WriteNil();
+            writer.Flush();
+            var bytes = bufferWriter.WrittenMemory.ToArray();
+
+            var act = () =>
+            {
+                var reader = new MessagePackReader(bytes);
+                StackItemFormatter.Instance.Deserialize(ref reader, options);
+            };
+
+            act.Should().Throw<MessagePackSerializationException>();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`StackItemFormatter.Deserialize` recurses for `Map`, `Array`, and `Struct` items with no depth limit:

```csharp
case StackItemType.Array:
case StackItemType.Struct:
    ...
    for (int i = 0; i < arrayCount; i++)
        array.Add(Deserialize(ref reader, options));   // unbounded recursion
```

StackItems are read from `.neo-trace` files, and `StackItemFormatter` is a shipped bctklib API used to read them. A deeply nested payload recurses until the stack overflows with an uncatchable `StackOverflowException` that crashes the process. The `MessagePackSerializerOptions.Standard` options used for trace files treat the data as trusted and **do not** enforce a depth limit (verified: a 100k-deep payload still crashes even when calling `options.Security.DepthStep`).

## Fix

Enforce a depth limit explicitly using the reader's depth counter: reject payloads nested beyond 500 levels (MessagePack's own default depth limit) with a catchable `MessagePackSerializationException`, and maintain the counter with a `try/finally`. Real traces nest far shallower, so legitimate data is unaffected.

Most of the diff is the existing `switch` body being re-indented into the new `try` block; the logical change is the depth check plus the counter increment/decrement.

## Verification

- New regression test `StackItemFormatterTests.Deserialize_bounds_recursion_depth` builds a payload nested past the limit (with a loop, so building the input cannot itself overflow) and asserts the descriptive exception. With the limit removed the test fails (the old code returns without error and overflows on deeper input).
- `dotnet test test/test.bctklib` — all 253 tests pass, including `TraceDebugTests` which round-trip real StackItems, confirming legitimate traces are unaffected.
- `dotnet format --verify-no-changes` passes for the changed files.