### PR TITLE
Remove dead FindPaths method from coverage collector

### DIFF
--- a/src/collector/ContractCoverageCollector.cs
+++ b/src/collector/ContractCoverageCollector.cs
@@ -12,7 +12,6 @@ using Neo.Collector.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace Neo.Collector
 {
@@ -69,47 +68,6 @@ namespace Neo.Collector
         public ContractCoverage CollectCoverage()
         {
             return new(contractName, debugInfo, instructionMap, hitMap, branchMap);
-        }
-
-        internal IEnumerable<ImmutableQueue<int>> FindPaths(int address, ImmutableQueue<int>? path = null, int methodEnd = int.MaxValue, int nextSPAddress = int.MaxValue)
-        {
-            var maxAddress = instructionMap.Keys.Max();
-            path = path is null ? ImmutableQueue<int>.Empty : path;
-
-            while (true)
-            {
-                var ins = address <= maxAddress
-                    ? instructionMap[address]
-                    : new Instruction(OpCode.RET);
-
-                if (ins.IsBranchInstruction())
-                {
-                }
-
-                if (ins.IsCallInstruction())
-                {
-                    var offset = ins.GetCallOffset();
-                    var paths = Enumerable.Empty<ImmutableQueue<int>>();
-                    foreach (var callPath in FindPaths(address + offset))
-                    {
-                        var tempPath = path;
-                        foreach (var item in callPath)
-                        {
-                            tempPath = tempPath.Enqueue(item);
-                        }
-                        paths = paths.Concat(FindPaths(address + ins.Size, tempPath, methodEnd, nextSPAddress));
-                    }
-                    return paths;
-                }
-
-                address += ins.Size;
-                if (ins.OpCode == OpCode.RET
-                    || address > methodEnd
-                    || address >= nextSPAddress)
-                {
-                    return Enumerable.Repeat(path, 1);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`ContractCoverageCollector.FindPaths` is never invoked — a repo-wide search finds only its own recursive self-calls, no external caller. It also carries latent defects:

- an empty `if (ins.IsBranchInstruction()) { }` body that does nothing,
- `instructionMap.Keys.Max()`, which throws `InvalidOperationException` on an empty instruction map,
- unbounded recursion with no visited set.

## Fix

Remove the dead method and the `using System.Linq;` import that was only used by it.

The `IsBranchInstruction`, `IsCallInstruction`, and `GetCallOffset` helpers it referenced are defined in `Extensions` and used elsewhere, so they are unaffected.

## Verification

- A repo-wide search confirms `FindPaths` had no external caller.
- `dotnet build src/collector -c Release` succeeds with no new warnings on the changed file (and the `System.Linq` removal compiles, confirming it was unused).
- `dotnet test test/test-collector` passes.
- `dotnet format --verify-no-changes` passes for the changed file.