### PR TITLE
Add tests for Utility.TryParseRpcUri

### DIFF
--- a/test/test.bctklib/TryParseRpcUriTests.cs
+++ b/test/test.bctklib/TryParseRpcUriTests.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TryParseRpcUriTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using System;
+using Xunit;
+using static Neo.BlockchainToolkit.Constants;
+using BTUtility = Neo.BlockchainToolkit.Utility;
+
+namespace test.bctklib
+{
+    public class TryParseRpcUriTests
+    {
+        [Theory]
+        [InlineData("mainnet")]
+        [InlineData("MAINNET")]
+        public void mainnet_alias_resolves_to_first_mainnet_endpoint(string value)
+        {
+            BTUtility.TryParseRpcUri(value, out var uri).Should().BeTrue();
+            uri.Should().Be(new Uri(MAINNET_RPC_ENDPOINTS[0]));
+        }
+
+        [Theory]
+        [InlineData("testnet")]
+        [InlineData("TestNet")]
+        public void testnet_alias_resolves_to_first_testnet_endpoint(string value)
+        {
+            BTUtility.TryParseRpcUri(value, out var uri).Should().BeTrue();
+            uri.Should().Be(new Uri(TESTNET_RPC_ENDPOINTS[0]));
+        }
+
+        [Theory]
+        [InlineData("http://localhost:10332")]
+        [InlineData("https://seed1.neo.org:10332")]
+        public void absolute_http_and_https_uris_are_accepted(string value)
+        {
+            BTUtility.TryParseRpcUri(value, out var uri).Should().BeTrue();
+            uri.Should().Be(new Uri(value));
+        }
+
+        [Theory]
+        [InlineData("ftp://host:1234")]   // non-http(s) scheme
+        [InlineData("localhost:10332")]   // not an absolute http(s) uri
+        [InlineData("not a uri")]
+        [InlineData("")]
+        public void non_http_or_relative_values_are_rejected(string value)
+        {
+            // The method only guarantees a non-null uri when it returns true
+            // ([NotNullWhen(true)]), so only the boolean result is asserted here.
+            BTUtility.TryParseRpcUri(value, out _).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

`Utility.TryParseRpcUri` ([Utility.cs:24](https://github.com/neo-project/neo-express/blob/master/src/bctklib/Utility.cs#L24)) is the parser behind every command that accepts an RPC endpoint (`neoxp`, `neotrace`, `worknet create`, policy and transaction commands), yet it had no tests. It carries real branching logic — case-insensitive `mainnet`/`testnet` aliases resolving to a configured endpoint, and a guard that only accepts absolute http/https URIs — so a future edit to the alias table or scheme check could silently break endpoint resolution everywhere.

## Change

Test-only. Adds `TryParseRpcUriTests` covering:
- `mainnet`/`MAINNET` → first mainnet endpoint; `testnet`/`TestNet` → first testnet endpoint.
- absolute `http://` and `https://` URIs accepted and returned.
- non-http scheme (`ftp://`), non-absolute value (`localhost:10332`), garbage, and empty string rejected.

The rejection cases assert only the boolean result, because `TryParseRpcUri` is annotated `[NotNullWhen(true)]` and leaves `out uri` unspecified (in fact sometimes non-null) when it returns false.

## Verification

10 theory cases pass. Mutating the production code (dropping the scheme guard and pointing the mainnet alias at the testnet endpoint) makes four of them fail, confirming they pin the real behavior. Full `test.bctklib` suite (300 tests) passes; `dotnet format --verify-no-changes` is clean. No production code changed.