### PR TITLE
Don't disable the populated-blocks query on a messageless RPC error

### DIFF
--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -343,6 +343,7 @@
     "watch": "concurrently -r npm:watch-*",
     "watch-ext": "webpack --config src/extension/webpack.config.js --mode development --watch --stats-error-details",
     "watch-panel": "webpack --config src/panel/webpack.config.js --mode development --watch --stats-error-details",
+    "test:method-not-found": "node --test -r ts-node/register src/extension/blockchainMonitor/isMethodNotFoundError.test.ts",
     "test:quickstart": "node --test -r ts-node/register src/panel/components/views/quickStartActions.test.ts",
     "test:server-list": "node --test -r ts-node/register src/extension/fileDetectors/serverListConfig.test.ts"
   },

--- a/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/blockchainMonitorInternal.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/blockchainMonitorInternal.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import AddressInfo from "../../shared/addressInfo";
 import ApplicationLog from "../../shared/applicationLog";
 import BlockchainState from "./blockchainState";
+import isMethodNotFoundError from "./isMethodNotFoundError";
 import Log from "../util/log";
 
 const APP_LOG_CACHE_SIZE = 1024;
@@ -305,8 +306,8 @@ export default class BlockchainMonitorInternal {
             : 0;
           mayBeMoreResults = result.blocks.length >= count;
         } while (mayBeMoreResults);
-      } catch (e : any) {
-        if (e.message?.indexOf("Method not found") !== -1) {
+      } catch (e) {
+        if (isMethodNotFoundError(e)) {
           this.tryGetPopulatedBlocks = false;
         } else {
           throw e;

--- a/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/isMethodNotFoundError.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/isMethodNotFoundError.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import isMethodNotFoundError from "./isMethodNotFoundError";
+
+test("detects a method-not-found error message", () => {
+  assert.equal(isMethodNotFoundError(new Error("Method not found")), true);
+  assert.equal(
+    isMethodNotFoundError({ message: "RPC error: Method not found (-32601)" }),
+    true
+  );
+});
+
+test("treats an error with an unrelated message as transient", () => {
+  assert.equal(isMethodNotFoundError(new Error("socket hang up")), false);
+});
+
+test("treats an error with no usable message as transient", () => {
+  // Regression: the previous `e.message?.indexOf(...) !== -1` evaluated to
+  // `undefined !== -1` (true) when message was absent, wrongly classifying a
+  // transient/messageless error as method-not-found.
+  assert.equal(isMethodNotFoundError({}), false);
+  assert.equal(isMethodNotFoundError(undefined), false);
+  assert.equal(isMethodNotFoundError(null), false);
+  assert.equal(isMethodNotFoundError("boom"), false);
+});

--- a/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/isMethodNotFoundError.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/isMethodNotFoundError.ts
@@ -1,0 +1,8 @@
+// Returns true only when the error actually reports an unsupported RPC method.
+// A missing/non-string message must NOT be treated as "method not found": doing
+// so would permanently disable the populated-blocks query and swallow a transient
+// error instead of letting the refresh loop retry it.
+export default function isMethodNotFoundError(e: unknown): boolean {
+  const message = (e as { message?: unknown } | null | undefined)?.message;
+  return typeof message === "string" && message.indexOf("Method not found") !== -1;
+}


### PR DESCRIPTION
## Problem

In `BlockchainMonitorInternal.updateState`, the catch for the `expressgetpopulatedblocks` query distinguishes *method not supported by this node* (set `tryGetPopulatedBlocks = false`, permanent) from a *transient* error (rethrow so the refresh loop retries) with ([blockchainMonitorInternal.ts:309](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/blockchainMonitorInternal.ts#L309)):

```ts
if (e.message?.indexOf("Method not found") !== -1) {
  this.tryGetPopulatedBlocks = false;
} else {
  throw e;
}
```

When the error has **no message** (a thrown non-Error, a network/timeout failure with `undefined` message), `e.message?.indexOf(...)` short-circuits to `undefined`, and `undefined !== -1` is `true`. So a transient, messageless error is misclassified as *method not found*: the populated-blocks filter is **permanently disabled** for the monitor's lifetime (`tryGetPopulatedBlocks` is never reset) and the underlying error is **swallowed** (never rethrown, never retried).

## Fix

Classify the error with a small tested helper that returns `true` only when the message is actually a string containing `"Method not found"`; a missing/non-string message is treated as transient and rethrown.

## Tests

`isMethodNotFoundError.test.ts` (node:test, run via `test:method-not-found`) covers a real method-not-found message, an unrelated message, and the messageless cases (`{}`, `undefined`, `null`, a bare string). Replacing the helper with the old `e.message?.indexOf(...) !== -1` makes the messageless case fail. `npm run typecheck` passes and lint reports no new problems; also runs under the aggregate `npm test` from #676.