### PR TITLE
Add a --json output option to the execute command

### DIFF
--- a/src/neoxp/Commands/ExecuteCommand.cs
+++ b/src/neoxp/Commands/ExecuteCommand.cs
@@ -60,6 +60,9 @@ namespace NeoExpress.Commands
         [Option(Description = "Enable contract execution tracing")]
         internal bool Trace { get; init; } = false;
 
+        [Option(Description = "Output as JSON")]
+        internal bool Json { get; init; } = false;
+
         [Option(Description = "Path to neo-express data file")]
         internal string Input { get; init; } = string.Empty;
 
@@ -74,7 +77,7 @@ namespace NeoExpress.Commands
                 }
 
                 var (chainManager, _) = chainManagerFactory.LoadChain(Input);
-                using var txExec = txExecutorFactory.Create(chainManager, Trace, false);
+                using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
 
                 var script = ConvertTextToScript(InputText) ?? LoadFileScript(InputText);
                 if (script == null)
@@ -93,10 +96,13 @@ namespace NeoExpress.Commands
                     await txExec.ContractInvokeAsync(script, Account, password, WitnessScope, AdditionalGas);
                 }
 
-                console.WriteLine("Opcodes:");
-                foreach (var opInfo in GetInstructionString(script))
+                if (!Json)
                 {
-                    console.WriteLine(opInfo);
+                    console.WriteLine("Opcodes:");
+                    foreach (var opInfo in GetInstructionString(script))
+                    {
+                        console.WriteLine(opInfo);
+                    }
                 }
                 return 0;
             }

--- a/test/test.workflowvalidation/ExecuteCommandTests.cs
+++ b/test/test.workflowvalidation/ExecuteCommandTests.cs
@@ -9,14 +9,34 @@
 // modifications are permitted.
 
 using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
 using NeoExpress.Commands;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace test.workflowvalidation;
 
 public class ExecuteCommandTests
 {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Json_option_binds_from_the_command_line(bool flagSupplied)
+    {
+        // ExecuteCommand has no parameterless constructor, so bypass construction
+        // (the factories are unused for argument parsing) and bind options directly.
+        var app = new CommandLineApplication<ExecuteCommand>
+        {
+            ModelFactory = () => (ExecuteCommand)RuntimeHelpers.GetUninitializedObject(typeof(ExecuteCommand)),
+        };
+        app.Conventions.UseOptionAttributes().UseArgumentAttributes();
+
+        app.Parse(flagSupplied ? ["somescript", "--json"] : ["somescript"]);
+
+        app.Model.Json.Should().Be(flagSupplied);
+    }
+
     [Fact]
     public void LoadFileScript_returns_null_for_long_non_file_input()
     {


### PR DESCRIPTION
## Motivation

The `execute` command runs the same underlying invocation as `contract invoke` (`InvokeForResultsAsync` / `ContractInvokeAsync` via the transaction executor), but unlike `invoke` — and `transfer`, candidate vote/register, and oracle response — it has no `--json` option and hardcodes JSON output off ([ExecuteCommand.cs:77](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ExecuteCommand.cs#L77)). `execute` is the only invocation command that cannot emit machine-readable output, which is awkward when scripting against a custom neo-vm script.

## Change

Mirror `invoke` ([ContractCommand.Invoke.cs:55](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Invoke.cs#L55)):
- add `[Option(Description = "Output as JSON")] internal bool Json`;
- pass it to `txExecutorFactory.Create(chainManager, Trace, Json)`;
- skip the human-readable `Opcodes:` dump when `--json` is set so the JSON stays clean.

Default is `false`, so current output is unchanged unless the flag is supplied.

## Tests

Added a parsing theory to `ExecuteCommandTests` asserting `--json` binds `Json` to `true` and that it defaults to `false` when omitted. Removing the `[Option]` attribute in the production code makes the `true` case fail, confirming the test verifies the actual option wiring rather than just the property. Release build is clean and `dotnet format --verify-no-changes` reports no changes.