### PR TITLE
Stop double-popping the result stack in TryGetIndivisibleNep11Owner

### DIFF
--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -160,7 +160,7 @@ namespace NeoExpress
                 && engine.ResultStack.Pop() is ByteString byteString
                 && byteString.Size == UInt160.Length)
             {
-                owner = new UInt160(engine.ResultStack.Pop().GetSpan());
+                owner = new UInt160(byteString.GetSpan());
                 return true;
             }
 


### PR DESCRIPTION
## Problem

`TryGetIndivisibleNep11Owner` invokes `ownerOf`, which leaves a **single** owner `ByteString` on the result stack:

```csharp
if (engine.State != VMState.FAULT
    && engine.ResultStack.Count >= 1
    && engine.ResultStack.Pop() is ByteString byteString   // pops the only item
    && byteString.Size == UInt160.Length)
{
    owner = new UInt160(engine.ResultStack.Pop().GetSpan());  // pops again -> empty stack
    return true;
}
```

The first `Pop()` takes the only item into `byteString`; the second `Pop()` runs on an empty stack and throws `InvalidOperationException`. The already-validated `byteString` is never used. This breaks `getnep11balances` for any address holding an indivisible NEP-11 token (the RPC handler calls `GetIndivisibleNep11Owner` for each such token).

## Fix

Build the owner from the validated `byteString`, matching the correct implementation in bctklib's `ToolkitRpcServer` (`return new UInt160(byteString);`).

## Verification

- `dotnet build neo-express.sln -c Release` succeeds.
- `dotnet test` (CI-filtered) passes across the solution.
- `dotnet format --verify-no-changes` passes for the changed file.

Note: a focused end-to-end test would require deploying a NEP-11 contract whose `ownerOf` returns a 20-byte value into an in-memory chain; that fixture infrastructure does not exist in the test project with access to this internal method (`test.workflowvalidation`), so it is disproportionate here. The fix is a one-line correction that mirrors the already-correct, single-pop implementation in `src/bctklib/plugins/ToolkitRpcServer.cs`.