### PR TITLE
Add UInt160 and UInt256 prefix overloads to NeoStorage.StorageMap

### DIFF
--- a/src/test-harness/Extensions.cs
+++ b/src/test-harness/Extensions.cs
@@ -146,6 +146,12 @@ namespace NeoTestHarness
             => storages.Where(kvp => kvp.Key.Span.StartsWith(prefix.Span))
                 .ToDictionary(kvp => kvp.Key.Slice(prefix.Length), kvp => kvp.Value, MemorySequenceComparer.Default);
 
+        public static NeoStorage StorageMap(this NeoStorage storages, UInt160 prefix)
+            => storages.StorageMap(prefix.ToArray().AsMemory());
+
+        public static NeoStorage StorageMap(this NeoStorage storages, UInt256 prefix)
+            => storages.StorageMap(prefix.ToArray().AsMemory());
+
 
         public static bool TryGetValue(this NeoStorage storages, byte key, [MaybeNullWhen(false)] out StorageItem item)
         {

--- a/src/test-harness/Extensions.cs
+++ b/src/test-harness/Extensions.cs
@@ -152,7 +152,6 @@ namespace NeoTestHarness
         public static NeoStorage StorageMap(this NeoStorage storages, UInt256 prefix)
             => storages.StorageMap(prefix.ToArray().AsMemory());
 
-
         public static bool TryGetValue(this NeoStorage storages, byte key, [MaybeNullWhen(false)] out StorageItem item)
         {
             byte[]? buffer = null;

--- a/test/test-harness/NeoStorageExtensionsTests.cs
+++ b/test/test-harness/NeoStorageExtensionsTests.cs
@@ -57,6 +57,41 @@ public class NeoStorageExtensionsTests
     }
 
     [Fact]
+    public void StorageMap_UInt160_prefix_strips_prefix()
+    {
+        var hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+        var hashBytes = hash.ToArray();
+        var storages = BuildStorage(
+            (Concat(hashBytes, [0xaa]), [0x11]),
+            (Concat(hashBytes, [0xbb]), [0x22]),
+            ([0x99], [0x33]));
+
+        var mapped = storages.StorageMap(hash);
+
+        mapped.Should().HaveCount(2);
+        mapped.TryGetValue(new ReadOnlyMemory<byte>([0xaa]), out var first).Should().BeTrue();
+        first!.Value.ToArray().Should().Equal(0x11);
+        mapped.TryGetValue(new ReadOnlyMemory<byte>([0xbb]), out var second).Should().BeTrue();
+        second!.Value.ToArray().Should().Equal(0x22);
+    }
+
+    [Fact]
+    public void StorageMap_UInt256_prefix_strips_prefix()
+    {
+        var hash = UInt256.Parse("0x0101010101010101010101010101010101010101010101010101010101010101");
+        var hashBytes = hash.ToArray();
+        var storages = BuildStorage(
+            (Concat(hashBytes, [0x01]), [0xcd]),
+            ([0x99], [0x33]));
+
+        var mapped = storages.StorageMap(hash);
+
+        mapped.Should().HaveCount(1);
+        mapped.TryGetValue(new ReadOnlyMemory<byte>([0x01]), out var item).Should().BeTrue();
+        item!.Value.ToArray().Should().Equal(0xcd);
+    }
+
+    [Fact]
     public void TryGetValue_byte_key_returns_matching_entry()
     {
         var storages = BuildStorage(


### PR DESCRIPTION
## Motivation

The `NeoStorage` navigation helpers in [Extensions.cs](https://github.com/neo-project/neo-express/blob/master/src/test-harness/Extensions.cs) are asymmetric. The single-key `TryGetValue` family has `UInt160` ([:183](https://github.com/neo-project/neo-express/blob/master/src/test-harness/Extensions.cs#L183)) and `UInt256` ([:186](https://github.com/neo-project/neo-express/blob/master/src/test-harness/Extensions.cs#L186)) overloads, but the parallel `StorageMap(...)` prefix family only has `byte`, `string`, and `ReadOnlyMemory<byte>` forms.

Compound storage keys of the form *prefix + UInt160* are everywhere in Neo contracts (NEP-17 balance maps keyed by account, allowance and ownership maps). A test author who wants one account's sub-map currently has to hand-serialize the hash (`hash.ToArray().AsMemory()`), because there is no implicit `UInt160`→`ReadOnlyMemory<byte>` conversion — even though the sibling `TryGetValue(UInt160)` already hides exactly that.

## Change

Add `StorageMap(UInt160)` and `StorageMap(UInt256)`, each delegating to the existing `ReadOnlyMemory<byte>` overload with the same serialization the `TryGetValue` siblings use. Six lines, purely additive.

## Tests

Added `StorageMap_UInt160_prefix_strips_prefix` and `StorageMap_UInt256_prefix_strips_prefix` to `NeoStorageExtensionsTests`, modeled on the existing `StorageMap_byte_*` and `TryGetValue_UInt160_*` tests: they assert matching entries are returned with the prefix stripped and non-matching entries excluded. Replacing the prefix with an empty span makes both fail, confirming they pin the stripping behavior. Full `test-harness` suite (9 tests) passes; `dotnet format --verify-no-changes` is clean.