### PR TITLE
Register contract update as a batch-file subcommand (with data parameter)

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -880,6 +880,7 @@ The commands supported in a batch file include:
 * `contract deploy`
 * `contract invoke`
 * `contract run`
+* `contract update`
 * `fastfwd`
 * `oracle enable`
 * `oracle response`

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -38,7 +38,7 @@ namespace NeoExpress.Commands
             }
 
             [Command("contract")]
-            [Subcommand(typeof(Deploy), typeof(Download), typeof(Invoke), typeof(Run))]
+            [Subcommand(typeof(Deploy), typeof(Download), typeof(Invoke), typeof(Run), typeof(Update))]
             internal class Contract
             {
                 [Command("deploy")]
@@ -152,6 +152,9 @@ namespace NeoExpress.Commands
 
                     [Option(Description = "Password to use for NEP-2/NEP-6 account")]
                     internal string Password { get; init; } = string.Empty;
+
+                    [Option(Description = "Data parameter for update method on contract (Format: JSON)")]
+                    internal string Data { get; init; } = string.Empty;
                 }
             }
 

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -179,12 +179,14 @@ namespace NeoExpress.Commands
                         }
                     case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:
                         {
+                            var data = txExec.ContractParameterParser(cmd.Model.Data);
                             await txExec.ContractUpdateAsync(
                                 cmd.Model.Contract,
                                 root.Resolve(cmd.Model.NefFile),
                                 cmd.Model.Account,
                                 cmd.Model.Password,
-                                cmd.Model.WitnessScope).ConfigureAwait(false);
+                                cmd.Model.WitnessScope,
+                                data).ConfigureAwait(false);
                             break;
                         }
                     case CommandLineApplication<BatchFileCommands.FastForward> cmd:

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
 using NeoExpress.Commands;
 using Xunit;
 
@@ -16,6 +17,31 @@ namespace test.workflowvalidation;
 
 public class BatchCommandParserTests
 {
+    [Fact]
+    public void Contract_update_is_a_recognized_batch_subcommand()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("contract", "update", "myContract", "contract.nef", "alice");
+
+        result.SelectedCommand.Should()
+            .BeOfType<CommandLineApplication<BatchCommand.BatchFileCommands.Contract.Update>>();
+    }
+
+    [Fact]
+    public void Contract_update_binds_the_data_option()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("contract", "update", "myContract", "contract.nef", "alice", "--data", "42");
+
+        var update = result.SelectedCommand.Should()
+            .BeOfType<CommandLineApplication<BatchCommand.BatchFileCommands.Contract.Update>>().Subject;
+        update.Model.Data.Should().Be("42");
+    }
+
     [Fact]
     public void SplitCommandLine_reports_unbalanced_quotes()
     {


### PR DESCRIPTION
## Problem

The batch-file `contract` command registers `Deploy`, `Download`, `Invoke` and `Run` ([BatchCommand.BatchFileCommands.cs:41](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs#L41)) but **omits `Update`**, even though the `Contract.Update` model and its executor case (calling `ContractUpdateAsync`) both exist. So `contract update …` in a `.batch` file was unreachable — parsing threw `UnrecognizedCommandParsingException`.

In addition, the batch `Contract.Update` model lacked the `--data` option that the top-level `neoxp contract update` command has ([ContractCommand.Update.cs:44](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Update.cs#L44)); the executor called `ContractUpdateAsync` without a data argument, so even once reachable a batch `update` could not pass the `data` parameter to a contract's update method.

## Fix

- Register `Update` as a subcommand.
- Add the `--data` option to the batch `Contract.Update` model (mirroring the top-level command and the sibling batch `deploy`), parse it through `ContractParameterParser`, and pass it to `ContractUpdateAsync`.
- Document `contract update` in the batch command reference.

## Tests

`BatchCommandParserTests` now covers that `contract update myContract contract.nef alice` resolves to the `Contract.Update` application and that `--data 42` binds to `Model.Data`. Without the subcommand registration the parse throws `UnrecognizedCommandParsingException`; without the `[Option]` the `--data` test fails with `Unrecognized option '--data'`. Release build is clean and `dotnet format --verify-no-changes` reports no changes.