### PR TITLE
Surface the real RPC error when getblockhash fails in GetBranchInfoAsync

### DIFF
--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -143,14 +143,16 @@ namespace Neo.BlockchainToolkit.Persistence
             }
         }
 
+        // Awaits the block hash directly so a faulted getblockhash propagates its real
+        // exception. The previous ContinueWith(OnlyOnRanToCompletion) cancelled the
+        // continuation on fault, surfacing a generic TaskCanceledException instead.
+        internal static async Task<UInt256> ParseBlockHashAsync(RpcClient rpcClient, uint index)
+            => UInt256.Parse(await rpcClient.GetBlockHashAsync(index).ConfigureAwait(false));
+
         public static async Task<BranchInfo> GetBranchInfoAsync(RpcClient rpcClient, uint index)
         {
             var versionTask = rpcClient.GetVersionAsync();
-            var blockHashTask = rpcClient.GetBlockHashAsync(index)
-                .ContinueWith(task => UInt256.Parse(task.Result),
-                              cancellationToken: default,
-                              TaskContinuationOptions.OnlyOnRanToCompletion,
-                              TaskScheduler.Default);
+            var blockHashTask = ParseBlockHashAsync(rpcClient, index);
             var stateRoot = await rpcClient.GetStateRootAsync(index).ConfigureAwait(false);
             var contractsTask = GetContractsAsync(rpcClient, stateRoot.RootHash);
 

--- a/test/test.bctklib/StateServiceStoreBlockHashTests.cs
+++ b/test/test.bctklib/StateServiceStoreBlockHashTests.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StateServiceStoreBlockHashTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.Persistence;
+using Neo.Json;
+using Neo.Network.RPC;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class StateServiceStoreBlockHashTests
+    {
+        // The block hash retrieval used by GetBranchInfoAsync must surface the real RPC
+        // error rather than masking it as a TaskCanceledException.
+        [Fact]
+        public async Task ParseBlockHashAsync_surfaces_the_real_rpc_error()
+        {
+            var client = new FaultingRpcClient(new RpcException(-100, "block index out of range"));
+
+            await FluentActions
+                .Awaiting(() => StateServiceStore.ParseBlockHashAsync(client, 12345u))
+                .Should().ThrowAsync<RpcException>()
+                .WithMessage("*block index out of range*");
+        }
+
+        sealed class FaultingRpcClient : RpcClient
+        {
+            readonly RpcException exception;
+
+            public FaultingRpcClient(RpcException exception) : base(null!) => this.exception = exception;
+
+            public override Task<JToken> RpcSendAsync(string method, params JToken[] paraArgs)
+                => Task.FromException<JToken>(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`StateServiceStore.GetBranchInfoAsync` built the block-hash task with ([StateServiceStore.cs:149](https://github.com/neo-project/neo-express/blob/master/src/bctklib/persistence/StateServiceStore.cs#L149)):

```csharp
var blockHashTask = rpcClient.GetBlockHashAsync(index)
    .ContinueWith(task => UInt256.Parse(task.Result),
                  cancellationToken: default,
                  TaskContinuationOptions.OnlyOnRanToCompletion,
                  TaskScheduler.Default);
```

With `OnlyOnRanToCompletion`, if `GetBlockHashAsync` **faults** (an out-of-range block index, or any transient `RpcException`), the continuation is **cancelled** rather than faulted. The later `await Task.WhenAll(...)` / `await blockHashTask` then throws a generic `TaskCanceledException` ("A task was canceled."), so the real RPC error message is lost — and the faulted antecedent's exception is never observed. Callers include `worknet create` and `neotrace` with a user-supplied index.

## Fix

Await the block hash directly via a small `ParseBlockHashAsync` helper, so a faulted `getblockhash` propagates its original exception. The task is still started before the `WhenAll`, preserving parallelism.

## Tests

`StateServiceStoreBlockHashTests` calls `ParseBlockHashAsync` with an `RpcClient` whose `RpcSendAsync` returns a faulted task carrying an `RpcException`, and asserts that `RpcException` (with its message) propagates. Reverting the helper to the old `ContinueWith(OnlyOnRanToCompletion)` pattern makes the test observe `TaskCanceledException` instead. Full `test.bctklib` suite (291) passes; format clean.