### PR TITLE
Apply snapshot read options to tracked items in PersistentTrackingStore.Seek

### DIFF
--- a/src/bctklib/persistence/PersistentTrackingStore.cs
+++ b/src/bctklib/persistence/PersistentTrackingStore.cs
@@ -159,7 +159,7 @@ namespace Neo.BlockchainToolkit.Persistence
 
         public static IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[]? key, SeekDirection direction, RocksDb db, ColumnFamilyHandle columnFamily, ReadOptions? readOptions, IReadOnlyStore<byte[], byte[]> store)
         {
-            var trackedItems = SeekTracked(key, direction, db, columnFamily);
+            var trackedItems = SeekTracked(key, direction, db, columnFamily, readOptions);
             var storeItems = store.Find(key, direction).Where(KeyUntracked);
 
             var comparer = direction == SeekDirection.Forward

--- a/test/test.bctklib/TrackingStoreTests.cs
+++ b/test/test.bctklib/TrackingStoreTests.cs
@@ -256,6 +256,24 @@ public class TrackingStoreTests : IDisposable
     }
 
     [Fact]
+    public void PersistentTrackingSnapshotFindIgnoresWritesAfterSnapshot()
+    {
+        var keyA = Bytes(0);
+        var keyB = Bytes(1);
+
+        var memoryStore = new MemoryStore();
+        using var store = new PersistentTrackingStore(RocksDbUtility.OpenDb(path), memoryStore);
+
+        store.Put(keyA, Bytes("v1"));
+        using var snapshot = store.GetSnapshot();
+        store.Put(keyB, Bytes("v2")); // written after the snapshot was taken
+
+        var keys = snapshot.Find().Select(kvp => kvp.Key).ToList();
+
+        keys.Should().ContainSingle().Which.Should().BeEquivalentTo(keyA);
+    }
+
+    [Fact]
     public void PersistentTrackingResetDiscardsTrackedChanges()
     {
         var existingKey = Bytes(0);


### PR DESCRIPTION
## Problem

`PersistentTrackingStore.Seek` passes the caller's `ReadOptions` to the backing-store lookup (`KeyUntracked` via `db.GetSlice(..., readOptions)`) but calls `SeekTracked` without them:

```csharp
var trackedItems = SeekTracked(key, direction, db, columnFamily);   // readOptions dropped
...
static IEnumerable<...> SeekTracked(..., ReadOptions? readOptions = null)
{
    readOptions ??= RocksDbUtility.DefaultReadOptions;   // falls back to a live iterator
    using var iterator = db.NewIterator(columnFamily, readOptions);
    ...
}
```

So the iterator over tracked items uses the default (live) read options. When `Seek`/`Find` is invoked from a snapshot — which passes a `ReadOptions` pinned to a RocksDB snapshot — the tracked-item iterator still reads the **live** column family. Writes made after the snapshot was taken therefore leak into the snapshot's `Find`/`Seek` results, breaking snapshot isolation.

## Fix

Pass `readOptions` through to `SeekTracked`. A non-snapshot `Find` still passes `null`, preserving the existing default (live) behavior.

## Verification

- New test `PersistentTrackingSnapshotFindIgnoresWritesAfterSnapshot` writes a key, takes a snapshot, writes a second key, and asserts the snapshot's `Find` returns only the first key. With the dropped `readOptions` the test fails (both keys are returned).
- `dotnet test test/test.bctklib` passes.
- `dotnet format --verify-no-changes` passes for the changed files.