### PR TITLE
Write the State payload when serializing a bctklib NotificationRecord

### DIFF
--- a/src/bctklib/plugins/NotificationRecord.cs
+++ b/src/bctklib/plugins/NotificationRecord.cs
@@ -67,7 +67,7 @@ namespace Neo.BlockchainToolkit.Plugins
         public void Serialize(BinaryWriter writer)
         {
             ScriptHash.Serialize(writer);
-            BinarySerializer.Serialize(State, ExecutionEngineLimits.Default);
+            writer.Write(BinarySerializer.Serialize(State, ExecutionEngineLimits.Default));
             writer.WriteVarString(EventName);
             InventoryHash.Serialize(writer);
             writer.Write((byte)InventoryType);

--- a/test/test.bctklib/NotificationRecordTests.cs
+++ b/test/test.bctklib/NotificationRecordTests.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NotificationRecordTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Plugins;
+using Neo.Extensions;
+using Neo.IO;
+using Neo.Network.P2P.Payloads;
+using System.Numerics;
+using System.Text;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+using NeoByteString = Neo.VM.Types.ByteString;
+using NeoInteger = Neo.VM.Types.Integer;
+
+namespace test.bctklib
+{
+    public class NotificationRecordTests
+    {
+        [Fact]
+        public void Serialize_round_trips_including_the_state_payload()
+        {
+            var scriptHash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+            var state = new NeoArray(new Neo.VM.Types.StackItem[]
+            {
+                new NeoByteString(Encoding.UTF8.GetBytes("from")),
+                new NeoInteger(new BigInteger(42)),
+            });
+            var record = new NotificationRecord(scriptHash, "Transfer", state, InventoryType.TX, UInt256.Zero);
+
+            var restored = record.ToArray().AsSerializable<NotificationRecord>();
+
+            restored.ScriptHash.Should().Be(scriptHash);
+            restored.EventName.Should().Be("Transfer");
+            restored.InventoryType.Should().Be(InventoryType.TX);
+            restored.InventoryHash.Should().Be(UInt256.Zero);
+            restored.State.Count.Should().Be(2);
+            restored.State[0].GetString().Should().Be("from");
+            restored.State[1].GetInteger().Should().Be(new BigInteger(42));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`NotificationRecord.Serialize` ([NotificationRecord.cs:70](https://github.com/neo-project/neo-express/blob/master/src/bctklib/plugins/NotificationRecord.cs#L70)) called `BinarySerializer.Serialize(State, ExecutionEngineLimits.Default)` but **discarded the returned byte array** — the notification `State` was never written to the stream:

```csharp
ScriptHash.Serialize(writer);
BinarySerializer.Serialize(State, ExecutionEngineLimits.Default);  // result thrown away
writer.WriteVarString(EventName);
```

`Deserialize` then reads the *next* field's bytes as the State and throws `FormatException: Invalid StackItemType` (the first byte of the var-string event name is misread as a stack-item type). Every round trip through the toolkit persistence plugin — i.e. worknet's notification-backed RPC methods — fails on the stored record.

This is the same defect already fixed for the neoxp `NotificationRecord` in #647; the bctklib copy was missed.

## Fix

Write the serialized State bytes:

```csharp
writer.Write(BinarySerializer.Serialize(State, ExecutionEngineLimits.Default));
```

matching [neoxp's NotificationRecord.cs:72](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Models/NotificationRecord.cs#L72).

## Tests

`NotificationRecordTests` serializes a record with a non-empty State (a string and an integer) via `ToArray()` and reads it back via `AsSerializable<NotificationRecord>`, asserting the script hash, event name, inventory fields, and both State items survive. The test fails against the previous code with `Invalid StackItemType` and passes with the fix. Full `test.bctklib` suite (291) passes; `dotnet format --verify-no-changes` is clean.