### PR TITLE
Emit lowercase booleans for the Cobertura branch attribute

### DIFF
--- a/src/collector/Formats/CoberturaFormat.ContractCoverageWriter.cs
+++ b/src/collector/Formats/CoberturaFormat.ContractCoverageWriter.cs
@@ -135,13 +135,13 @@ namespace Neo.Collector.Formats
 
                 if (branchCount == 0)
                 {
-                    writer.WriteAttributeString("branch", $"{false}");
+                    writer.WriteAttributeString("branch", "false");
                 }
                 else
                 {
                     var branchRate = Utility.CalculateHitRate(branchCount, branchHit);
 
-                    writer.WriteAttributeString("branch", $"{true}");
+                    writer.WriteAttributeString("branch", "true");
                     writer.WriteAttributeString("condition-coverage", $"{branchRate * 100:N}% ({branchHit}/{branchCount})");
                     writer.WriteStartElement("conditions");
                     foreach (var (address, opCode) in contract.InstructionMap.GetBranchInstructions(method, index))

--- a/test/test-collector/CoberturaBranchBoolTests.cs
+++ b/test/test-collector/CoberturaBranchBoolTests.cs
@@ -1,0 +1,44 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CoberturaBranchBoolTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Moq;
+using Neo.Collector;
+using Neo.Collector.Formats;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace test_collector;
+
+public class CoberturaBranchBoolTests
+{
+    [Fact]
+    public void Branch_attribute_uses_lowercase_boolean()
+    {
+        var logger = new Mock<ILogger>();
+        var collector = new CodeCoverageCollector(logger.Object);
+        collector.TrackTestContract("contract", "registrar.nefdbgnfo");
+        collector.LoadTestOutput("run1");
+        var coverage = collector.CollectCoverage().ToList();
+
+        var xml = "";
+        new CoberturaFormat().WriteReport(coverage, (filename, write) =>
+        {
+            using var ms = new MemoryStream();
+            write(ms);
+            xml = Encoding.UTF8.GetString(ms.ToArray());
+        });
+
+        Assert.DoesNotContain("branch=\"True\"", xml);
+        Assert.DoesNotContain("branch=\"False\"", xml);
+        Assert.Contains("branch=\"false\"", xml);
+    }
+}


### PR DESCRIPTION
## Problem

The per-line `branch` attribute in the Cobertura coverage report is written with interpolated booleans:

```csharp
writer.WriteAttributeString("branch", $"{false}");
...
writer.WriteAttributeString("branch", $"{true}");
```

`$"{false}"` calls `Boolean.ToString()`, which returns the PascalCase `"False"`/`"True"`. Cobertura consumers expect lowercase XML boolean literals (`true`/`false`), so coverage tooling can misread the branch flag.

## Fix

Write the lowercase literals `"false"`/`"true"`.

## Verification

- New test `CoberturaBranchBoolTests` generates a report from the existing coverage fixtures and asserts it contains `branch="false"` and no `branch="True"`/`branch="False"`. With the interpolated booleans the test fails.
- `dotnet test test/test-collector` passes.
- `dotnet format --verify-no-changes` passes for the changed files.