### PR TITLE
Document the create command private-key and batch-filename options

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -63,6 +63,9 @@ Arguments:
   -a|--address-version <ADDRESS_VERSION>  Version to use for addresses in this blockchain instance
                                           Default: 53
   -f|--force                              Overwrite existing data
+  --private-key <PRIVATE_KEY>             Private key for default dev account (Format: HEX, Base64, or WIF)
+                                          Default: Random
+  --batch-filename <BATCH_FILENAME>       Use a batch file to initialize the blockchain after creation.
 ```
 
 The `create` command is used to create a new Neo-Express blockchain network for local development


### PR DESCRIPTION
## Problem

The `neoxp create` usage block in the command reference ([command-reference.md:51](https://github.com/neo-project/neo-express/blob/master/docs/command-reference.md#L51)) reproduces the command help but lists only `-o/--output`, `-c/--count`, `-a/--address-version`, and `-f/--force`. The command actually defines two more user-facing options:

- `--private-key` — "Private key for default dev account (Format: HEX, Base64, or WIF)" ([CreateCommand.cs:45](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/CreateCommand.cs#L45))
- `--batch-filename` — "Use a batch file to initialize the blockchain after creation." ([CreateCommand.cs:48](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/CreateCommand.cs#L48))

Both appear in real `neoxp create --help` output, so the reproduced help in the docs is stale and hides two capabilities (a deterministic dev key, and initialize-on-create from a batch file).

## Fix

Add the two options to the create usage block with their code descriptions. Documentation-only.

## Verification

Each `[Option]` long name on `CreateCommand` (`--output`, `--count`, `--address-version`, `--force`, `--private-key`, `--batch-filename`) now appears in the usage block, matching `neoxp create --help`.