### PR TITLE
Skip malformed Transfer notifications in ToolkitRpcServer.GetNep17Balances

### DIFF
--- a/src/bctklib/plugins/ToolkitRpcServer.cs
+++ b/src/bctklib/plugins/ToolkitRpcServer.cs
@@ -184,6 +184,11 @@ namespace Neo.BlockchainToolkit.Plugins
 
                 foreach (var (blockIndex, _, _, notification) in notifications)
                 {
+                    // a well-formed NEP-17 Transfer carries from/to/amount; skip malformed
+                    // events so a buggy or malicious contract cannot abort the whole query
+                    if (notification.State.Count < 3)
+                        continue;
+
                     // iterate backwards thru the notifications looking for all the Transfer events from a contract
                     // in assets where a Transfer event hasn't already been recorded
                     if (!updateIndexes.ContainsKey(notification.ScriptHash))

--- a/test/test.bctklib/ToolkitRpcServerNep17Tests.cs
+++ b/test/test.bctklib/ToolkitRpcServerNep17Tests.cs
@@ -1,0 +1,101 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ToolkitRpcServerNep17Tests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Plugins;
+using Neo.Cryptography.ECC;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+
+namespace test.bctklib
+{
+    public class ToolkitRpcServerNep17Tests : IDisposable
+    {
+        static readonly ProtocolSettings Settings = new()
+        {
+            Network = 0x334F454Eu,
+            AddressVersion = ProtocolSettings.Default.AddressVersion,
+            StandbyCommittee =
+            [
+                ECPoint.Parse("03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c", ECCurve.Secp256r1),
+            ],
+            ValidatorsCount = 1,
+            SeedList = [],
+            MillisecondsPerBlock = ProtocolSettings.Default.MillisecondsPerBlock,
+            MaxTransactionsPerBlock = ProtocolSettings.Default.MaxTransactionsPerBlock,
+            MemoryPoolMaxTransactions = ProtocolSettings.Default.MemoryPoolMaxTransactions,
+            MaxTraceableBlocks = ProtocolSettings.Default.MaxTraceableBlocks,
+            InitialGasDistribution = ProtocolSettings.Default.InitialGasDistribution,
+            Hardforks = ProtocolSettings.Default.Hardforks,
+        };
+
+        readonly MemoryStore store = new();
+
+        public ToolkitRpcServerNep17Tests()
+        {
+            var block = NeoSystem.CreateGenesisBlock(Settings);
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            Persist(snapshot, block, TriggerType.OnPersist, ApplicationEngine.System_Contract_NativeOnPersist);
+            Persist(snapshot, block, TriggerType.PostPersist, ApplicationEngine.System_Contract_NativePostPersist);
+            snapshot.Commit();
+
+            static void Persist(StoreCache snapshot, Neo.Network.P2P.Payloads.Block block, TriggerType trigger, uint syscall)
+            {
+                using var engine = ApplicationEngine.Create(trigger, null, snapshot, block, Settings, 0L);
+                using var sb = new ScriptBuilder();
+                sb.EmitSysCall(syscall);
+                engine.LoadScript(sb.ToArray());
+                if (engine.Execute() != VMState.HALT)
+                    throw new InvalidOperationException("genesis persist failed", engine.FaultException);
+            }
+        }
+
+        public void Dispose() => store.Dispose();
+
+        // A contract-emitted Transfer event with fewer than the from/to/amount items must not
+        // abort the whole getnep17balances query by throwing on the State indexer.
+        [Fact]
+        public void GetNep17Balances_skips_a_malformed_transfer_notification()
+        {
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            var account = Contract.GetBFTAddress(Settings.StandbyValidators);
+
+            var malformed = new NotificationRecord(
+                NativeContract.NEO.Hash, "Transfer", new NeoArray(), Neo.Network.P2P.Payloads.InventoryType.TX, UInt256.Zero);
+            var provider = new StubNotificationsProvider(new NotificationInfo(1, 0, 0, malformed));
+
+            var act = () => ToolkitRpcServer.GetNep17Balances(snapshot, provider, account, Settings).ToList();
+
+            var balances = act.Should().NotThrow().Subject;
+            balances.Select(b => b.AssetHash).Should().Contain(NativeContract.NEO.Hash);
+        }
+
+        sealed class StubNotificationsProvider : INotificationsProvider
+        {
+            readonly NotificationInfo[] notifications;
+
+            public StubNotificationsProvider(params NotificationInfo[] notifications) => this.notifications = notifications;
+
+            public IEnumerable<NotificationInfo> GetNotifications(
+                SeekDirection direction = SeekDirection.Forward,
+                IReadOnlySet<UInt160>? contracts = null,
+                IReadOnlySet<string>? eventNames = null) => notifications;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ToolkitRpcServer.GetNep17Balances` (behind worknet's `getnep17balances` RPC) indexes `notification.State[0]` and `notification.State[1]` ([ToolkitRpcServer.cs:191](https://github.com/neo-project/neo-express/blob/master/src/bctklib/plugins/ToolkitRpcServer.cs#L191)) **without checking `notification.State.Count`**.

These notifications come from contract-emitted `Transfer` events, whose argument count is fully controlled by the (possibly buggy or malicious) contract. A `Transfer` raised with fewer than two state items makes the `Neo.VM` array indexer throw, aborting the entire RPC call instead of skipping the bad event.

Every sibling path already guards this: `GetNep11Balances` checks `State.Count < 4`, `GetTransfers` checks the count, and neoxp's `TransferNotificationRecord.Create` starts with `State.Count < 3`. `GetNep17Balances` was the lone outlier.

## Fix

Skip a notification whose `State.Count < 3` (a well-formed NEP-17 Transfer carries from/to/amount), before indexing — matching the sibling guards.

## Tests

`ToolkitRpcServerNep17Tests` initializes a genesis ledger (so the genesis account holds the native NEP-17 NEO/GAS), then drives `GetNep17Balances` with a stub notifications provider returning a `Transfer` whose state array is empty. With the fix the query completes and returns the balances; against the previous code it throws `ArgumentOutOfRangeException`. Full `test.bctklib` suite (291) passes; `dotnet format --verify-no-changes` is clean.