### PR TITLE
Correct the stop command multi-node error message

### DIFF
--- a/src/neoxp/Commands/StopCommand.cs
+++ b/src/neoxp/Commands/StopCommand.cs
@@ -53,20 +53,27 @@ namespace NeoExpress.Commands
             }
             else
             {
-                var nodeIndex = NodeIndex.HasValue
-                    ? NodeIndex.Value
-                    : chain.ConsensusNodes.Count == 1
-                        ? 0
-                        : throw new InvalidOperationException("node index or --all must be specified when resetting a multi-node chain");
-
-                if (nodeIndex < 0 || nodeIndex >= chain.ConsensusNodes.Count)
-                {
-                    throw new ArgumentException($"node-index must be in [0, {chain.ConsensusNodes.Count - 1}]", nameof(NodeIndex));
-                }
+                var nodeIndex = ResolveNodeIndex(NodeIndex, chain.ConsensusNodes.Count);
 
                 var wasRunning = await chainManager.StopNodeAsync(chain.ConsensusNodes[nodeIndex]).ConfigureAwait(false);
                 await console.Out.WriteLineAsync($"node {nodeIndex} {(wasRunning ? "stopped" : "was not running")}").ConfigureAwait(false);
             }
+        }
+
+        internal static int ResolveNodeIndex(int? nodeIndex, int nodeCount)
+        {
+            var index = nodeIndex.HasValue
+                ? nodeIndex.Value
+                : nodeCount == 1
+                    ? 0
+                    : throw new InvalidOperationException("node index or --all must be specified when stopping a multi-node chain");
+
+            if (index < 0 || index >= nodeCount)
+            {
+                throw new ArgumentException($"node-index must be in [0, {nodeCount - 1}]", nameof(nodeIndex));
+            }
+
+            return index;
         }
 
         internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)

--- a/test/test.workflowvalidation/StopCommandTests.cs
+++ b/test/test.workflowvalidation/StopCommandTests.cs
@@ -1,0 +1,47 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StopCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class StopCommandTests
+{
+    [Fact]
+    public void ResolveNodeIndex_requires_an_index_for_a_multi_node_chain()
+    {
+        var action = () => StopCommand.ResolveNodeIndex(null, nodeCount: 4);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("node index or --all must be specified when stopping a multi-node chain");
+    }
+
+    [Fact]
+    public void ResolveNodeIndex_defaults_to_zero_for_a_single_node_chain()
+    {
+        StopCommand.ResolveNodeIndex(null, nodeCount: 1).Should().Be(0);
+    }
+
+    [Fact]
+    public void ResolveNodeIndex_returns_the_supplied_index_when_in_range()
+    {
+        StopCommand.ResolveNodeIndex(2, nodeCount: 4).Should().Be(2);
+    }
+
+    [Fact]
+    public void ResolveNodeIndex_rejects_an_out_of_range_index()
+    {
+        var action = () => StopCommand.ResolveNodeIndex(7, nodeCount: 4);
+
+        action.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Problem

Running `neoxp stop` on a multi-node chain without `--node-index` or `--all` throws:

> node index or --all must be specified when **resetting** a multi-node chain

This is the `stop` command ([`[Command("stop", …)]`](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/StopCommand.cs#L15)), not reset. The string was copy-pasted from [ResetCommand.cs:61](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ResetCommand.cs#L61) and names the wrong action, which is confusing when diagnosing why a stop failed.

## Fix

Correct "resetting" to "stopping", and extract the node-index resolution into an `internal static ResolveNodeIndex(int?, int)` helper (mirroring the existing `FastForwardCommand.ValidateCount` pattern) so it can be unit-tested without a running chain. Behavior is otherwise unchanged.

## Tests

`StopCommandTests` covers the corrected message for a multi-node chain, the single-node default (index 0), an in-range index, and an out-of-range rejection. Restoring the "resetting" wording makes the message test fail. Release build is clean and `dotnet format --verify-no-changes` reports no changes.