### PR TITLE
Escape generated contract member names that are C# keywords

### DIFF
--- a/src/build-tasks/ContractGenerator.cs
+++ b/src/build-tasks/ContractGenerator.cs
@@ -63,7 +63,7 @@ namespace Neo.BuildTasks
                 if (method.Name.StartsWith("_"))
                     continue;
 
-                builder.Append($"{ConvertParameterType(method.ReturnType)} {method.Name}(");
+                builder.Append($"{ConvertParameterType(method.ReturnType)} {CreateEscapedIdentifier(method.Name)}(");
                 builder.Append(string.Join(", ", method.Parameters.Select(p => $"{ConvertParameterType(p.Type)} {CreateEscapedIdentifier(p.Name)}")));
                 builder.AppendLine(");");
             }
@@ -75,7 +75,7 @@ namespace Neo.BuildTasks
                 for (int i = 0; i < manifest.Events.Count; i++)
                 {
                     var @event = manifest.Events[i];
-                    builder.Append($"void {@event.Name}(");
+                    builder.Append($"void {CreateEscapedIdentifier(@event.Name)}(");
                     builder.Append(string.Join(", ", @event.Parameters.Select(p => $"{ConvertParameterType(p.Type)} {CreateEscapedIdentifier(p.Name)}")));
                     builder.AppendLine($");");
                 }

--- a/test/test-build-tasks/TestContractGeneratorEscaping.cs
+++ b/test/test-build-tasks/TestContractGeneratorEscaping.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestContractGeneratorEscaping.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BuildTasks;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestContractGeneratorEscaping
+    {
+        [Fact]
+        public void escapes_method_name_that_is_a_keyword()
+        {
+            var manifest = new NeoManifest()
+            {
+                Name = "C",
+                Methods = new List<NeoManifest.Method>
+                {
+                    new NeoManifest.Method { Name = "lock", ReturnType = "Void" },
+                },
+            };
+            var manifestPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var code = ContractGenerator.GenerateContractInterface(manifest, manifestPath, "", "");
+            Assert.Contains("void @lock(", code);
+            Assert.DoesNotContain("void lock(", code);
+        }
+
+        [Fact]
+        public void escapes_event_name_that_is_a_keyword()
+        {
+            var manifest = new NeoManifest()
+            {
+                Name = "C",
+                Events = new List<NeoManifest.Event>
+                {
+                    new NeoManifest.Event { Name = "event" },
+                },
+            };
+            var manifestPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var code = ContractGenerator.GenerateContractInterface(manifest, manifestPath, "", "");
+            Assert.Contains("void @event(", code);
+            Assert.DoesNotContain("void event(", code);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ContractGenerator.GenerateContractInterface` emits method names ([ContractGenerator.cs:66](https://github.com/neo-project/neo-express/blob/master/src/build-tasks/ContractGenerator.cs#L66)) and event names ([ContractGenerator.cs:78](https://github.com/neo-project/neo-express/blob/master/src/build-tasks/ContractGenerator.cs#L78)) verbatim, while parameter names are already escaped via `CreateEscapedIdentifier` (lines 67 and 79).

When a manifest declares a method or event whose name is a C# keyword (for example `lock` or `event`, both present in `CSHARP_KEYWORDS`), the generated interface contains an unescaped keyword as a member name and fails to compile.

## Fix

Wrap method and event names in `CreateEscapedIdentifier`, the same helper already applied to parameter names. For non-keyword names the helper returns the name unchanged, so existing output is unaffected.

## Tests

Added `TestContractGeneratorEscaping` covering a keyword method name (`lock`) and a keyword event name (`event`). Both assert the generated code uses the `@`-escaped form. The tests fail against the previous code and pass with the fix. Full `test-build-tasks` suite (28 tests) passes and `dotnet format --verify-no-changes` is clean.