### PR TITLE
Validate Transfer state count before indexing in ToolkitRpcServer.GetTransfers

### DIFF
--- a/src/bctklib/plugins/ToolkitRpcServer.cs
+++ b/src/bctklib/plugins/ToolkitRpcServer.cs
@@ -236,11 +236,14 @@ namespace Neo.BlockchainToolkit.Plugins
                 var header = NativeContract.Ledger.GetHeader(snapshot, blockIndex);
                 if (startTime > header.Timestamp || header.Timestamp > endTime)
                     continue;
-                if (notification.State[2] is not ByteString and not Integer)
-                    continue;
+                // a well-formed Transfer carries from/to/amount (and a token id for NEP-11);
+                // validate the item count before indexing State so a malformed event
+                // cannot throw and abort the whole enumeration
                 if (standard == NEP_17 && notification.State.Count != 3)
                     continue;
                 if (standard == NEP_11 && notification.State.Count != 4)
+                    continue;
+                if (notification.State[2] is not ByteString and not Integer)
                     continue;
 
                 var asset = notification.ScriptHash;

--- a/test/test.bctklib/ToolkitRpcServerTransfersTests.cs
+++ b/test/test.bctklib/ToolkitRpcServerTransfersTests.cs
@@ -1,0 +1,101 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ToolkitRpcServerTransfersTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Plugins;
+using Neo.Cryptography.ECC;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+
+namespace test.bctklib
+{
+    public class ToolkitRpcServerTransfersTests : IDisposable
+    {
+        static readonly ProtocolSettings Settings = new()
+        {
+            Network = 0x334F454Eu,
+            AddressVersion = ProtocolSettings.Default.AddressVersion,
+            StandbyCommittee =
+            [
+                ECPoint.Parse("03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c", ECCurve.Secp256r1),
+            ],
+            ValidatorsCount = 1,
+            SeedList = [],
+            MillisecondsPerBlock = ProtocolSettings.Default.MillisecondsPerBlock,
+            MaxTransactionsPerBlock = ProtocolSettings.Default.MaxTransactionsPerBlock,
+            MemoryPoolMaxTransactions = ProtocolSettings.Default.MemoryPoolMaxTransactions,
+            MaxTraceableBlocks = ProtocolSettings.Default.MaxTraceableBlocks,
+            InitialGasDistribution = ProtocolSettings.Default.InitialGasDistribution,
+            Hardforks = ProtocolSettings.Default.Hardforks,
+        };
+
+        readonly MemoryStore store = new();
+
+        public ToolkitRpcServerTransfersTests()
+        {
+            var block = NeoSystem.CreateGenesisBlock(Settings);
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            Persist(snapshot, block, TriggerType.OnPersist, ApplicationEngine.System_Contract_NativeOnPersist);
+            Persist(snapshot, block, TriggerType.PostPersist, ApplicationEngine.System_Contract_NativePostPersist);
+            snapshot.Commit();
+
+            static void Persist(StoreCache snapshot, Neo.Network.P2P.Payloads.Block block, TriggerType trigger, uint syscall)
+            {
+                using var engine = ApplicationEngine.Create(trigger, null, snapshot, block, Settings, 0L);
+                using var sb = new ScriptBuilder();
+                sb.EmitSysCall(syscall);
+                engine.LoadScript(sb.ToArray());
+                if (engine.Execute() != VMState.HALT)
+                    throw new InvalidOperationException("genesis persist failed", engine.FaultException);
+            }
+        }
+
+        public void Dispose() => store.Dispose();
+
+        // A contract-emitted Transfer event with fewer than from/to/amount items must not
+        // abort getnep17transfers by throwing on the State[2] indexer.
+        [Fact]
+        public void GetNep17Transfers_skips_a_malformed_transfer_notification()
+        {
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            var malformed = new NotificationRecord(
+                NativeContract.NEO.Hash, "Transfer", new NeoArray(), Neo.Network.P2P.Payloads.InventoryType.TX, UInt256.Zero);
+            var provider = new StubNotificationsProvider(new NotificationInfo(0, 0, 0, malformed));
+
+            var act = () => ToolkitRpcServer
+                .GetNep17Transfers(snapshot, provider, UInt160.Zero, 0, ulong.MaxValue)
+                .ToList();
+
+            act.Should().NotThrow().Subject.Should().BeEmpty();
+        }
+
+        sealed class StubNotificationsProvider : INotificationsProvider
+        {
+            readonly NotificationInfo[] notifications;
+
+            public StubNotificationsProvider(params NotificationInfo[] notifications) => this.notifications = notifications;
+
+            public IEnumerable<NotificationInfo> GetNotifications(
+                SeekDirection direction = SeekDirection.Forward,
+                IReadOnlySet<UInt160>? contracts = null,
+                IReadOnlySet<string>? eventNames = null) => notifications;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ToolkitRpcServer.GetTransfers` (behind worknet's `getnep17transfers` / `getnep11transfers` RPC) reads `notification.State[2]` ([ToolkitRpcServer.cs:239](https://github.com/neo-project/neo-express/blob/master/src/bctklib/plugins/ToolkitRpcServer.cs#L239)) **before** the `State.Count` checks that follow on lines 241/243:

```csharp
if (notification.State[2] is not ByteString and not Integer)   // 239 — unsafe
    continue;
if (standard == NEP_17 && notification.State.Count != 3)       // 241
    continue;
if (standard == NEP_11 && notification.State.Count != 4)       // 243
    continue;
```

`State` is a `Neo.VM.Types.Array` whose indexer throws on out-of-range access. A contract-emitted `Transfer` event with fewer than the from/to/amount items makes line 239 throw `ArgumentOutOfRangeException`, aborting the entire `yield`-based enumeration. This is the same class of bug fixed for `GetNep17Balances` in #689; `GetTransfers` was missed.

## Fix

Move the `State.Count` checks ahead of the `State[2]` dereference, so a malformed event is skipped before any indexing (after the checks pass, `State` has exactly 3 or 4 items, making `State[0..3]` safe).

## Tests

`ToolkitRpcServerTransfersTests` initializes a genesis ledger and drives `GetNep17Transfers` with a stub notifications provider returning a `Transfer` whose state array is empty. With the fix the enumeration completes and skips the record; against the previous order it throws `ArgumentOutOfRangeException`. Full `test.bctklib` suite (291) passes; format clean.