### PR TITLE
Look up royaltyInfo with its actual arity in NEP-24 check

### DIFF
--- a/src/neoxp/Extensions/ContractManifestExtensions.cs
+++ b/src/neoxp/Extensions/ContractManifestExtensions.cs
@@ -155,7 +155,7 @@ internal static class ContractManifestExtensions
     public static List<string> Nep24CompliantErrors(this ContractManifest manifest)
     {
         var errors = new List<string>();
-        var royaltyInfoMethod = manifest.Abi.GetMethod("royaltyInfo", 0);
+        var royaltyInfoMethod = manifest.Abi.GetMethod("royaltyInfo", 3);
 
         var royaltyInfoValid = royaltyInfoMethod != null && royaltyInfoMethod.Safe &&
                             royaltyInfoMethod.ReturnType == ContractParameterType.Array &&

--- a/test/test.workflowvalidation/Nep24CompliantErrorsTests.cs
+++ b/test/test.workflowvalidation/Nep24CompliantErrorsTests.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Nep24CompliantErrorsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.SmartContract.Manifest;
+using NeoExpress;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class Nep24CompliantErrorsTests
+{
+    const string ManifestJson = @"{
+        ""name"": ""Test"",
+        ""groups"": [],
+        ""features"": {},
+        ""supportedstandards"": [""NEP-24""],
+        ""abi"": {
+            ""methods"": [
+                {
+                    ""name"": ""royaltyInfo"",
+                    ""parameters"": [
+                        { ""name"": ""tokenId"", ""type"": ""ByteArray"" },
+                        { ""name"": ""royaltyToken"", ""type"": ""Hash160"" },
+                        { ""name"": ""salePrice"", ""type"": ""Integer"" }
+                    ],
+                    ""returntype"": ""Array"",
+                    ""offset"": 0,
+                    ""safe"": true
+                }
+            ],
+            ""events"": []
+        },
+        ""permissions"": [{ ""contract"": ""*"", ""methods"": ""*"" }],
+        ""trusts"": [],
+        ""extra"": null
+    }";
+
+    [Fact]
+    public void Compliant_royaltyInfo_produces_no_errors()
+    {
+        var manifest = ContractManifest.Parse(ManifestJson);
+
+        manifest.Nep24CompliantErrors().Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

`Nep24CompliantErrors` resolves the `royaltyInfo` method with the wrong arity:

```csharp
var royaltyInfoMethod = manifest.Abi.GetMethod("royaltyInfo", 0);
```

A NEP-24 `royaltyInfo` takes three parameters (`tokenId`, `royaltyToken`, `salePrice`). `ContractAbi.GetMethod` matches by name **and** parameter count, so the arity-0 lookup always returns `null`, `royaltyInfoValid` is always false, and the check always reports `royaltyInfo` as missing — even for a fully compliant NEP-24 contract. The validation immediately below already expects `Parameters.Length == 3`.

## Fix

Look up `royaltyInfo` with arity 3.

## Verification

- New test `Nep24CompliantErrorsTests` parses a manifest with a compliant 3-parameter `royaltyInfo` and asserts `Nep24CompliantErrors()` is empty. With the arity-0 lookup the test fails (the royaltyInfo error is reported).
- `dotnet test` (CI-filtered) passes.
- `dotnet format --verify-no-changes` passes for the changed files.