### PR TITLE
Add tests for Extensions.GetOperandString hex formatting

### DIFF
--- a/test/test.bctklib/GetOperandStringTests.cs
+++ b/test/test.bctklib/GetOperandStringTests.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// GetOperandStringTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Neo.VM;
+using System.Linq;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class GetOperandStringTests
+    {
+        [Fact]
+        public void multi_byte_operand_is_dash_separated_uppercase_hex()
+        {
+            using var sb = new ScriptBuilder();
+            sb.Emit(OpCode.SYSCALL, new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+            var instruction = new Script(sb.ToArray()).EnumerateInstructions().First().instruction;
+
+            instruction.OpCode.Should().Be(OpCode.SYSCALL);
+            instruction.GetOperandString().Should().Be("AA-BB-CC-DD");
+        }
+
+        [Fact]
+        public void single_byte_operand_has_no_separator()
+        {
+            using var sb = new ScriptBuilder();
+            sb.Emit(OpCode.JMP, new byte[] { 0x0F });
+            var instruction = new Script(sb.ToArray()).EnumerateInstructions().First().instruction;
+
+            instruction.OpCode.Should().Be(OpCode.JMP);
+            instruction.GetOperandString().Should().Be("0F");
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

`Extensions.GetOperandString` ([Extensions.cs:149](https://github.com/neo-project/neo-express/blob/master/src/bctklib/Extensions.cs#L149)) formats an instruction operand as dash-separated uppercase hex, using hand-rolled `string.Create` span arithmetic — a buffer sized `Operand.Length * 3 - 1` and a manual loop that writes the `-` separators. It is used in trace/dump output but had no tests, and the off-by-one sizing and nibble logic are exactly the kind of code a refactor can silently regress (wrong separator placement, lowercase, trailing dash).

## Change

Test-only. Adds `GetOperandStringTests`:
- a multi-byte operand (`SYSCALL` + 4 bytes) → `AA-BB-CC-DD`;
- a single-byte operand (`JMP` + 1 byte) → `0F` (exercises the `length == 1` path, where the buffer is 2 chars and the separator loop never runs).

## Verification

2 tests pass. Lower-casing the hex digit in the production code makes both fail, confirming they pin the formatting. Full `test.bctklib` suite (292 tests) passes; `dotnet format --verify-no-changes` is clean. No production code changed.