### PR TITLE
Emit lowercase tokenid in worknet getnep11balances

### DIFF
--- a/src/worknet/Commands/WorknetRpcServerPlugin.cs
+++ b/src/worknet/Commands/WorknetRpcServerPlugin.cs
@@ -148,7 +148,7 @@ class WorknetRpcServerPlugin : Plugin
                 var token = balance.Tokens[i];
                 jsonTokens.Add(new JObject
                 {
-                    ["tokenid"] = Convert.ToHexString(token.TokenId.Span),
+                    ["tokenid"] = token.TokenId.Span.ToHexString(),
                     ["amount"] = $"{token.Balance}",
                     ["lastupdatedblock"] = token.LastUpdatedBlock,
                 });


### PR DESCRIPTION
## Problem

The worknet `getnep11balances` handler encodes the NEP-11 token id with `Convert.ToHexString` ([WorknetRpcServerPlugin.cs:151](https://github.com/neo-project/neo-express/blob/master/src/worknet/Commands/WorknetRpcServerPlugin.cs#L151)), which produces **uppercase** hex.

Every other token id the toolkit emits is lowercase. The neoxp `ExpressRpcServerPlugin` encodes the same `tokenid` field with `ReadOnlySpan<byte>.ToHexString()` ([ExpressRpcServerPlugin.cs:571](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs#L571) and [:771](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs#L771)), which is lowercase and matches the standard tokens-tracker convention. A client that switches between neoxp and worknet, or compares token ids case-sensitively, sees mismatched values for the same token.

## Fix

Replace `Convert.ToHexString(token.TokenId.Span)` with `token.TokenId.Span.ToHexString()` (the `Neo.Extensions` helper already imported in this file), so worknet emits the same lowercase form as neoxp.

## Verification

`Convert.ToHexString` and `Neo.Extensions` `ToHexString()` were confirmed against Neo 3.10.0 to produce `ABCD0A` vs `abcd0a` respectively for the same input. worknet builds clean in Release and `dotnet format --verify-no-changes` reports no changes.

No automated test is included: the worknet plugin has no test project, the class is `internal` with no `InternalsVisibleTo`, and exercising `GetNep11Balances` requires a live `NeoSystem` with a deployed NEP-11 contract. The change is a direct, one-line alignment with the existing neoxp convention.