### PR TITLE
Fix out-of-range access in FileNameUtilities for degenerate paths

### DIFF
--- a/src/bctklib/FileNameUtilities.cs
+++ b/src/bctklib/FileNameUtilities.cs
@@ -57,13 +57,13 @@ namespace Neo.BlockchainToolkit
         internal static string GetDirectoryName(string path)
         {
             int fileNameStart = IndexOfFileName(path);
-            while (fileNameStart >= 0
+            while (fileNameStart > 0
                 && IsDirectorySeparator(path[fileNameStart - 1]))
             {
                 fileNameStart--;
             }
 
-            return (fileNameStart <= 0) ? path : path.Substring(0, fileNameStart);
+            return (fileNameStart <= 0) ? string.Empty : path.Substring(0, fileNameStart);
         }
 
         internal static string TrimStartDirectorySeparators(string path)
@@ -72,7 +72,8 @@ namespace Neo.BlockchainToolkit
                 return path;
 
             var i = 0;
-            while (IsDirectorySeparator(path[i]))
+            while (i < path.Length
+                && IsDirectorySeparator(path[i]))
             {
                 i++;
             }

--- a/test/test.bctklib/FileNameUtilitiesTests.cs
+++ b/test/test.bctklib/FileNameUtilitiesTests.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// FileNameUtilitiesTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class FileNameUtilitiesTests
+    {
+        [Theory]
+        [InlineData("Contract.cs", "")]
+        [InlineData("a", "")]
+        [InlineData("", "")]
+        [InlineData("/foo", "")]
+        [InlineData("foo/bar", "foo")]
+        [InlineData("foo/bar/baz", "foo/bar")]
+        public void GetDirectoryName_handles_paths_without_a_parent_directory(string path, string expected)
+        {
+            FileNameUtilities.GetDirectoryName(path).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("/", "")]
+        [InlineData("//", "")]
+        [InlineData("\\", "")]
+        [InlineData("/a", "a")]
+        [InlineData("//a", "a")]
+        [InlineData("abc", "abc")]
+        public void TrimStartDirectorySeparators_handles_all_separator_paths(string path, string expected)
+        {
+            FileNameUtilities.TrimStartDirectorySeparators(path).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Two methods in `FileNameUtilities` index past the bounds of the path string for degenerate inputs:

- **`GetDirectoryName`** loops `while (fileNameStart >= 0 && IsDirectorySeparator(path[fileNameStart - 1]))`. When the path has no parent directory, `IndexOfFileName` returns `0`, so the condition evaluates `path[-1]` and throws `IndexOutOfRangeException`. This affects `"Contract.cs"`, `"a"`, `""`, `"/foo"`, etc. It also returned the whole path instead of an empty directory name for the no-parent case.
- **`TrimStartDirectorySeparators`** loops `while (IsDirectorySeparator(path[i]))` with no bound on `i`, so an all-separator path such as `"/"` or `"//"` advances `i` past the end and throws `IndexOutOfRangeException`.

## Fix

Bound both loops (`fileNameStart > 0`; `i < path.Length`) and return an empty string as the directory name when there is no parent directory.

## Verification

- New `FileNameUtilitiesTests` cover no-parent paths (`"Contract.cs"`, `"a"`, `""`, `"/foo"` → `""`), normal paths (`"foo/bar"` → `"foo"`), and all-separator paths (`"/"`, `"//"`, `"\\"` → `""`). The previous code throws `IndexOutOfRangeException` for the degenerate cases.
- `dotnet test test/test.bctklib` — all 264 tests pass.
- `dotnet format --verify-no-changes` passes for the changed files.