### PR TITLE
Convert large JSON integers in ToNeoJson without throwing

### DIFF
--- a/src/bctklib/JsonWriterExtensions.cs
+++ b/src/bctklib/JsonWriterExtensions.cs
@@ -150,7 +150,10 @@ namespace Neo.BlockchainToolkit
                 JTokenType.Null => null,
                 JTokenType.Boolean => json.Value<bool>(),
                 JTokenType.Float => json.Value<double>(),
-                JTokenType.Integer => json.Value<long>(),
+                // Neo.Json numbers are double-backed, and a JSON integer can exceed Int64
+                // (Newtonsoft then stores it as a BigInteger, for which Value<long>() and
+                // Value<double>() both throw). Parse the textual form, then narrow to double.
+                JTokenType.Integer => (double)System.Numerics.BigInteger.Parse(json.ToString(), System.Globalization.CultureInfo.InvariantCulture),
                 JTokenType.String => json.Value<string>(),
                 JTokenType.Array => new Neo.Json.JArray(json.Select(ToNeoJson)),
                 JTokenType.Object => ConvertJObject((JObject)json),

--- a/test/test.bctklib/ToNeoJsonIntegerTests.cs
+++ b/test/test.bctklib/ToNeoJsonIntegerTests.cs
@@ -1,0 +1,35 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ToNeoJsonIntegerTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Newtonsoft.Json.Linq;
+using System.Numerics;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class ToNeoJsonIntegerTests
+    {
+        [Theory]
+        [InlineData("42")]
+        [InlineData("9223372036854775808")]    // long.MaxValue + 1
+        [InlineData("18446744073709551615")]   // ulong.MaxValue
+        [InlineData("-9223372036854775809")]   // long.MinValue - 1
+        [InlineData("-18446744073709551615")]  // below long range, negative
+        public void ToNeoJson_converts_integers_outside_long_range(string text)
+        {
+            var result = JsonWriterExtensions.ToNeoJson(JToken.Parse(text));
+
+            result.Should().BeOfType<Neo.Json.JNumber>();
+            result!.GetNumber().Should().Be((double)BigInteger.Parse(text));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ToNeoJson` mapped a JSON integer with `JTokenType.Integer => json.Value<long>()` ([JsonWriterExtensions.cs:152](https://github.com/neo-project/neo-express/blob/master/src/bctklib/JsonWriterExtensions.cs#L152)). When Newtonsoft parses an integer larger than `Int64` (e.g. `ulong.MaxValue`) it stores it as a `BigInteger`, and `Value<long>()` (and `Value<double>()`) throw `InvalidCastException` on that token. So converting JSON containing a large integer crashed.

## Fix

Parse the textual form and narrow to `double`:

```csharp
JTokenType.Integer => (double)BigInteger.Parse(json.ToString(), CultureInfo.InvariantCulture),
```

**Precision note:** the target `Neo.Json.JNumber` is double-backed, so integers above 2^53 are already represented with double precision regardless of this change — the previous `long` path also went `long → JNumber(double)` and lost the same precision. This change does **not** alter precision for any value that previously converted; it only stops the throw for values outside `Int64`.

## Tests

`ToNeoJsonIntegerTests` covers `42`, `long.MaxValue+1`, `ulong.MaxValue`, and now `long.MinValue-1` and a large negative value, asserting each yields a `JNumber` equal to `(double)BigInteger.Parse(text)`. The previous code throws on the out-of-range cases. Full `test.bctklib` suite passes; format clean.