### PR TITLE
Ignore duplicate script when collecting contract coverage

### DIFF
--- a/src/collector/ContractCoverageCollector.cs
+++ b/src/collector/ContractCoverageCollector.cs
@@ -55,7 +55,11 @@ namespace Neo.Collector
         {
             if (this.instructionMap.Count > 0)
             {
-                throw new InvalidOperationException($"RecordScript already called for {contractName}");
+                // A contract can appear in the coverage output as both a .nef and a
+                // .neo-script (deployed and executed); both describe the same script,
+                // so ignore the duplicate rather than failing, which would otherwise
+                // drop this contract's coverage entirely.
+                return;
             }
 
             var instructionMap = new SortedDictionary<int, Instruction>();

--- a/test/test-collector/RecordScriptTests.cs
+++ b/test/test-collector/RecordScriptTests.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RecordScriptTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Collector;
+using Neo.Collector.Models;
+using System;
+using Xunit;
+
+namespace test_collector;
+
+public class RecordScriptTests
+{
+    [Fact]
+    public void RecordScript_ignores_duplicate_script_for_same_contract()
+    {
+        // A contract present in the coverage output as both a .nef and a .neo-script
+        // records its script twice. The second call must not throw, which would
+        // otherwise drop the contract's coverage.
+        var debugInfo = new NeoDebugInfo(
+            Hash160.Zero,
+            string.Empty,
+            Array.Empty<string>(),
+            Array.Empty<NeoDebugInfo.Method>());
+        var collector = new ContractCoverageCollector("contract", debugInfo);
+        var script = new byte[] { (byte)OpCode.PUSH1, (byte)OpCode.RET };
+
+        collector.RecordScript(script.EnumerateInstructions());
+        var exception = Record.Exception(() => collector.RecordScript(script.EnumerateInstructions()));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Problem

`CodeCoverageCollector` records a contract's script from the coverage output, dispatching `.nef` files to `LoadNef` and `.neo-script` files to `LoadScript` — both of which call `ContractCoverageCollector.RecordScript` for the same contract hash. A contract that is both deployed and executed produces both files, so `RecordScript` is called twice and the second call throws:

```csharp
if (this.instructionMap.Count > 0)
    throw new InvalidOperationException($"RecordScript already called for {contractName}");
```

The caller catches and logs the exception, so that contract's coverage is dropped.

## Fix

Both files describe the same script, so ignore the duplicate: return early when the script has already been recorded instead of throwing.

## Verification

- New test `RecordScriptTests.RecordScript_ignores_duplicate_script_for_same_contract` records a script twice and asserts the second call does not throw. With the previous `throw` the test fails (`RecordScript already called`).
- `dotnet test test/test-collector` — all tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.