### PR TITLE
Correct the default block time in the readme quick start

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ neoxp run
 neoxp show balances genesis
 ```
 
-> **Tip:** While the blockchain is running it mints a new block every 3 seconds by
+> **Tip:** While the blockchain is running it mints a new block every 15 seconds by
 > default, so a transaction is not reflected in queries such as `show balances` until the
 > next block is produced. For faster local iteration, start the chain with a shorter block
 > time, for example `neoxp run --seconds-per-block 1`.


### PR DESCRIPTION
## Problem

The quick-start tip in [readme.md:122](https://github.com/neo-project/neo-express/blob/master/readme.md#L122) states the chain mints a new block **every 3 seconds** by default. The actual default is **15 seconds**:

- [ExpressChainExtensions.cs:33](https://github.com/neo-project/neo-express/blob/master/src/bctklib/ExpressChainExtensions.cs#L33) sets `MillisecondsPerBlock = secondsPerBlock == 0 ? 15000 : …`, i.e. 15 s when no `--seconds-per-block` override is given.
- [docs/command-reference.md:105](https://github.com/neo-project/neo-express/blob/master/docs/command-reference.md#L105) and [docs/settings.md:12](https://github.com/neo-project/neo-express/blob/master/docs/settings.md#L12) both already state 15 seconds.

The tip also self-contradicted: it suggests `--seconds-per-block 1` to go *faster*, which only makes sense against a 15 s baseline.

## Fix

Change "every 3 seconds" to "every 15 seconds" so the readme matches the code and the other two docs. Documentation-only.

## Verification

`grep` across `readme.md`, `docs/command-reference.md` and `docs/settings.md` now shows all three say 15 seconds, matching `ExpressChainExtensions.cs:33` (15000 ms).