### PR TITLE
Add tests for Extensions.ResolveFileName

### DIFF
--- a/test/test.bctklib/ResolveFileNameTests.cs
+++ b/test/test.bctklib/ResolveFileNameTests.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ResolveFileNameTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class ResolveFileNameTests
+    {
+        [Fact]
+        public void empty_fileName_uses_the_default_callback()
+        {
+            var fs = new MockFileSystem();
+            var cwd = fs.Directory.GetCurrentDirectory();
+
+            fs.ResolveFileName("", ".neo-express", () => "default.neo-express")
+                .Should().Be(fs.Path.Combine(cwd, "default.neo-express"));
+        }
+
+        [Fact]
+        public void bare_name_is_qualified_against_the_current_directory_and_extension_appended()
+        {
+            var fs = new MockFileSystem();
+            var cwd = fs.Directory.GetCurrentDirectory();
+
+            fs.ResolveFileName("foo", ".neo-express", () => "unused")
+                .Should().Be(fs.Path.Combine(cwd, "foo.neo-express"));
+        }
+
+        [Fact]
+        public void matching_extension_is_case_insensitive_and_not_doubled()
+        {
+            var fs = new MockFileSystem();
+            var cwd = fs.Directory.GetCurrentDirectory();
+
+            fs.ResolveFileName("foo.NEO-EXPRESS", ".neo-express", () => "unused")
+                .Should().Be(fs.Path.Combine(cwd, "foo.NEO-EXPRESS"));
+        }
+
+        [Fact]
+        public void fully_qualified_path_keeps_its_directory()
+        {
+            var fs = new MockFileSystem();
+            var input = fs.Path.Combine(fs.Path.GetTempPath(), "bar");
+
+            fs.ResolveFileName(input, ".neo-express", () => "unused")
+                .Should().Be(input + ".neo-express");
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

`Extensions.ResolveFileName` ([Extensions.cs:29](https://github.com/neo-project/neo-express/blob/master/src/bctklib/Extensions.cs#L29)) resolves the path of neo-express config and output files. It encodes three behaviors callers rely on, none of which were tested:
1. an empty/null file name falls back to `getDefaultFileName()`;
2. a non-fully-qualified path is combined with the current directory;
3. the extension is appended unless the path already ends with it, compared case-insensitively.

A regression in any branch would mis-resolve file paths.

## Change

Test-only. Adds `ResolveFileNameTests` with one case per behavior, plus a fully-qualified-input case. Tests use `MockFileSystem` and the file system's own `Path`/`Directory` helpers, so they run identically on any OS.

## Verification

4 tests pass. Changing the extension comparison from `OrdinalIgnoreCase` to `Ordinal` makes the case-insensitivity test fail, confirming it pins the real branch. Full `test.bctklib` suite (294 tests) passes; `dotnet format --verify-no-changes` is clean. No production code changed.

Note (out of scope): `NeoExpress.FileSystemExtensions.ResolveFileName` in `src/neoxp` is a byte-identical duplicate of this method; deduping it is worth a separate change and is intentionally not folded in here.