### PR TITLE
Write the State payload when serializing a NotificationRecord

### DIFF
--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -69,10 +69,6 @@ namespace NeoExpress.Models
         public void Serialize(BinaryWriter writer)
         {
             ScriptHash.Serialize(writer);
-            // Write the serialized State bytes the paired Deserialize reads. The
-            // BinarySerializer.Serialize(StackItem, ExecutionEngineLimits) overload
-            // returns the bytes rather than writing to the stream, so its result must
-            // be written explicitly; previously it was discarded, omitting State.
             writer.Write(BinarySerializer.Serialize(State, ExecutionEngineLimits.Default));
             writer.WriteVarString(EventName);
             InventoryHash.Serialize(writer);

--- a/src/neoxp/Models/NotificationRecord.cs
+++ b/src/neoxp/Models/NotificationRecord.cs
@@ -69,7 +69,11 @@ namespace NeoExpress.Models
         public void Serialize(BinaryWriter writer)
         {
             ScriptHash.Serialize(writer);
-            BinarySerializer.Serialize(State, ExecutionEngineLimits.Default);
+            // Write the serialized State bytes the paired Deserialize reads. The
+            // BinarySerializer.Serialize(StackItem, ExecutionEngineLimits) overload
+            // returns the bytes rather than writing to the stream, so its result must
+            // be written explicitly; previously it was discarded, omitting State.
+            writer.Write(BinarySerializer.Serialize(State, ExecutionEngineLimits.Default));
             writer.WriteVarString(EventName);
             InventoryHash.Serialize(writer);
             writer.Write((byte)InventoryType);

--- a/test/test.workflowvalidation/NotificationRecordTests.cs
+++ b/test/test.workflowvalidation/NotificationRecordTests.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NotificationRecordTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
+using NeoExpress.Models;
+using System.Linq;
+using Xunit;
+using ByteString = Neo.VM.Types.ByteString;
+using Integer = Neo.VM.Types.Integer;
+using NeoArray = Neo.VM.Types.Array;
+
+namespace test.workflowvalidation;
+
+public class NotificationRecordTests
+{
+    [Fact]
+    public void Serialize_round_trips_state()
+    {
+        var state = new NeoArray(new Neo.VM.Types.StackItem[]
+        {
+            new ByteString(new byte[20]),
+            new ByteString(Enumerable.Repeat((byte)1, 20).ToArray()),
+            new Integer(100),
+        });
+        var record = new NotificationRecord(UInt160.Zero, "Transfer", state, (InventoryType)0, UInt256.Zero);
+
+        var round = record.ToArray().AsSerializable<NotificationRecord>();
+
+        round.EventName.Should().Be("Transfer");
+        round.State.Count.Should().Be(3);
+        round.State[2].GetInteger().Should().Be(100);
+    }
+}


### PR DESCRIPTION
## Problem

`NotificationRecord.Serialize` discards the serialized `State`:

```csharp
public void Serialize(BinaryWriter writer)
{
    ScriptHash.Serialize(writer);
    BinarySerializer.Serialize(State, ExecutionEngineLimits.Default);   // returns bytes; result discarded
    writer.WriteVarString(EventName);
    ...
}
```

`BinarySerializer.Serialize(StackItem, ExecutionEngineLimits)` is the overload that **returns** the serialized bytes rather than writing them to the stream, and the return value is dropped. So `State` is never written, while `Deserialize` still reads it:

```csharp
State = (Neo.VM.Types.Array)BinarySerializer.Deserialize(ref reader, ExecutionEngineLimits.Default);
```

Serialize and deserialize are therefore asymmetric. After the script hash, the reader interprets the `EventName` var-string length byte as a `StackItem` type tag and throws `FormatException: Invalid StackItemType`. Every persisted notification round-trip is corrupted.

This is a regression from commit 9588707, which changed the writer overload `BinarySerializer.Serialize(writer, State, ...)` to the byte-returning overload.

## Fix

Write the serialized `State` bytes that the paired `Deserialize` reads:

```csharp
writer.Write(BinarySerializer.Serialize(State, ExecutionEngineLimits.Default));
```

Reusing the byte-returning overload keeps serialize and deserialize symmetric by construction (the `Size` calculation already accounts for the State bytes).

## Verification

- New test `NotificationRecordTests.Serialize_round_trips_state` builds a record with a non-empty `State` array, round-trips it through `ToArray()`/`AsSerializable<NotificationRecord>()`, and asserts the State survives. With the discarded result the test fails with `FormatException: Invalid StackItemType(8)`; with the fix it passes.
- `dotnet test` (CI-filtered) passes — test.workflowvalidation 62.
- `dotnet format --verify-no-changes` passes for the changed files.