### PR TITLE
Honor the cancellation token while parsing an oracle response

### DIFF
--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -473,7 +473,7 @@ namespace NeoExpress
                 memory.Position = 0;
                 using var reader = new StreamReader(memory);
                 using var jsonReader = new JsonTextReader(reader);
-                return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+                return await JObject.LoadAsync(jsonReader, token).ConfigureAwait(false);
             }
             catch (JsonException ex)
             {


### PR DESCRIPTION
## Problem

`TransactionExecutor.LoadOracleResponseJsonAsync` receives a `CancellationToken` and threads it into the stream copy ([TransactionExecutor.cs:472](https://github.com/neo-project/neo-express/blob/master/src/neoxp/TransactionExecutor.cs#L472)):

```csharp
await stream.CopyToAsync(memory, 81920, token).ConfigureAwait(false);
…
return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);   // token omitted
```

but then calls `JObject.LoadAsync(jsonReader)` **without** the token. Newtonsoft's `JObject.LoadAsync(JsonReader, CancellationToken)` overload propagates the token into `reader.ReadAsync(cancellationToken)`, so as written the parse phase (after the in-memory copy) cannot be cancelled — the method only half-honors the token it receives.

## Fix

Pass the already-available `token` to the overload that honors it:

```csharp
return await JObject.LoadAsync(jsonReader, token).ConfigureAwait(false);
```

## Verification

The fix binds against the `JObject.LoadAsync(JsonReader, CancellationToken)` overload (compiles). The existing `TransactionExecutorOracleResponseTests` pass unchanged (no regression for the default-token path). A deterministic unit test of mid-parse cancellation isn't practical — an already-cancelled token would trip `CopyToAsync` first, before the parse — so this is verified by the token now being passed to the cancellation-honoring overload plus the no-regression run. Release build is clean and `dotnet format --verify-no-changes` reports no changes.