### PR TITLE
Write the generated contract interface once and surface a persistent write failure

### DIFF
--- a/src/build-tasks/NeoContractInterface.cs
+++ b/src/build-tasks/NeoContractInterface.cs
@@ -61,7 +61,7 @@ namespace Neo.BuildTasks
 
         public string ContractNameOverride { get; set; } = "";
 
-        static void FileOperationWithRetry(Action operation)
+        internal static void FileOperationWithRetry(Action operation)
         {
             const int ProcessCannotAccessFileHR = unchecked((int)0x80070020);
 
@@ -70,8 +70,9 @@ namespace Neo.BuildTasks
                 try
                 {
                     operation();
+                    return;
                 }
-                catch (IOException ex) when (ex.HResult == ProcessCannotAccessFileHR && retriesLeft > 0)
+                catch (IOException ex) when (ex.HResult == ProcessCannotAccessFileHR && retriesLeft > 1)
                 {
                     System.Threading.Tasks.Task.Delay(100).Wait();
                     continue;

--- a/test/test-build-tasks/TestNeoContractInterface.cs
+++ b/test/test-build-tasks/TestNeoContractInterface.cs
@@ -1,0 +1,62 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestNeoContractInterface.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BuildTasks;
+using System;
+using System.IO;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestNeoContractInterface
+    {
+        [Fact]
+        public void successful_operation_runs_once()
+        {
+            var count = 0;
+
+            NeoContractInterface.FileOperationWithRetry(() => count++);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void operation_is_retried_after_a_sharing_violation()
+        {
+            const int ProcessCannotAccessFileHR = unchecked((int)0x80070020);
+            var count = 0;
+
+            NeoContractInterface.FileOperationWithRetry(() =>
+            {
+                count++;
+                if (count == 1)
+                    throw new IOException("file in use") { HResult = ProcessCannotAccessFileHR };
+            });
+
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void persistent_sharing_violation_surfaces_after_retries_are_exhausted()
+        {
+            const int ProcessCannotAccessFileHR = unchecked((int)0x80070020);
+            var count = 0;
+
+            void Operation()
+            {
+                count++;
+                throw new IOException("file in use") { HResult = ProcessCannotAccessFileHR };
+            }
+
+            Assert.Throws<IOException>(() => NeoContractInterface.FileOperationWithRetry(Operation));
+            Assert.Equal(6, count);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`NeoContractInterface.FileOperationWithRetry` ([NeoContractInterface.cs:64](https://github.com/neo-project/neo-express/blob/master/src/build-tasks/NeoContractInterface.cs#L64)) has two retry-loop defects:

```csharp
for (int retriesLeft = 6; retriesLeft > 0; retriesLeft--)
{
    try { operation(); }
    catch (IOException ex) when (… && retriesLeft > 0) { Task.Delay(100).Wait(); continue; }
}
```

1. **No break on success** — the only flow control is the `continue` in the catch, so a *successful* `operation()` falls through and runs again: the output file is written **six times** per generation.
2. **Silent failure on exhaustion** — the catch filter `retriesLeft > 0` is always true (the loop guarantees it), so when the sharing violation never clears, the loop runs all six attempts, then exits **silently** — the `IOException` is dropped, leaving no output file and no error.

## Fix

- `return;` after a successful `operation()` so the loop is only re-entered for the sharing-violation `IOException`.
- Retry only while a further attempt remains (`retriesLeft > 1`), so the **last** failure propagates instead of being swallowed.

## Tests

`TestNeoContractInterface` covers: a successful operation runs exactly once; an operation that throws one sharing violation is retried exactly twice; and an operation that always throws the sharing violation **surfaces the `IOException`** after exactly six attempts. Reverting either change fails the corresponding test. Builds for `net10.0` and `netstandard2.0`; full `test-build-tasks` suite (29) passes; format clean.