### PR TITLE
Read the lock field when parsing a toolkit wallet account

### DIFF
--- a/src/bctklib/models/ToolkitWallet.Account.cs
+++ b/src/bctklib/models/ToolkitWallet.Account.cs
@@ -35,6 +35,7 @@ namespace Neo.BlockchainToolkit.Models
             {
                 var isDefault = json.TryGetValue("is-default", out var token) && token.Value<bool>();
                 var label = json.TryGetValue("label", out token) ? token.Value<string>() : null;
+                var locked = json.TryGetValue("lock", out token) && token.Value<bool>();
 
                 if (json.TryGetValue("private-key", out token) && token.Type == JTokenType.String)
                 {
@@ -47,7 +48,8 @@ namespace Neo.BlockchainToolkit.Models
                         {
                             Contract = contract,
                             IsDefault = isDefault,
-                            Label = label
+                            Label = label,
+                            Lock = locked
                         };
                     }
                 }

--- a/test/test.bctklib/ToolkitWalletAccountLockTests.cs
+++ b/test/test.bctklib/ToolkitWalletAccountLockTests.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ToolkitWalletAccountLockTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class ToolkitWalletAccountLockTests
+    {
+        [Fact]
+        public void Account_round_trips_lock()
+        {
+            var wallet = new ToolkitWallet("test", ProtocolSettings.Default);
+            var privateKey = Enumerable.Range(1, 32).Select(i => (byte)i).ToArray();
+            var account = (ToolkitWallet.Account)wallet.CreateAccount(privateKey);
+            account.Lock = true;
+
+            var sw = new StringWriter();
+            using (var jw = new JsonTextWriter(sw))
+            {
+                account.WriteJson(jw);
+            }
+            var parsed = ToolkitWallet.Account.Parse(JObject.Parse(sw.ToString()), ProtocolSettings.Default);
+
+            parsed.Lock.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ToolkitWallet.Account.WriteJson` writes the `lock` property:

```csharp
if (Lock)
    writer.WriteProperty("lock", Lock);
```

but `Account.Parse` reads `is-default`, `label`, and `private-key` and never reads `lock`. A locked account therefore loses its `Lock` flag on a serialize/parse round-trip (it reverts to the default `false`).

## Fix

Read `lock` in `Parse` and apply it to the constructed account.

## Verification

- New test `ToolkitWalletAccountLockTests.Account_round_trips_lock` creates an account, sets `Lock = true`, serializes and re-parses it, and asserts `Lock` is `true`. Without reading `lock` the test fails (`Lock` is `false`).
- `dotnet test test/test.bctklib` passes.
- `dotnet format --verify-no-changes` passes for the changed files.