### PR TITLE
Format Cobertura coverage rates with the invariant culture

### DIFF
--- a/src/collector/Formats/CoberturaFormat.ContractCoverageWriter.cs
+++ b/src/collector/Formats/CoberturaFormat.ContractCoverageWriter.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using Neo.Collector.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -40,8 +41,8 @@ namespace Neo.Collector.Formats
                 // TODO: complexity
                 writer.WriteAttributeString("name", contract.Name);
                 writer.WriteAttributeString("scripthash", $"{contract.DebugInfo.Hash}");
-                writer.WriteAttributeString("line-rate", $"{lineRate:N4}");
-                writer.WriteAttributeString("branch-rate", $"{branchRate:N4}");
+                writer.WriteAttributeString("line-rate", FormattableString.Invariant($"{lineRate:N4}"));
+                writer.WriteAttributeString("branch-rate", FormattableString.Invariant($"{branchRate:N4}"));
                 writer.WriteStartElement("classes");
                 {
                     foreach (var group in DebugInfo.Methods.GroupBy(NamespaceAndFilename))
@@ -79,8 +80,8 @@ namespace Neo.Collector.Formats
                 writer.WriteAttributeString("name", name);
                 if (filename.Length > 0)
                 { writer.WriteAttributeString("filename", filename); }
-                writer.WriteAttributeString("line-rate", $"{lineRate:N4}");
-                writer.WriteAttributeString("branch-rate", $"{branchRate:N4}");
+                writer.WriteAttributeString("line-rate", FormattableString.Invariant($"{lineRate:N4}"));
+                writer.WriteAttributeString("branch-rate", FormattableString.Invariant($"{branchRate:N4}"));
 
                 writer.WriteStartElement("methods");
                 foreach (var method in methods)
@@ -111,8 +112,8 @@ namespace Neo.Collector.Formats
                 writer.WriteStartElement("method");
                 writer.WriteAttributeString("name", method.Name);
                 writer.WriteAttributeString("signature", $"({signature})");
-                writer.WriteAttributeString("line-rate", $"{lineRate:N4}");
-                writer.WriteAttributeString("branch-rate", $"{branchRate:N4}");
+                writer.WriteAttributeString("line-rate", FormattableString.Invariant($"{lineRate:N4}"));
+                writer.WriteAttributeString("branch-rate", FormattableString.Invariant($"{branchRate:N4}"));
                 writer.WriteStartElement("lines");
                 for (int i = 0; i < method.SequencePoints.Count; i++)
                 {
@@ -142,7 +143,7 @@ namespace Neo.Collector.Formats
                     var branchRate = Utility.CalculateHitRate(branchCount, branchHit);
 
                     writer.WriteAttributeString("branch", "true");
-                    writer.WriteAttributeString("condition-coverage", $"{branchRate * 100:N}% ({branchHit}/{branchCount})");
+                    writer.WriteAttributeString("condition-coverage", FormattableString.Invariant($"{branchRate * 100:N}% ({branchHit}/{branchCount})"));
                     writer.WriteStartElement("conditions");
                     foreach (var (address, opCode) in contract.InstructionMap.GetBranchInstructions(method, index))
                     {
@@ -153,7 +154,7 @@ namespace Neo.Collector.Formats
                         writer.WriteStartElement("condition");
                         writer.WriteAttributeString("number", $"{address}");
                         writer.WriteAttributeString("type", $"{opCode}");
-                        writer.WriteAttributeString("coverage", $"{coverage / 2m * 100m}%");
+                        writer.WriteAttributeString("coverage", FormattableString.Invariant($"{coverage / 2m * 100m}%"));
                         writer.WriteEndElement();
                     }
                     writer.WriteEndElement();

--- a/src/collector/Formats/CoberturaFormat.cs
+++ b/src/collector/Formats/CoberturaFormat.cs
@@ -51,10 +51,10 @@ namespace Neo.Collector.Formats
 
             writer.WriteStartDocument();
             writer.WriteStartElement("coverage");
-            writer.WriteAttributeString("line-rate", $"{lineRate:N4}");
+            writer.WriteAttributeString("line-rate", FormattableString.Invariant($"{lineRate:N4}"));
             writer.WriteAttributeString("lines-covered", $"{linesCovered}");
             writer.WriteAttributeString("lines-valid", $"{linesValid}");
-            writer.WriteAttributeString("branch-rate", $"{branchRate:N4}");
+            writer.WriteAttributeString("branch-rate", FormattableString.Invariant($"{branchRate:N4}"));
             writer.WriteAttributeString("branches-covered", $"{branchesCovered}");
             writer.WriteAttributeString("branches-valid", $"{branchesValid}");
             writer.WriteAttributeString("version", ThisAssembly.AssemblyFileVersion);

--- a/test/test-collector/CoberturaCultureTests.cs
+++ b/test/test-collector/CoberturaCultureTests.cs
@@ -1,0 +1,61 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CoberturaCultureTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Moq;
+using Neo.Collector;
+using Neo.Collector.Formats;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+namespace test_collector;
+
+public class CoberturaCultureTests
+{
+    [Fact]
+    public void Rates_use_invariant_decimal_separator_under_non_invariant_culture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            // de-DE uses ',' as the decimal separator.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var logger = new Mock<ILogger>();
+            var collector = new CodeCoverageCollector(logger.Object);
+            collector.TrackTestContract("contract", "registrar.nefdbgnfo");
+            collector.LoadTestOutput("run1");
+            var coverage = collector.CollectCoverage().ToList();
+
+            var xml = "";
+            new CoberturaFormat().WriteReport(coverage, (filename, write) =>
+            {
+                using var ms = new MemoryStream();
+                write(ms);
+                xml = Encoding.UTF8.GetString(ms.ToArray());
+            });
+
+            var root = XDocument.Parse(xml).Root!;
+            var lineRate = root.Attribute("line-rate")!.Value;
+            var branchRate = root.Attribute("branch-rate")!.Value;
+
+            Assert.DoesNotContain(",", lineRate);
+            Assert.DoesNotContain(",", branchRate);
+            Assert.Contains(".", lineRate);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The Cobertura report formats `line-rate`, `branch-rate`, `condition-coverage`, and `coverage` values with interpolated strings and no format provider, so they use the **current culture**:

```csharp
writer.WriteAttributeString("line-rate", $"{lineRate:N4}");
```

On a machine with a non-invariant culture (e.g. de-DE, which uses `,` as the decimal separator) the report emits `line-rate="0,6667"`, which is invalid for the Cobertura XML schema and is misparsed by coverage tooling.

## Fix

Wrap the numeric formatting with `FormattableString.Invariant(...)` at every rate/percentage site in both Cobertura writers, so the values always use `.` regardless of host culture. (Adds the missing `using System;` to the partial writer.)

## Verification

- New test `CoberturaCultureTests` sets `CurrentCulture` to de-DE, generates the report, and asserts the root `line-rate`/`branch-rate` attributes contain no comma and use `.`. Reverting any rate to culture-sensitive formatting fails the test.
- `dotnet test test/test-collector` passes.
- `dotnet format --verify-no-changes` passes for the changed files.