### PR TITLE
Reject a negative timestamp delta when parsing fastfwd arguments

### DIFF
--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -64,12 +64,19 @@ namespace NeoExpress.Commands
         }
 
         internal static TimeSpan ParseTimestampDelta(string timestampDelta)
-            => string.IsNullOrEmpty(timestampDelta)
+        {
+            var delta = string.IsNullOrEmpty(timestampDelta)
                 ? TimeSpan.Zero
                 : ulong.TryParse(timestampDelta, out var @ulong)
                     ? TimeSpan.FromSeconds(@ulong)
                     : TimeSpan.TryParse(timestampDelta, out var timeSpan)
                         ? timeSpan
                         : throw new Exception($"Could not parse timestamp delta {timestampDelta}");
+
+            if (delta < TimeSpan.Zero)
+                throw new Exception($"Timestamp delta {timestampDelta} cannot be negative");
+
+            return delta;
+        }
     }
 }

--- a/test/test.workflowvalidation/FastForwardCommandTests.cs
+++ b/test/test.workflowvalidation/FastForwardCommandTests.cs
@@ -24,4 +24,23 @@ public class FastForwardCommandTests
         action.Should().Throw<Exception>()
             .WithMessage($"Cannot mint more than {FastForwardCommand.MaxFastForwardCount} blocks at once");
     }
+
+    [Theory]
+    [InlineData("-10")]
+    [InlineData("-1.00:00:00")]
+    public void ParseTimestampDelta_rejects_negative(string input)
+    {
+        var action = () => FastForwardCommand.ParseTimestampDelta(input);
+
+        action.Should().Throw<Exception>()
+            .WithMessage($"*{input}*");
+    }
+
+    [Fact]
+    public void ParseTimestampDelta_accepts_valid_inputs()
+    {
+        FastForwardCommand.ParseTimestampDelta("5").Should().Be(TimeSpan.FromSeconds(5));
+        FastForwardCommand.ParseTimestampDelta("").Should().Be(TimeSpan.Zero);
+        FastForwardCommand.ParseTimestampDelta("1.00:00:00").Should().Be(TimeSpan.FromDays(1));
+    }
 }


### PR DESCRIPTION
## Problem

`FastForwardCommand.ParseTimestampDelta` ([FastForwardCommand.cs:66](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/FastForwardCommand.cs#L66)) accepts a negative `TimeSpan` string. `ulong.TryParse("-10")` fails, but `TimeSpan.TryParse("-10")` succeeds (as `-10` days), so:

```
neoxp fastfwd 5 --timestamp-delta -10
```

parses to a negative delta. That value is only rejected much later, deep inside `NodeUtility.FastForwardAsync` ([NodeUtility.cs:90](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/NodeUtility.cs#L90)), which requires spinning up an express node to surface — and `ParseTimestampDelta` is also reused by batch-file execution ([BatchCommand.cs:193](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L193)), so the same unvalidated path applies there.

## Fix

Reject a negative delta at parse time, with a clear message that names the offending input. This moves the existing rule forward so the error appears immediately, without starting a node, on both the command and batch paths. The `NodeUtility` guard is left in place as defense in depth. Valid inputs (ulong seconds, non-negative `TimeSpan` strings, empty) parse exactly as before.

## Tests

Added to `FastForwardCommandTests`: `-10` and `-1.00:00:00` throw with the input named, and `5`/`""`/`1.00:00:00` still parse correctly. The negative tests fail against the previous code and pass with the fix. Release build is clean and `dotnet format --verify-no-changes` reports no changes.