### PR TITLE
Keep batch command text after a mid-word quote in the same token

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -394,7 +394,13 @@ namespace NeoExpress.Commands
 
             string CurrentToken()
             {
-                return memory.Slice(startTokenIndex, IndexOfEndOfToken()).ToString().Replace("\"", string.Empty);
+                var slice = memory.Slice(startTokenIndex, IndexOfEndOfToken());
+                var token = slice.ToString();
+                // Mid-word quotes are stripped from the token; skip the allocation
+                // for the common case of a token that contains no quote characters.
+                return slice.Span.IndexOf('\"') >= 0
+                    ? token.Replace("\"", string.Empty)
+                    : token;
             }
 
             int IndexOfEndOfToken() => pos - startTokenIndex;

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -308,7 +308,7 @@ namespace NeoExpress.Commands
             var pos = 0;
 
             var seeking = Boundary.TokenStart;
-            int? skipQuoteAtIndex = null;
+            var seekingQuote = Boundary.QuoteStart;
 
             while (pos < memory.Length)
             {
@@ -316,44 +316,55 @@ namespace NeoExpress.Commands
 
                 if (char.IsWhiteSpace(c))
                 {
-                    switch (seeking)
+                    if (seekingQuote == Boundary.QuoteStart)
                     {
-                        case Boundary.WordEnd:
-                            yield return CurrentToken();
-                            startTokenIndex = pos;
-                            seeking = Boundary.TokenStart;
-                            break;
+                        switch (seeking)
+                        {
+                            case Boundary.WordEnd:
+                                yield return CurrentToken();
+                                startTokenIndex = pos;
+                                seeking = Boundary.TokenStart;
+                                break;
 
-                        case Boundary.TokenStart:
-                            startTokenIndex = pos;
-                            break;
-
-                        case Boundary.QuoteEnd:
-                            break;
+                            case Boundary.TokenStart:
+                                startTokenIndex = pos;
+                                break;
+                        }
                     }
                 }
                 else if (c == '\"')
                 {
-                    switch (seeking)
+                    if (seeking == Boundary.TokenStart)
                     {
-                        case Boundary.QuoteEnd:
-                            yield return CurrentToken();
-                            startTokenIndex = pos;
-                            seeking = Boundary.TokenStart;
-                            break;
+                        switch (seekingQuote)
+                        {
+                            case Boundary.QuoteEnd:
+                                yield return CurrentToken();
+                                startTokenIndex = pos;
+                                seekingQuote = Boundary.QuoteStart;
+                                break;
 
-                        case Boundary.TokenStart:
-                            startTokenIndex = pos + 1;
-                            seeking = Boundary.QuoteEnd;
-                            break;
+                            case Boundary.QuoteStart:
+                                startTokenIndex = pos + 1;
+                                seekingQuote = Boundary.QuoteEnd;
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        switch (seekingQuote)
+                        {
+                            case Boundary.QuoteEnd:
+                                seekingQuote = Boundary.QuoteStart;
+                                break;
 
-                        case Boundary.WordEnd:
-                            seeking = Boundary.QuoteEnd;
-                            skipQuoteAtIndex = pos;
-                            break;
+                            case Boundary.QuoteStart:
+                                seekingQuote = Boundary.QuoteEnd;
+                                break;
+                        }
                     }
                 }
-                else if (seeking == Boundary.TokenStart)
+                else if (seeking == Boundary.TokenStart && seekingQuote == Boundary.QuoteStart)
                 {
                     seeking = Boundary.WordEnd;
                     startTokenIndex = pos;
@@ -363,12 +374,15 @@ namespace NeoExpress.Commands
 
                 if (IsAtEndOfInput())
                 {
+                    if (seekingQuote == Boundary.QuoteEnd)
+                    {
+                        throw new FormatException("Unbalanced quote in batch command line.");
+                    }
+
                     switch (seeking)
                     {
                         case Boundary.TokenStart:
                             break;
-                        case Boundary.QuoteEnd:
-                            throw new FormatException("Unbalanced quote in batch command line.");
                         default:
                             yield return CurrentToken();
                             break;
@@ -380,26 +394,7 @@ namespace NeoExpress.Commands
 
             string CurrentToken()
             {
-                if (skipQuoteAtIndex is null)
-                {
-                    return memory.Slice(startTokenIndex, IndexOfEndOfToken()).ToString();
-                }
-                else
-                {
-                    var beforeQuote = memory.Slice(
-                        startTokenIndex,
-                        skipQuoteAtIndex.Value - startTokenIndex);
-
-                    var indexOfCharAfterQuote = skipQuoteAtIndex.Value + 1;
-
-                    var afterQuote = memory.Slice(
-                        indexOfCharAfterQuote,
-                        pos - skipQuoteAtIndex.Value - 1);
-
-                    skipQuoteAtIndex = null;
-
-                    return $"{beforeQuote}{afterQuote}";
-                }
+                return memory.Slice(startTokenIndex, IndexOfEndOfToken()).ToString().Replace("\"", string.Empty);
             }
 
             int IndexOfEndOfToken() => pos - startTokenIndex;
@@ -411,6 +406,7 @@ namespace NeoExpress.Commands
         {
             TokenStart,
             WordEnd,
+            QuoteStart,
             QuoteEnd
         }
     }

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -31,4 +31,18 @@ public class BatchCommandParserTests
         BatchCommand.SplitCommandLine("wallet create \"alice bob\"").Should()
             .Equal("wallet", "create", "alice bob");
     }
+
+    [Fact]
+    public void SplitCommandLine_keeps_text_after_a_mid_word_quote_in_the_same_token()
+    {
+        BatchCommand.SplitCommandLine("foo\"bar\"baz").Should()
+            .Equal("foobarbaz");
+    }
+
+    [Fact]
+    public void SplitCommandLine_joins_quoted_segments_within_a_single_word()
+    {
+        BatchCommand.SplitCommandLine("a\"b\"c").Should()
+            .Equal("abc");
+    }
 }

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -45,4 +45,14 @@ public class BatchCommandParserTests
         BatchCommand.SplitCommandLine("a\"b\"c").Should()
             .Equal("abc");
     }
+
+    [Fact]
+    public void SplitCommandLine_strips_every_quote_from_a_single_token()
+    {
+        // A token carrying more than one quoted segment has all of its quote
+        // characters removed, so a word with two quote pairs collapses to a
+        // single unquoted token.
+        BatchCommand.SplitCommandLine("a\"b\"c\"d\"").Should()
+            .Equal("abcd");
+    }
 }


### PR DESCRIPTION
## Problem

`BatchCommand.SplitCommandLine` is adapted from the [command-line-api](https://github.com/dotnet/command-line-api) string splitter, but the adaptation collapsed the splitter's two independent state machines (word boundary and quote boundary) into one enum plus a single `skipQuoteAtIndex`.

As a result, a quote that appears **mid-word** — while a token is already started — makes the closing quote terminate the token. Text following the closing quote becomes a separate token:

| Input | Current | Reference splitter |
|-------|---------|--------------------|
| `foo"bar"baz` | `foobar`, `baz` | `foobarbaz` |
| `a"b"c` | `ab`, `c` | `abc` |

## Fix

Restore the upstream two-state machine: track word boundaries (`seeking`) and quote boundaries (`seekingQuote`) independently, and strip quotes when materializing each token. A mid-word quote now only toggles quote mode instead of ending the token.

The existing neo-express behavior of rejecting an unbalanced quote (`FormatException`) — which the upstream splitter does not do — is preserved.

## Tests

Added two cases to `BatchCommandParserTests` for the mid-word quote inputs above. They fail against the previous code and pass with the fix. The existing `SplitCommandLine_reports_unbalanced_quotes` and `SplitCommandLine_preserves_balanced_quoted_tokens` tests continue to pass. Release build is clean and `dotnet format --verify-no-changes` reports no changes.