### PR TITLE
Add event-name and negative-sender assertions to NotifyEventArgsAssertions

### DIFF
--- a/src/assertions/NotifyEventArgsAssertions.cs
+++ b/src/assertions/NotifyEventArgsAssertions.cs
@@ -58,5 +58,28 @@ namespace Neo.Assertions
 
             return new AndConstraint<NotifyEventArgsAssertions>(this);
         }
+
+        public AndConstraint<NotifyEventArgsAssertions> NotBeSentBy(ContractState expected, string because = "", params object[] becauseArgs)
+            => NotBeSentBy(expected.Hash, because, becauseArgs);
+
+        public AndConstraint<NotifyEventArgsAssertions> NotBeSentBy(UInt160 expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.ScriptHash != expected)
+                .FailWith("Expected {context:NotifyEventArgs} not to be sent by {0}{reason}.", expected);
+
+            return new AndConstraint<NotifyEventArgsAssertions>(this);
+        }
+
+        public AndConstraint<NotifyEventArgsAssertions> HaveEventName(string expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.EventName == expected)
+                .FailWith("Expected {context:NotifyEventArgs} to have event name {0}{reason}, but found {1}.", expected, Subject.EventName);
+
+            return new AndConstraint<NotifyEventArgsAssertions>(this);
+        }
     }
 }

--- a/test/test-assertions/NotifyEventArgsAssertionsTests.cs
+++ b/test/test-assertions/NotifyEventArgsAssertionsTests.cs
@@ -1,0 +1,70 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NotifyEventArgsAssertionsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Assertions;
+using Neo.SmartContract;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+
+namespace test.assertions;
+
+public class NotifyEventArgsAssertionsTests
+{
+    static readonly UInt160 HashA = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+    static readonly UInt160 HashB = UInt160.Parse("0x1414131211100f0e0d0c0b0a0908070605040302");
+
+    static NotifyEventArgs Make(UInt160 scriptHash, string eventName) =>
+        new NotifyEventArgs(null!, scriptHash, eventName, new NeoArray());
+
+    [Fact]
+    public void HaveEventName_matches()
+    {
+        var act = () => Make(HashA, "Transfer").Should().HaveEventName("Transfer");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void HaveEventName_reports_mismatch()
+    {
+        var act = () => Make(HashA, "Transfer").Should().HaveEventName("Burn");
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*Transfer*");
+    }
+
+    [Fact]
+    public void HaveEventName_includes_the_supplied_reason_in_the_failure_message()
+    {
+        var act = () => Make(HashA, "Transfer").Should().HaveEventName("Burn", "of {0}", "the expected event");
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*because of the expected event*");
+    }
+
+    [Fact]
+    public void NotBeSentBy_passes_for_a_different_hash()
+    {
+        var act = () => Make(HashA, "Transfer").Should().NotBeSentBy(HashB);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void NotBeSentBy_reports_a_matching_hash()
+    {
+        var act = () => Make(HashA, "Transfer").Should().NotBeSentBy(HashA);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*not to be sent by*");
+    }
+}


### PR DESCRIPTION
## Motivation

`NotifyEventArgsAssertions` exposes only two assertions ([NotifyEventArgsAssertions.cs](https://github.com/neo-project/neo-express/blob/master/src/assertions/NotifyEventArgsAssertions.cs)):
- `BeEquivalentTo<T>(Expression<Action<T>>)` — requires a strongly-typed contract-method lambda **and every argument value**.
- `BeSentBy(...)` — with no negative counterpart.

Two routine test needs have no lightweight assertion today:
1. Confirm an event of a given name (e.g. `Transfer`) was emitted, without restating its arguments.
2. Confirm an event was **not** raised by a particular contract (e.g. checking a proxy/re-entrancy path did not directly emit it).

## Change

Add, consistent with the existing `BeSentBy` overloads:
- `HaveEventName(string expected, …)`
- `NotBeSentBy(UInt160 expected, …)` and `NotBeSentBy(ContractState expected, …)`

Purely additive.

## Tests

New `NotifyEventArgsAssertionsTests` (the class previously had no coverage): match / mismatch / `because`-reason for `HaveEventName`, and pass / fail for `NotBeSentBy`. Inverting both conditions in the production code makes all five fail, confirming they exercise the real logic. Full `test-assertions` suite (23 tests) passes; `dotnet format --verify-no-changes` is clean.