### PR TITLE
Fix the ungrammatical subcommand group message

### DIFF
--- a/src/neoxp/Commands/CandidateCommand.cs
+++ b/src/neoxp/Commands/CandidateCommand.cs
@@ -23,7 +23,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/src/neoxp/Commands/CheckpointCommand.cs
+++ b/src/neoxp/Commands/CheckpointCommand.cs
@@ -18,7 +18,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/src/neoxp/Commands/ContractCommand.cs
+++ b/src/neoxp/Commands/ContractCommand.cs
@@ -28,7 +28,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/src/neoxp/Commands/OracleCommand.cs
+++ b/src/neoxp/Commands/OracleCommand.cs
@@ -18,7 +18,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/src/neoxp/Commands/PolicyCommand.cs
+++ b/src/neoxp/Commands/PolicyCommand.cs
@@ -18,7 +18,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/src/neoxp/Commands/ShowCommand.cs
+++ b/src/neoxp/Commands/ShowCommand.cs
@@ -18,7 +18,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/src/neoxp/Commands/WalletCommand.cs
+++ b/src/neoxp/Commands/WalletCommand.cs
@@ -18,7 +18,7 @@ namespace NeoExpress.Commands
     {
         internal int OnExecute(CommandLineApplication app, IConsole console)
         {
-            console.WriteLine("You must specify at a subcommand.");
+            console.WriteLine("You must specify a subcommand.");
             app.ShowHelp(false);
             return 1;
         }

--- a/test/test.workflowvalidation/SubcommandGroupMessageTests.cs
+++ b/test/test.workflowvalidation/SubcommandGroupMessageTests.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SubcommandGroupMessageTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
+using NeoExpress.Commands;
+using System;
+using System.IO;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class SubcommandGroupMessageTests
+{
+    [Fact]
+    public void Subcommand_group_prints_a_grammatical_message_when_no_subcommand_is_given()
+    {
+        var console = new CapturingConsole();
+        using var app = new CommandLineApplication<ShowCommand>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = new ShowCommand().OnExecute(app, console);
+
+        result.Should().Be(1);
+        console.Text.Should().Contain("You must specify a subcommand.");
+        console.Text.Should().NotContain("at a subcommand");
+    }
+
+    sealed class CapturingConsole : IConsole
+    {
+        readonly StringWriter writer = new();
+
+        public string Text => writer.ToString();
+
+        public TextWriter Out => writer;
+        public TextWriter Error => writer;
+        public TextReader In => TextReader.Null;
+        public bool IsInputRedirected => true;
+        public bool IsOutputRedirected => true;
+        public bool IsErrorRedirected => true;
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+
+        public void ResetColor() { }
+
+        public event ConsoleCancelEventHandler? CancelKeyPress { add { } remove { } }
+    }
+}


### PR DESCRIPTION
## Problem

Every neoxp parent subcommand group prints **"You must specify at a subcommand."** when invoked with no subcommand (e.g. `neoxp show`, `neoxp contract`, `neoxp wallet`). The stray "at" is ungrammatical.

The three program entry points already print the correct form, **"You must specify a subcommand."** ([neoxp/Program.cs:76](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Program.cs#L76), trace, worknet), so this is an internal inconsistency the user hits routinely.

## Fix

Remove the extra word in the seven subcommand groups (`ShowCommand`, `ContractCommand`, `PolicyCommand`, `CandidateCommand`, `WalletCommand`, `CheckpointCommand`, `OracleCommand`) so they match the entry-point wording. String-only change.

## Tests

`SubcommandGroupMessageTests` invokes `ShowCommand.OnExecute` with a capturing console and asserts the output contains the corrected sentence and not the "at a subcommand" form. Restoring the stray "at" makes it fail. `grep "at a subcommand" src/` now returns nothing. Release build is clean and `dotnet format --verify-no-changes` reports no changes.