### PR TITLE
Dispose the RpcClient owned by OnlineNode

### DIFF
--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -33,6 +33,7 @@ namespace NeoExpress.Node
         readonly ExpressChain chain;
         readonly RpcClient rpcClient;
         readonly Lazy<KeyPair[]> consensusNodesKeys;
+        bool disposedValue;
 
         public ProtocolSettings ProtocolSettings { get; }
 
@@ -46,7 +47,11 @@ namespace NeoExpress.Node
 
         public void Dispose()
         {
-            rpcClient.Dispose();
+            if (!disposedValue)
+            {
+                rpcClient.Dispose();
+                disposedValue = true;
+            }
         }
 
         public async Task<IExpressNode.CheckpointMode> CreateCheckpointAsync(string checkPointPath)

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -49,8 +49,8 @@ namespace NeoExpress.Node
         {
             if (!disposedValue)
             {
-                rpcClient.Dispose();
                 disposedValue = true;
+                rpcClient.Dispose();
             }
         }
 

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -46,6 +46,7 @@ namespace NeoExpress.Node
 
         public void Dispose()
         {
+            rpcClient.Dispose();
         }
 
         public async Task<IExpressNode.CheckpointMode> CreateCheckpointAsync(string checkPointPath)

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OnlineNodeTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Neo.Network.RPC;
+using NeoExpress.Node;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class OnlineNodeTests
+{
+    [Fact]
+    public void Dispose_disposes_the_owned_rpc_client()
+    {
+        var chain = new ExpressChain();
+        var node = new ExpressConsensusNode { RpcPort = 65001 };
+        var onlineNode = new OnlineNode(ProtocolSettings.Default, chain, node);
+
+        onlineNode.Dispose();
+
+        var rpcClient = (RpcClient)typeof(OnlineNode)
+            .GetField("rpcClient", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(onlineNode)!;
+
+        // A disposed RpcClient throws ObjectDisposedException on use; an
+        // undisposed one would instead attempt a network call.
+        var act = () => rpcClient.RpcSendAsync("getversion").GetAwaiter().GetResult();
+        act.Should().Throw<ObjectDisposedException>();
+    }
+}

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -39,4 +39,20 @@ public class OnlineNodeTests
         var act = () => rpcClient.RpcSendAsync("getversion").GetAwaiter().GetResult();
         act.Should().Throw<ObjectDisposedException>();
     }
+
+    [Fact]
+    public void Dispose_is_idempotent()
+    {
+        var chain = new ExpressChain();
+        var node = new ExpressConsensusNode { RpcPort = 65002 };
+        var onlineNode = new OnlineNode(ProtocolSettings.Default, chain, node);
+
+        var act = () =>
+        {
+            onlineNode.Dispose();
+            onlineNode.Dispose();
+        };
+
+        act.Should().NotThrow();
+    }
 }


### PR DESCRIPTION
## Problem

`OnlineNode` is an `IExpressNode` (which is `IDisposable`) that constructs and holds an `RpcClient` ([OnlineNode.cs:34](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L34), [:43](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L43)), but its `Dispose()` body is empty ([:47](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L47)). `RpcClient` is `IDisposable` and owns an `HttpClient` that it releases in its own `Dispose`.

Every neoxp command that runs against a live node does `using var expressNode = chainManager.GetExpressNode()`, and `GetExpressNode()` returns a new `OnlineNode` when connected — so each such invocation leaks the `HttpClient` and its socket handle. The sibling `OfflineNode` disposes its resources, and `TransactionExecutor` uses `using var rpcClient = new RpcClient(uri)`, confirming the codebase's own convention.

## Fix

```csharp
public void Dispose()
{
    rpcClient.Dispose();
}
```

## Tests

`OnlineNodeTests` constructs an `OnlineNode` (its constructor performs no network I/O), disposes it, and asserts the owned `RpcClient` now throws `ObjectDisposedException` on use. Against the previous empty `Dispose()` the client is still live and instead attempts a network call (`HttpRequestException`), so the test fails. Release build is clean and `dotnet format --verify-no-changes` reports no changes.