### PR TITLE
Add a byte-array Be overload to StorageItemAssertions

### DIFF
--- a/src/assertions/StorageItemAssertions.cs
+++ b/src/assertions/StorageItemAssertions.cs
@@ -45,5 +45,21 @@ namespace Neo.Assertions
 
         public AndConstraint<StorageItemAssertions> Be(UInt256 expected, string because = "", params object[] becauseArgs)
             => Be<UInt256>(expected, bytes => new UInt256(bytes.Span), because, becauseArgs);
+
+        public AndConstraint<StorageItemAssertions> Be(ReadOnlySpan<byte> expected, string because = "", params object[] becauseArgs)
+        {
+            var span = Subject.Value.Span;
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(span.SequenceEqual(expected))
+                .FailWith("Expected {context:StorageItem} to be {0}{reason}, but was {1}.",
+                    Convert.ToHexString(expected), Convert.ToHexString(span));
+
+            return new AndConstraint<StorageItemAssertions>(this);
+        }
+
+        public AndConstraint<StorageItemAssertions> Be(byte[] expected, string because = "", params object[] becauseArgs)
+            => Be(expected.AsSpan(), because, becauseArgs);
     }
 }

--- a/src/assertions/StorageItemAssertions.cs
+++ b/src/assertions/StorageItemAssertions.cs
@@ -60,6 +60,13 @@ namespace Neo.Assertions
         }
 
         public AndConstraint<StorageItemAssertions> Be(byte[] expected, string because = "", params object[] becauseArgs)
-            => Be(expected.AsSpan(), because, becauseArgs);
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(expected is not null)
+                .FailWith("Expected {context:StorageItem} to compare against a byte array, but {0} was null.", "expected");
+
+            return Be(expected.AsSpan(), because, becauseArgs);
+        }
     }
 }

--- a/test/test-assertions/StorageItemAssertionsTests.cs
+++ b/test/test-assertions/StorageItemAssertionsTests.cs
@@ -74,4 +74,46 @@ public class StorageItemAssertionsTests
 
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public void Be_byte_array_matches_raw_value()
+    {
+        var item = new StorageItem(new byte[] { 0xde, 0xad, 0xbe, 0xef });
+
+        var act = () => item.Should().Be(new byte[] { 0xde, 0xad, 0xbe, 0xef });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Be_byte_array_matches_an_empty_value()
+    {
+        var item = new StorageItem(System.Array.Empty<byte>());
+
+        var act = () => item.Should().Be(System.Array.Empty<byte>());
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Be_byte_array_reports_mismatch()
+    {
+        var item = new StorageItem(new byte[] { 0x01, 0x02 });
+
+        var act = () => item.Should().Be(new byte[] { 0x03, 0x04 });
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*0304*");
+    }
+
+    [Fact]
+    public void Be_byte_array_includes_the_supplied_reason_in_the_failure_message()
+    {
+        var item = new StorageItem(new byte[] { 0x01, 0x02 });
+
+        var act = () => item.Should().Be(new byte[] { 0x03, 0x04 }, "of {0}", "the configured value");
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*because of the configured value*");
+    }
 }

--- a/test/test-assertions/StorageItemAssertionsTests.cs
+++ b/test/test-assertions/StorageItemAssertionsTests.cs
@@ -96,6 +96,17 @@ public class StorageItemAssertionsTests
     }
 
     [Fact]
+    public void Be_byte_array_reports_a_null_expected_value()
+    {
+        var item = new StorageItem(new byte[] { 0x01, 0x02 });
+
+        var act = () => item.Should().Be((byte[])null!);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*expected*null*");
+    }
+
+    [Fact]
     public void Be_byte_array_reports_mismatch()
     {
         var item = new StorageItem(new byte[] { 0x01, 0x02 });


### PR DESCRIPTION
## Motivation

`StorageItemAssertions` can assert that a `StorageItem` holds a `BigInteger`, `UInt160`, or `UInt256` ([StorageItemAssertions.cs:40-47](https://github.com/neo-project/neo-express/blob/master/src/assertions/StorageItemAssertions.cs#L40-L47)), but there is no way to assert it holds a specific **raw byte sequence**. The shared `Be<T>` helper is constrained to `IEquatable<T>`, which a byte array does not satisfy.

Persisting an arbitrary byte blob (a serialized struct, a stored key, a hash) is one of the most common things a Neo N3 contract does, and the sibling `StackItemAssertions` already exposes byte-array equality via `BeEquivalentTo(ReadOnlySpan<byte>)` ([StackItemAssertions.cs:183](https://github.com/neo-project/neo-express/blob/master/src/assertions/StackItemAssertions.cs#L183)). This is a missing-but-expected overload, not a stylistic choice.

## Change

Add two public overloads to `StorageItemAssertions`:
- `Be(ReadOnlySpan<byte> expected, …)` — compares the stored value with `SequenceEqual` and reports a hex diff on mismatch, mirroring `StackItemAssertions`.
- `Be(byte[] expected, …)` — a convenience overload forwarding to the span form.

Purely additive; the signatures are distinct from the existing typed overloads, so no existing call resolves differently.

## Tests

Added to `StorageItemAssertionsTests`: a match case, a mismatch case (asserts the hex of the differing bytes appears in the message), and a `because` reason case. Inverting the comparison in the production code makes all three fail, confirming they exercise the real logic. Full `test-assertions` suite (21 tests) passes; `dotnet format --verify-no-changes` is clean.