### PR TITLE
Write rpc-port when serializing a ToolkitConsensusNode

### DIFF
--- a/src/bctklib/models/ToolkitConsensusNode.cs
+++ b/src/bctklib/models/ToolkitConsensusNode.cs
@@ -29,6 +29,8 @@ namespace Neo.BlockchainToolkit.Models
             writer.WriteStartObject();
             if (TcpPort != 0)
                 writer.WriteProperty("tcp-port", TcpPort);
+            if (RpcPort != 0)
+                writer.WriteProperty("rpc-port", RpcPort);
             writer.WritePropertyName("wallet");
             Wallet.WriteJson(writer);
             writer.WriteEndObject();

--- a/test/test.bctklib/ToolkitConsensusNodeTests.cs
+++ b/test/test.bctklib/ToolkitConsensusNodeTests.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ToolkitConsensusNodeTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class ToolkitConsensusNodeTests
+    {
+        [Fact]
+        public void WriteJson_round_trips_rpc_port()
+        {
+            var wallet = new ToolkitWallet("test", ProtocolSettings.Default);
+            var node = new ToolkitConsensusNode(wallet, (ushort)50011, (ushort)50012);
+
+            var sw = new StringWriter();
+            using (var jw = new JsonTextWriter(sw))
+            {
+                node.WriteJson(jw);
+            }
+            var parsed = ToolkitConsensusNode.Parse(JObject.Parse(sw.ToString()), ProtocolSettings.Default);
+
+            parsed.TcpPort.Should().Be(50011);
+            parsed.RpcPort.Should().Be(50012);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ToolkitConsensusNode.Parse` reads the `rpc-port` property:

```csharp
var rpc = json.Value<ushort>("rpc-port");
```

but `WriteJson` only writes `tcp-port` and `wallet` — never `rpc-port`. Serializing a node and parsing it back loses `RpcPort`, which reverts to its default of `0`.

## Fix

Write `rpc-port` in `WriteJson`, mirroring the existing `tcp-port` handling.

## Verification

- New test `ToolkitConsensusNodeTests.WriteJson_round_trips_rpc_port` writes a node with rpc-port 50012, re-parses it, and asserts `RpcPort == 50012`. Without the write the test fails (`RpcPort` is 0).
- `dotnet test test/test.bctklib` passes.
- `dotnet format --verify-no-changes` passes for the changed files.