### PR TITLE
Make NuGet package version comparison and equality consistent for a null suffix

### DIFF
--- a/src/build-tasks/NugetPackageVersion.cs
+++ b/src/build-tasks/NugetPackageVersion.cs
@@ -91,20 +91,21 @@ namespace Neo.BuildTasks
             if (result != 0)
                 return result;
 
-            if (Suffix.Length == 0 && other.Suffix.Length > 0)
+            // Suffix is null for default(NugetPackageVersion); treat it as empty.
+            var suffix = Suffix ?? string.Empty;
+            var otherSuffix = other.Suffix ?? string.Empty;
+            if (suffix.Length == 0 && otherSuffix.Length > 0)
                 return 1;
-            if (Suffix.Length > 0 && other.Suffix.Length == 0)
+            if (suffix.Length > 0 && otherSuffix.Length == 0)
                 return -1;
-            return string.Compare(Suffix, other.Suffix, true);
+            return string.Compare(suffix, otherSuffix, true);
         }
 
         public override bool Equals(object? obj)
         {
-            return obj is NugetPackageVersion version &&
-                   Major == version.Major &&
-                   Minor == version.Minor &&
-                   Patch == version.Patch &&
-                   Suffix == version.Suffix;
+            // Defer to CompareTo so equality agrees with the == operator, including its
+            // null-suffix normalization and case-insensitive suffix comparison.
+            return obj is NugetPackageVersion version && CompareTo(version) == 0;
         }
 
         public override int GetHashCode()
@@ -113,7 +114,8 @@ namespace Neo.BuildTasks
             hashCode = hashCode * -1521134295 + Major.GetHashCode();
             hashCode = hashCode * -1521134295 + Minor.GetHashCode();
             hashCode = hashCode * -1521134295 + Patch.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Suffix);
+            // Match Equals/CompareTo: a null suffix hashes as empty and case is ignored.
+            hashCode = hashCode * -1521134295 + StringComparer.OrdinalIgnoreCase.GetHashCode(Suffix ?? string.Empty);
             return hashCode;
         }
 

--- a/test/test-build-tasks/TestNugetPackageVersionDefault.cs
+++ b/test/test-build-tasks/TestNugetPackageVersionDefault.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestNugetPackageVersionDefault.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BuildTasks;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestNugetPackageVersionDefault
+    {
+        [Fact]
+        public void compare_against_default_does_not_throw()
+        {
+            var def = default(NugetPackageVersion); // Suffix is null
+            var zero = new NugetPackageVersion(0, 0, 0); // Suffix is ""
+
+            Assert.Equal(0, zero.CompareTo(def));
+            Assert.Equal(0, def.CompareTo(zero));
+            Assert.Equal(0, def.CompareTo(def));
+            Assert.True(def == def);
+        }
+
+        [Fact]
+        public void equals_and_gethashcode_agree_with_the_equality_operator_for_default()
+        {
+            var def = default(NugetPackageVersion); // Suffix is null
+            var zero = new NugetPackageVersion(0, 0, 0); // Suffix is ""
+
+            Assert.True(def == zero);
+            Assert.True(def.Equals(zero));        // must agree with ==
+            Assert.True(zero.Equals(def));
+            Assert.Equal(zero.GetHashCode(), def.GetHashCode());
+            Assert.Equal(0, def.GetHashCode() - def.GetHashCode()); // does not throw
+        }
+
+        [Fact]
+        public void equals_and_gethashcode_ignore_suffix_case_like_compareto()
+        {
+            var upper = new NugetPackageVersion(1, 2, 3, "RC1");
+            var lower = new NugetPackageVersion(1, 2, 3, "rc1");
+
+            Assert.True(upper == lower);
+            Assert.True(upper.Equals(lower));     // must agree with ==
+            Assert.Equal(upper.GetHashCode(), lower.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`CompareTo` dereferenced `Suffix` ([NugetPackageVersion.cs:94](https://github.com/neo-project/neo-express/blob/master/src/build-tasks/NugetPackageVersion.cs#L94)). `Suffix` is `null` for `default(NugetPackageVersion)`, so comparing a default value threw `NullReferenceException`.

Fixing only `CompareTo` would leave the equality contract self-contradictory: the `==` operator delegates to `CompareTo`, so after the null fix `default == new(0,0,0)` is `true`, but `default.Equals(new(0,0,0))` was still `false` (case-sensitive ordinal suffix compare), and `Equals`/`==` also disagreed on suffix case (`"RC1"` vs `"rc1"`).

## Fix

- `CompareTo`: treat a null suffix as empty.
- `Equals`: defer to `CompareTo` so it matches `==` exactly (null and case handling).
- `GetHashCode`: hash the null-normalized suffix case-insensitively so equal values hash equally.

## Tests

`TestNugetPackageVersionDefault` covers comparing against `default` without throwing, `Equals`/`GetHashCode` agreement with `==` for the default-vs-`new(0,0,0)` case, and case-insensitive suffix equality/hashing. Reverting `Equals` to the old ordinal compare fails the two new consistency tests. Builds for both `net10.0` and `netstandard2.0`; full `test-build-tasks` suite (29) passes; format clean.