### PR TITLE
Run all extension unit tests in CI

### DIFF
--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -45,6 +45,6 @@ jobs:
       working-directory: extentions/neo3-visual-tracker
       run: npm run lint
 
-    - name: Test Quick Start actions
+    - name: Run unit tests
       working-directory: extentions/neo3-visual-tracker
-      run: npm run test:quickstart
+      run: npm test

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -343,6 +343,7 @@
     "watch": "concurrently -r npm:watch-*",
     "watch-ext": "webpack --config src/extension/webpack.config.js --mode development --watch --stats-error-details",
     "watch-panel": "webpack --config src/panel/webpack.config.js --mode development --watch --stats-error-details",
+    "test": "node --test -r ts-node/register \"src/**/*.test.ts\"",
     "test:quickstart": "node --test -r ts-node/register src/panel/components/views/quickStartActions.test.ts",
     "test:server-list": "node --test -r ts-node/register src/extension/fileDetectors/serverListConfig.test.ts"
   },


### PR DESCRIPTION
## Motivation

The VS Code extension has six `node:test` unit-test files:

- `src/extension/commands/commandArguments.test.ts`
- `src/extension/fileDetectors/serverListConfig.test.ts`
- `src/extension/fileDetectors/serverListWorkspaceTrust.test.ts`
- `src/extension/util/tryFetchJson.test.ts`
- `src/panel/components/views/quickStartActions.test.ts`
- `src/shared/messages/viewRequest.test.ts`

But `package.json` defines no aggregate `test` script (so `npm test` errors with *Missing script: "test"*), and the CI workflow ([pr_extension.yml:48](https://github.com/neo-project/neo-express/blob/master/.github/workflows/pr_extension.yml#L48)) runs only `npm run test:quickstart`. The other five suites never run in CI and can silently rot.

## Change

- Add `"test": "node --test -r ts-node/register \"src/**/*.test.ts\""` to `package.json` (keeping the two granular scripts for ad-hoc use).
- Point the workflow's test step at `npm test` so every `*.test.ts` file runs on pull requests.

No production code changes.

## Verification

`npm test` discovers all six files and reports **tests 16 / pass 16 / fail 0**. To prove the new step adds coverage, breaking an assertion in `tryFetchJson.test.ts` (a file the old step never ran) leaves `npm run test:quickstart` green (4/4) while `npm test` fails (15 pass / 1 fail). CI runs Node 22, whose test runner supports the glob pattern.