### PR TITLE
Document the contract download and wallet create batch subcommands

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -878,6 +878,7 @@ The commands supported in a batch file include:
 
 * `checkpoint create`
 * `contract deploy`
+* `contract download`
 * `contract invoke`
 * `contract run`
 * `fastfwd`
@@ -889,6 +890,7 @@ The commands supported in a batch file include:
 * `policy unblock`
 * `transfer`
 * `transfernft`
+* `wallet create`
 
 ## neoxp execute
 


### PR DESCRIPTION
## Problem

The `neoxp batch` reference lists the commands supported in a batch file ([command-reference.md:877](https://github.com/neo-project/neo-express/blob/master/docs/command-reference.md#L877)) but omits two that are registered batch subcommands and dispatched by the executor:

- `contract download` — registered at [BatchCommand.BatchFileCommands.cs:41](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs#L41), dispatched at [BatchCommand.cs:133](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L133).
- `wallet create` — registered at [BatchCommand.BatchFileCommands.cs:321](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs#L321), dispatched at [BatchCommand.cs:283](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L283).

A developer reading the reference would conclude these can't be used in a batch file, which is false.

## Fix

Add the two bullets so the documented list matches the registered-and-dispatched subcommands. Documentation-only.

## Verification

Enumerating the dispatched leaf subcommands (`grep -oE 'BatchFileCommands\.[A-Za-z.]+>' src/neoxp/Commands/BatchCommand.cs`) and comparing against the bullet list shows `contract download` and `wallet create` are now documented. (`contract update` is dispatched but not yet reachable on master — that registration and its doc line are handled in #680.)