### PR TITLE
Correct the neotrace transaction argument help text

### DIFF
--- a/src/trace/Commands/TransactionCommand.cs
+++ b/src/trace/Commands/TransactionCommand.cs
@@ -18,7 +18,7 @@ namespace NeoTrace.Commands
     [Command("transaction", "tx", Description = "Trace the specified transaction")]
     class TransactionCommand
     {
-        [Argument(0, Description = "Block index or hash")]
+        [Argument(0, Description = "Transaction hash")]
         [Required]
         internal string TransactionHash { get; } = string.Empty;
 


### PR DESCRIPTION
## Problem

The `neotrace transaction` (alias `tx`) command's positional argument is a **transaction hash**, but its help description reads "Block index or hash" ([TransactionCommand.cs:21](https://github.com/neo-project/neo-express/blob/master/src/trace/Commands/TransactionCommand.cs#L21)) — copied from [BlockCommand.cs:22](https://github.com/neo-project/neo-express/blob/master/src/trace/Commands/BlockCommand.cs#L22) where it is correct. The argument is parsed strictly as a `UInt256` and rejected with `Invalid transaction hash` otherwise ([:36-38](https://github.com/neo-project/neo-express/blob/master/src/trace/Commands/TransactionCommand.cs#L36)), so `neotrace tx --help` tells the user to pass the wrong thing.

## Fix

Describe the argument as "Transaction hash", matching the property name and the error text.

## Verification

`dotnet run --project src/trace -- tx --help` now shows the argument line as `TransactionHash   Transaction hash` (previously "Block index or hash"). The trace project has no test harness, so this is a help before/after. `dotnet format --verify-no-changes` is clean.