### PR TITLE
Fix the version-keyed well-known contracts cache key

### DIFF
--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -343,6 +343,7 @@
     "watch": "concurrently -r npm:watch-*",
     "watch-ext": "webpack --config src/extension/webpack.config.js --mode development --watch --stats-error-details",
     "watch-panel": "webpack --config src/panel/webpack.config.js --mode development --watch --stats-error-details",
+    "test:cachekey": "node --test -r ts-node/register src/extension/util/wellKnownContractsCacheKey.test.ts",
     "test:quickstart": "node --test -r ts-node/register src/panel/components/views/quickStartActions.test.ts",
     "test:server-list": "node --test -r ts-node/register src/extension/fileDetectors/serverListConfig.test.ts"
   },

--- a/extentions/neo3-visual-tracker/src/extension/autoComplete.ts
+++ b/extentions/neo3-visual-tracker/src/extension/autoComplete.ts
@@ -13,6 +13,7 @@ import NeoExpress from "./neoExpress/neoExpress";
 import NeoExpressDetector from "./fileDetectors/neoExpressDetector";
 import NeoExpressIo from "./neoExpress/neoExpressIo";
 import WalletDetector from "./fileDetectors/walletDetector";
+import wellKnownContractsCacheKey from "./util/wellKnownContractsCacheKey";
 
 const LOG_PREFIX = "AutoComplete";
 
@@ -92,8 +93,7 @@ export default class AutoComplete {
       if (versionResult.isError) {
         Log.error(LOG_PREFIX, "Could not determine neo-express version");
       } else {
-        const version = versionResult.message.trim().substring(256);
-        cacheKey = `wellKnownContracts_${version}`;
+        cacheKey = wellKnownContractsCacheKey(versionResult.message);
         wellKnownContracts = this.context.globalState.get<
           typeof wellKnownContracts
         >(cacheKey, wellKnownContracts);

--- a/extentions/neo3-visual-tracker/src/extension/util/wellKnownContractsCacheKey.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/wellKnownContractsCacheKey.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import wellKnownContractsCacheKey from "./wellKnownContractsCacheKey";
+
+test("wellKnownContractsCacheKey builds a version-specific key", () => {
+  assert.equal(wellKnownContractsCacheKey("3.7.0"), "wellKnownContracts_3.7.0");
+});
+
+test("wellKnownContractsCacheKey trims surrounding whitespace", () => {
+  assert.equal(wellKnownContractsCacheKey("  3.7.0\n"), "wellKnownContracts_3.7.0");
+});
+
+test("wellKnownContractsCacheKey distinguishes different versions", () => {
+  // Under the previous substring(256) bug both collapsed to the constant
+  // "wellKnownContracts_", so the cache was never version-specific.
+  assert.notEqual(
+    wellKnownContractsCacheKey("3.7.0"),
+    wellKnownContractsCacheKey("3.8.0")
+  );
+});
+
+test("wellKnownContractsCacheKey caps the version at 256 characters", () => {
+  const key = wellKnownContractsCacheKey("v".repeat(300));
+  assert.equal(key, `wellKnownContracts_${"v".repeat(256)}`);
+});

--- a/extentions/neo3-visual-tracker/src/extension/util/wellKnownContractsCacheKey.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/wellKnownContractsCacheKey.ts
@@ -1,0 +1,7 @@
+// Builds the globalState cache key used to invalidate the cached well-known
+// contract manifests across neo-express versions. The version string is capped
+// at 256 characters (substring(0, 256)) so an unexpectedly long version output
+// cannot produce an unbounded key.
+export default function wellKnownContractsCacheKey(versionOutput: string): string {
+  return `wellKnownContracts_${versionOutput.trim().substring(0, 256)}`;
+}


### PR DESCRIPTION
## Problem

In `AutoComplete`, the cache key that invalidates the cached well-known contract manifests across neo-express upgrades is derived as ([autoComplete.ts:95](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/autoComplete.ts#L95)):

```ts
const version = versionResult.message.trim().substring(256);
cacheKey = `wellKnownContracts_${version}`;
```

`neoxp -v` prints a short version string (e.g. `3.7.0`), far under 256 chars. `String.prototype.substring(256)` returns the substring **starting at** index 256 — the empty string for any real version output. So `version` is always `""` and `cacheKey` is always the constant `wellKnownContracts_`.

The cache is therefore never version-specific: after the bundled neoxp binary is upgraded (which happens when the extension updates), the extension keeps serving the **previous** version's genesis/well-known contract manifests for autocomplete instead of regenerating them.

## Fix

Cap the version at 256 chars with `substring(0, 256)` (the obviously-intended call, given the variable name and its use as a key suffix), extracted into a small pure helper so it is unit-testable without importing `vscode`.

## Tests

`wellKnownContractsCacheKey.test.ts` (node:test, run via a new `test:cachekey` script) asserts the key is version-specific, trims whitespace, distinguishes two versions, and caps at 256 chars. Under the old `substring(256)` all four fail (every version collapses to `wellKnownContracts_`). `npm run typecheck` passes and lint reports no new problems. The test also runs under the aggregate `npm test` added in #676.