### PR TITLE
Tolerate a missing coverage directory at session end

### DIFF
--- a/src/collector/CodeCoverageCollector.cs
+++ b/src/collector/CodeCoverageCollector.cs
@@ -117,6 +117,17 @@ namespace Neo.Collector
 
         public void LoadCoverageFiles(string coveragePath)
         {
+            // The coverage directory is created lazily, the first time an engine
+            // writes coverage data. A test session that produced no coverage never
+            // creates it, so guard against it being absent rather than letting
+            // Directory.EnumerateFiles throw out of the session-end handler.
+            if (!Directory.Exists(coveragePath))
+            {
+                if (verboseLog)
+                    logger.LogWarning($"Coverage output directory {coveragePath} does not exist");
+                return;
+            }
+
             foreach (var filename in Directory.EnumerateFiles(coveragePath))
             {
                 if (verboseLog)

--- a/test/test-collector/LoadCoverageFilesTests.cs
+++ b/test/test-collector/LoadCoverageFilesTests.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// LoadCoverageFilesTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Moq;
+using Neo.Collector;
+using System;
+using System.IO;
+using Xunit;
+
+namespace test_collector;
+
+public class LoadCoverageFilesTests
+{
+    [Fact]
+    public void LoadCoverageFiles_ignores_missing_directory()
+    {
+        // When a test session produces no coverage, the coverage directory is never
+        // created. Loading from a missing directory must not throw.
+        var logger = new Mock<ILogger>();
+        var collector = new CodeCoverageCollector(logger.Object);
+        var missingPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        var exception = Record.Exception(() => collector.LoadCoverageFiles(missingPath));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Problem

`CodeCoverageDataCollector` picks a fresh, non-existent temp path for its coverage output and relies on it being created lazily — the coverage writer creates the directory the first time an engine writes coverage data. A test session that produces no coverage never creates it.

At session end the collector calls:

```csharp
collector?.LoadCoverageFiles(coveragePath);
```

and `LoadCoverageFiles` enumerates the directory with no existence check:

```csharp
foreach (var filename in Directory.EnumerateFiles(coveragePath))
```

For a session with no coverage, `coveragePath` does not exist and `Directory.EnumerateFiles` throws `DirectoryNotFoundException` out of the session-end handler.

## Fix

Return early from `LoadCoverageFiles` when the directory does not exist.

## Verification

- New test `LoadCoverageFilesTests.LoadCoverageFiles_ignores_missing_directory` calls `LoadCoverageFiles` with a missing directory and asserts it does not throw. Without the guard the test fails with `DirectoryNotFoundException`.
- `dotnet test test/test-collector` — all tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.