### PR TITLE
Remove duplicate ResolveFileName extension from neoxp

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -10,7 +10,6 @@
 
 using McMaster.Extensions.CommandLineUtils;
 using Neo;
-using Neo.BlockchainToolkit;
 using Neo.Wallets;
 using System.IO.Abstractions;
 using static Neo.BlockchainToolkit.Constants;

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -10,6 +10,7 @@
 
 using McMaster.Extensions.CommandLineUtils;
 using Neo;
+using Neo.BlockchainToolkit;
 using Neo.Wallets;
 using System.IO.Abstractions;
 using static Neo.BlockchainToolkit.Constants;

--- a/src/neoxp/Extensions/FileSystemExtensions.cs
+++ b/src/neoxp/Extensions/FileSystemExtensions.cs
@@ -21,22 +21,6 @@ namespace NeoExpress
     {
         internal const int MaxContractFileBytes = 4 * 1024 * 1024;
 
-        public static string ResolveFileName(this IFileSystem fileSystem, string fileName, string extension, Func<string> getDefaultFileName)
-        {
-            if (string.IsNullOrEmpty(fileName))
-            {
-                fileName = getDefaultFileName();
-            }
-
-            if (!fileSystem.Path.IsPathFullyQualified(fileName))
-            {
-                fileName = fileSystem.Path.Combine(fileSystem.Directory.GetCurrentDirectory(), fileName);
-            }
-
-            return extension.Equals(fileSystem.Path.GetExtension(fileName), StringComparison.OrdinalIgnoreCase)
-                ? fileName : fileName + extension;
-        }
-
         public static string GetTempFolder(this IFileSystem fileSystem)
         {
             string path;


### PR DESCRIPTION
## Description

`NeoExpress.FileSystemExtensions.ResolveFileName` was a byte-identical duplicate of `Neo.BlockchainToolkit.Extensions.ResolveFileName`. neoxp already references bctklib, and its callers bound to the local copy only via namespace precedence.

This removes the duplicate from `src/neoxp/Extensions/FileSystemExtensions.cs` and lets the callers bind to the surviving bctklib method through the `Neo.BlockchainToolkit` namespace (adding the using to `BatchCommand.cs`, the only caller that lacked it). The surviving method is already covered by `test/test.bctklib/ResolveFileNameTests.cs`.

## Type of change

- [x] Code cleanup / refactor (no functional change)

## How Has This Been Tested?

- `dotnet build src/neoxp/neoxp.csproj -c Release` — succeeds, 0 errors
- `dotnet test` — all tests pass
- `dotnet format --verify-no-changes` — no changes