### PR TITLE
Fix the custom-editor activation event id

### DIFF
--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -48,7 +48,7 @@
     "onCommand:neo3-visual-devtracker.tracker.openContract",
     "onCommand:neo3-visual-devtracker.tracker.openTracker",
     "onCommand:neo3-visual-devtracker.tracker.openWallet",
-    "onCustomEditor:neo3-visual-devtracker.express.neo-invoke-json",
+    "onCustomEditor:neo3-visual-devtracker.neo.neo-invoke-json",
     "onView:neo3-visual-devtracker.views.blockchains",
     "onView:neo3-visual-devtracker.views.quickStart",
     "workspaceContains:**/*.nef",

--- a/extentions/neo3-visual-tracker/src/extension/activationEventsConsistency.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/activationEventsConsistency.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, "../../package.json"), "utf8")
+) as {
+  activationEvents?: string[];
+  contributes?: { customEditors?: { viewType?: string }[] };
+};
+
+test("every onCustomEditor activation event matches a contributed customEditor viewType", () => {
+  const viewTypes = new Set(
+    (packageJson.contributes?.customEditors ?? [])
+      .map((editor) => editor.viewType)
+      .filter((viewType): viewType is string => typeof viewType === "string")
+  );
+
+  const customEditorEvents = (packageJson.activationEvents ?? []).filter(
+    (event) => event.startsWith("onCustomEditor:")
+  );
+
+  for (const event of customEditorEvents) {
+    const viewType = event.slice("onCustomEditor:".length);
+    assert.ok(
+      viewTypes.has(viewType),
+      `activationEvents entry "${event}" has no matching contributes.customEditors viewType`
+    );
+  }
+});


### PR DESCRIPTION
## Problem

`activationEvents` declares `onCustomEditor:neo3-visual-devtracker.express.neo-invoke-json` ([package.json:51](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/package.json#L51)), but the custom editor is contributed and registered under a **different** id:
- `contributes.customEditors[].viewType` is `neo3-visual-devtracker.neo.neo-invoke-json` ([package.json:68](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/package.json#L68));
- it is registered with that same id in [index.ts:137](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/index.ts#L137).

The `express.` vs `neo.` prefix mismatch means the activation event points at a viewType that does not exist — it is dead and misleading. The editor still opens today only because the `workspaceContains:**/*.neo-invoke.json` rule also triggers activation, which is why this is latent staleness rather than a visible outage.

## Change

- Correct the activation event id to `neo3-visual-devtracker.neo.neo-invoke-json`.
- Add `activationEventsConsistency.test.ts`, which asserts every `onCustomEditor:` activation event has a matching `contributes.customEditors` viewType, so this drift cannot silently recur.

## Verification

The test passes with the fix and fails against the previous id with a clear message. `npm run typecheck` passes and `npm run lint` reports no new problems. The test runs under the aggregate `npm test` runner.

> Note: it is picked up in CI by the aggregate test script added in #676; merged in either order, the result is consistent.