### PR TITLE
Parse JSON integer parameters as 256-bit values

### DIFF
--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -351,7 +351,10 @@ namespace Neo.BlockchainToolkit
                 JTokenType.Integer => new ContractParameter()
                 {
                     Type = ContractParameterType.Integer,
-                    Value = new BigInteger(json.Value<long>())
+                    // Neo Integer parameters are 256-bit. Parse the textual form so values
+                    // outside Int64 round-trip (Value<long>() throws for those, and
+                    // Value<BigInteger>() throws for the in-range case Newtonsoft stores as long).
+                    Value = BigInteger.Parse(json.ToString(), System.Globalization.CultureInfo.InvariantCulture)
                 },
                 JTokenType.Array => new ContractParameter()
                 {

--- a/test/test.bctklib/ParseParameterIntegerTests.cs
+++ b/test/test.bctklib/ParseParameterIntegerTests.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ParseParameterIntegerTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit;
+using Neo.SmartContract;
+using Newtonsoft.Json.Linq;
+using System.Numerics;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class ParseParameterIntegerTests
+    {
+        [Theory]
+        [InlineData("42")]
+        [InlineData("9223372036854775807")]   // long.MaxValue
+        [InlineData("9223372036854775808")]   // long.MaxValue + 1
+        [InlineData("18446744073709551615")]  // ulong.MaxValue
+        [InlineData("-9223372036854775809")]  // long.MinValue - 1
+        public void ParseParameter_handles_integers_outside_long_range(string text)
+        {
+            var parser = new ContractParameterParser(ProtocolSettings.Default.AddressVersion);
+
+            var param = parser.ParseParameter(JToken.Parse(text));
+
+            param.Type.Should().Be(ContractParameterType.Integer);
+            ((BigInteger)param.Value).Should().Be(BigInteger.Parse(text));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ContractParameterParser.ParseParameter` maps a JSON integer token like this:

```csharp
JTokenType.Integer => new ContractParameter()
{
    Type = ContractParameterType.Integer,
    Value = new BigInteger(json.Value<long>())
},
```

Neo `Integer` contract parameters are 256-bit, and a JSON integer can legitimately exceed `Int64` (e.g. a raw amount of a high-supply NEP-17 token). For such a value, Newtonsoft has already parsed the token into an internal `BigInteger`, and `json.Value<long>()` throws `InvalidCastException` ("Object must implement IConvertible") — the value cannot be parsed at all. A swap to `Value<BigInteger>()` is not sufficient either: for in-range values Newtonsoft stores a `long`, and `Value<BigInteger>()` itself throws.

## Fix

Parse the textual form with `BigInteger.Parse(json.ToString(), InvariantCulture)`, which preserves the value across the full range.

## Verification

- New `ParseParameterIntegerTests` cover `42`, `long.MaxValue`, `long.MaxValue + 1`, `ulong.MaxValue`, and `long.MinValue - 1`. The previous code throws `InvalidCastException` for the out-of-range values.
- `dotnet test test/test.bctklib` passes.
- `dotnet format --verify-no-changes` passes for the changed files.