### PR TITLE
Validate the second balanceOf parameter for divisible NEP-11 tokens

### DIFF
--- a/src/neoxp/Extensions/ContractManifestExtensions.cs
+++ b/src/neoxp/Extensions/ContractManifestExtensions.cs
@@ -43,7 +43,7 @@ internal static class ContractManifestExtensions
                                 balanceOfMethod2?.ReturnType == ContractParameterType.Integer &&
                                 balanceOfMethod2?.Parameters.Length == 2 &&
                                 balanceOfMethod2?.Parameters[0].Type == ContractParameterType.Hash160 &&
-                                balanceOfMethod2?.Parameters[0].Type == ContractParameterType.ByteArray;
+                                balanceOfMethod2?.Parameters[1].Type == ContractParameterType.ByteArray;
         var tokensOfValid = tokensOfMethod != null && tokensOfMethod.Safe &&
                             tokensOfMethod.ReturnType == ContractParameterType.InteropInterface &&
                             tokensOfMethod.Parameters.Length == 1 &&

--- a/test/test.workflowvalidation/Nep11CompliantErrorsTests.cs
+++ b/test/test.workflowvalidation/Nep11CompliantErrorsTests.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Nep11CompliantErrorsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.SmartContract.Manifest;
+using NeoExpress;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class Nep11CompliantErrorsTests
+{
+    // A divisible NEP-11 token exposes the two-parameter balanceOf(owner, tokenId)
+    // with owner: Hash160 and tokenId: ByteArray.
+    const string ManifestJson = @"{
+        ""name"": ""Test"",
+        ""groups"": [],
+        ""features"": {},
+        ""supportedstandards"": [""NEP-11""],
+        ""abi"": {
+            ""methods"": [
+                {
+                    ""name"": ""balanceOf"",
+                    ""parameters"": [
+                        { ""name"": ""owner"", ""type"": ""Hash160"" },
+                        { ""name"": ""tokenId"", ""type"": ""ByteArray"" }
+                    ],
+                    ""returntype"": ""Integer"",
+                    ""offset"": 0,
+                    ""safe"": true
+                }
+            ],
+            ""events"": []
+        },
+        ""permissions"": [{ ""contract"": ""*"", ""methods"": ""*"" }],
+        ""trusts"": [],
+        ""extra"": null
+    }";
+
+    [Fact]
+    public void Divisible_balanceOf_is_accepted()
+    {
+        var manifest = ContractManifest.Parse(ManifestJson);
+
+        manifest.Nep11CompliantErrors()
+            .Should().NotContain("Incomplete or unsafe NEP standard NEP-11 implementation: balanceOf");
+    }
+}


### PR DESCRIPTION
## Problem

The two-parameter `balanceOf` check for divisible NEP-11 tokens tests the **first** parameter twice:

```csharp
var balanceOfValid2 = balanceOfMethod2?.Safe == true &&
    balanceOfMethod2?.ReturnType == ContractParameterType.Integer &&
    balanceOfMethod2?.Parameters.Length == 2 &&
    balanceOfMethod2?.Parameters[0].Type == ContractParameterType.Hash160 &&
    balanceOfMethod2?.Parameters[0].Type == ContractParameterType.ByteArray;   // Parameters[0] again
```

A single parameter can never be both `Hash160` and `ByteArray`, so `balanceOfValid2` is always false. A divisible NEP-11 token exposes `balanceOf(owner, tokenId)` (and no single-parameter `balanceOf`), so `balanceOfValid1` is also false, and the token is always reported as non-compliant on `balanceOf`.

## Fix

Check `Parameters[1]` (the `tokenId`) for `ByteArray`, matching the divisible NEP-11 `balanceOf(Hash160 owner, ByteArray tokenId)` signature.

## Verification

- New test `Nep11CompliantErrorsTests` parses a manifest with a compliant two-parameter `balanceOf` and asserts the `balanceOf` error is not reported. With the duplicated `Parameters[0]` check the test fails.
- `dotnet test` (CI-filtered) passes.
- `dotnet format --verify-no-changes` passes for the changed files.