### PR TITLE
Guard state-service download loops against a non-advancing cursor

### DIFF
--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -201,7 +201,7 @@ namespace Neo.BlockchainToolkit.Persistence
                     }
                     if (!found.Truncated || found.Results.Length == 0)
                         break;
-                    from = found.Results[^1].key;
+                    from = EnsureCursorAdvanced(from, found.Results[^1].key);
                 }
                 return contracts;
             }
@@ -542,7 +542,7 @@ namespace Neo.BlockchainToolkit.Persistence
                     var found = await rpcClient.FindStatesAsync(branchInfo.RootHash, contractHash, prefixOwner.Memory, from).ConfigureAwait(false);
                     token.ThrowIfCancellationRequested();
                     callback?.Invoke(found);
-                    if (WriteFoundStates(found, snapshot, out from, ref count, loggerName))
+                    if (WriteFoundStates(found, snapshot, ref from, ref count, loggerName))
                         break;
                 }
                 snapshot.Commit();
@@ -575,7 +575,7 @@ namespace Neo.BlockchainToolkit.Persistence
                     token.ThrowIfCancellationRequested();
                     var found = rpcClient.FindStates(branchInfo.RootHash, contractHash, prefixOwner.Memory.Span, from);
                     token.ThrowIfCancellationRequested();
-                    if (WriteFoundStates(found, snapshot, out from, ref count, loggerName))
+                    if (WriteFoundStates(found, snapshot, ref from, ref count, loggerName))
                         break;
                 }
                 snapshot.Commit();
@@ -621,7 +621,20 @@ namespace Neo.BlockchainToolkit.Persistence
             return owner;
         }
 
-        bool WriteFoundStates(RpcFoundStates found, ICacheSnapshot snapshot, out byte[] from, ref int count, string loggerName)
+        // A truncated FindStates page must advance past the previous query cursor:
+        // results are returned in ascending key order, so the last key of a page is
+        // strictly greater than the cursor it was queried with. A node that returns a
+        // truncated page without advancing the cursor would otherwise drive an
+        // unbounded loop that re-fetches the same page forever and accumulates state
+        // without limit, so reject it.
+        internal static byte[] EnsureCursorAdvanced(byte[] previous, byte[] next)
+        {
+            if (((ReadOnlySpan<byte>)next).SequenceCompareTo(previous) <= 0)
+                throw new InvalidOperationException("State service returned a truncated result that did not advance the query cursor");
+            return next;
+        }
+
+        bool WriteFoundStates(RpcFoundStates found, ICacheSnapshot snapshot, ref byte[] from, ref int count, string loggerName)
         {
             ValidateFoundStates(branchInfo.RootHash, found);
             count += found.Results.Length;
@@ -641,7 +654,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 return true;
             }
 
-            from = found.Results[^1].key;
+            from = EnsureCursorAdvanced(from, found.Results[^1].key);
             return false;
         }
     }

--- a/test/test.bctklib/StateServiceStoreCursorTests.cs
+++ b/test/test.bctklib/StateServiceStoreCursorTests.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StateServiceStoreCursorTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.Persistence;
+using System;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class StateServiceStoreCursorTests
+    {
+        [Fact]
+        public void EnsureCursorAdvanced_returns_an_advancing_cursor()
+        {
+            var key = new byte[] { 1, 2, 3 };
+
+            StateServiceStore.EnsureCursorAdvanced(Array.Empty<byte>(), key).Should().Equal(key);
+            StateServiceStore.EnsureCursorAdvanced(new byte[] { 1, 2 }, key).Should().Equal(key);
+            StateServiceStore.EnsureCursorAdvanced(new byte[] { 1, 2, 2 }, key).Should().Equal(key);
+        }
+
+        [Fact]
+        public void EnsureCursorAdvanced_rejects_a_non_advancing_cursor()
+        {
+            var key = new byte[] { 1, 2, 3 };
+
+            // node returned the same last key
+            Assert.Throws<InvalidOperationException>(
+                () => StateServiceStore.EnsureCursorAdvanced(key, new byte[] { 1, 2, 3 }));
+            // cursor moved backward
+            Assert.Throws<InvalidOperationException>(
+                () => StateServiceStore.EnsureCursorAdvanced(key, new byte[] { 1, 2, 2 }));
+            // cursor is an earlier (shorter) prefix
+            Assert.Throws<InvalidOperationException>(
+                () => StateServiceStore.EnsureCursorAdvanced(key, new byte[] { 1, 2 }));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`StateServiceStore` pages through `FindStates` results, advancing the query cursor to the last key of each truncated page:

```csharp
from = found.Results[^1].key;
```

This happens in the shared `WriteFoundStates` helper (used by `DownloadStatesAsync`/`DownloadStates`) and in the `GetContractsAsync` loop. Neither checks that the cursor actually advanced. `FindStates` returns keys in ascending order, so a well-behaved node always moves the cursor forward — but a malfunctioning or malicious state node that returns a truncated page with the same (or an earlier) last key drives the loop forever, re-fetching the same page and accumulating state without bound (an unbounded-memory / hang DoS against any worknet/neotrace consumer pointed at it).

## Fix

Route both cursor updates through a single guard, `EnsureCursorAdvanced`, which rejects a cursor that does not move strictly forward (lexicographic byte order):

```csharp
if (((ReadOnlySpan<byte>)next).SequenceCompareTo(previous) <= 0)
    throw new InvalidOperationException("...did not advance the query cursor");
```

A legitimate node never trips this, since each truncated page's last key is strictly greater than the cursor it was queried with.

## Verification

- New tests `StateServiceStoreCursorTests` cover the guard: advancing cursors (including from an empty/shorter prefix) are returned; an identical, backward, or shorter-prefix cursor throws. Weakening the guard makes the rejection test fail, confirming it is meaningful.
- `dotnet test test/test.bctklib` — all 254 tests pass (the `out`→`ref` signature change and both call sites compile and regress nothing).
- `dotnet format --verify-no-changes` passes for the changed files.

Note: the cursor logic sits behind MPT-proof validation and the buggy behavior is an infinite loop, so it cannot be exercised end-to-end in a focused unit test; the advance check is extracted into a pure, directly-tested helper and applied at both cursor sites.