### PR TITLE
Fix swapped name and namespace when parsing debug info

### DIFF
--- a/src/bctklib/models/DebugInfo.cs
+++ b/src/bctklib/models/DebugInfo.cs
@@ -115,7 +115,7 @@ namespace Neo.BlockchainToolkit.Models
             var (@namespace, name) = ParseName(token["name"]);
             var @params = ParseSlotVariables(token["params"]).ToImmutableList();
 
-            return new Event(id, name, @namespace, @params);
+            return new Event(id, @namespace, name, @params);
         }
 
         static SequencePoint ParseSequencePoint(JToken token)
@@ -144,7 +144,7 @@ namespace Neo.BlockchainToolkit.Models
                 ?? Array.Empty<SequencePoint>();
             var range = ParseRange(token["range"]);
 
-            return new Method(id, name, @namespace, range, @return, @params, variables, sequencePoints);
+            return new Method(id, @namespace, name, range, @return, @params, variables, sequencePoints);
         }
 
         static (string, string) ParseName(JToken? token)

--- a/test/test.bctklib/DebugInfoNameTests.cs
+++ b/test/test.bctklib/DebugInfoNameTests.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DebugInfoNameTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.Models;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class DebugInfoNameTests
+    {
+        [Fact]
+        public void Parse_assigns_method_and_event_namespace_and_name()
+        {
+            // Debug-info names are encoded "namespace,name".
+            var json = new JObject
+            {
+                ["hash"] = "0xf69e5188632deb3a9273519efc86cb68da8d42b8",
+                ["methods"] = new JArray(new JObject
+                {
+                    ["id"] = "0",
+                    ["name"] = "NS.Sub,DoThing",
+                    ["range"] = "0-1",
+                }),
+                ["events"] = new JArray(new JObject
+                {
+                    ["id"] = "1",
+                    ["name"] = "My.Namespace,Transfer",
+                    ["params"] = new JArray(),
+                }),
+            };
+
+            var debugInfo = DebugInfo.Parse(json);
+
+            debugInfo.Methods[0].Namespace.Should().Be("NS.Sub");
+            debugInfo.Methods[0].Name.Should().Be("DoThing");
+            debugInfo.Events[0].Namespace.Should().Be("My.Namespace");
+            debugInfo.Events[0].Name.Should().Be("Transfer");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Debug-info method and event names are encoded as `"namespace,name"`. `ParseName` splits and returns `(namespace, name)`:

```csharp
return values.Length == 2 ? (values[0], values[1]) : throw ...;   // (namespace, name)
```

But `ParseMethod` and `ParseEvent` build the records with the destructured values in the wrong positions:

```csharp
var (@namespace, name) = ParseName(token["name"]);
return new Method(id, name, @namespace, range, ...);   // record is (Id, Namespace, Name, Range, ...)
return new Event(id, name, @namespace, @params);       // record is (Id, Namespace, Name, Parameters)
```

So `Name` received the namespace and `Namespace` received the name. A method `"DevHawk.Contracts.DomainStorage,Get"` parsed to `Name == "DevHawk.Contracts.DomainStorage"`, `Namespace == "Get"`.

## Fix

Pass the arguments in the record's order (`@namespace` then `name`) in both `ParseMethod` and `ParseEvent`.

## Verification

- New test `DebugInfoNameTests` parses a method `"NS.Sub,DoThing"` and event `"My.Namespace,Transfer"` and asserts `Name`/`Namespace` are correct. With the swap the test fails (`Namespace` holds `"DoThing"`).
- `dotnet test test/test.bctklib` — all 253 tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.