### PR TITLE
Parse transfer quantity with the invariant culture

### DIFF
--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -516,21 +516,24 @@ namespace NeoExpress
             var assetHash = await expressNode.ParseAssetAsync(asset).ConfigureAwait(false);
             var txHash = await expressNode.TransferAsync(assetHash, ParseQuantity(quantity), senderWallet, senderAccountHash, receiverHash, dataParam);
             await writer.WriteTxHashAsync(txHash, "Transfer", json).ConfigureAwait(false);
+        }
 
-            static OneOf<decimal, All> ParseQuantity(string quantity)
+        // Quantities are always expressed with '.' as the decimal separator, so parse
+        // with the invariant culture rather than the host culture (which would, for
+        // example, read "1.5" as 15 where '.' is a thousands separator).
+        internal static OneOf<decimal, All> ParseQuantity(string quantity)
+        {
+            if ("all".Equals(quantity, StringComparison.OrdinalIgnoreCase))
             {
-                if ("all".Equals(quantity, StringComparison.OrdinalIgnoreCase))
-                {
-                    return new All();
-                }
-
-                if (decimal.TryParse(quantity, out var amount))
-                {
-                    return amount;
-                }
-
-                throw new Exception($"Invalid quantity value {quantity}");
+                return new All();
             }
+
+            if (decimal.TryParse(quantity, System.Globalization.CultureInfo.InvariantCulture, out var amount))
+            {
+                return amount;
+            }
+
+            throw new Exception($"Invalid quantity value {quantity}");
         }
 
         public async Task TransferNFTAsync(string contract, string tokenId, string sender, string password, string receiver, string data)

--- a/test/test.workflowvalidation/ParseQuantityTests.cs
+++ b/test/test.workflowvalidation/ParseQuantityTests.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ParseQuantityTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using System.Globalization;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ParseQuantityTests
+{
+    [Fact]
+    public void ParseQuantity_parses_decimal_with_invariant_culture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            // de-DE uses '.' as a thousands separator, so a culture-sensitive parse
+            // would read "1.5" as 15.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = TransactionExecutor.ParseQuantity("1.5");
+
+            result.AsT0.Should().Be(1.5m);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The transfer command parses the quantity with no format provider:

```csharp
if (decimal.TryParse(quantity, out var amount))
    return amount;
```

so it uses the host culture. In a culture where `.` is a thousands separator (for example de-DE), `neoxp transfer 1.5 gas ...` parses `"1.5"` as **15**, sending ten times the intended amount.

## Fix

Parse with `CultureInfo.InvariantCulture`, matching the `.`-as-decimal-separator convention the quantity string uses. The parse is also extracted from a static local function to an `internal static` method so it can be tested.

## Verification

- New test `ParseQuantityTests` sets `CurrentCulture` to de-DE and asserts `ParseQuantity("1.5")` is `1.5m`. With the culture-sensitive parse the test fails (the result is `15m`).
- `dotnet test` (CI-filtered) passes.
- `dotnet format --verify-no-changes` passes for the changed files.