### PR TITLE
Report non-compliance and exit non-zero from contract validate

### DIFF
--- a/src/neoxp/Commands/ContractCommand.Validate.cs
+++ b/src/neoxp/Commands/ContractCommand.Validate.cs
@@ -29,6 +29,11 @@ internal partial class ContractCommand
                 ? ($"{scriptHash} is {standard} compliant.", 0)
                 : ($"{scriptHash} is NOT {standard} compliant.", 1);
 
+        internal static Task WriteMessageAsync(IConsole console, string message)
+            => string.IsNullOrWhiteSpace(message)
+                ? Task.CompletedTask
+                : console.Out.WriteLineAsync(message);
+
         [Command("nep11", Description = "Checks if contract is NEP-11 compliant")]
         public class Nep11Compliant
         {
@@ -58,7 +63,7 @@ internal partial class ContractCommand
                     var nep11 = await expressNode.IsNep11CompliantAsync(scriptHash).ConfigureAwait(false);
 
                     var (message, exitCode) = ComplianceResult(scriptHash, "NEP-11", nep11);
-                    await console.Out.WriteLineAsync(message);
+                    await WriteMessageAsync(console, message);
                     return exitCode;
                 }
                 catch (Exception ex)
@@ -98,7 +103,7 @@ internal partial class ContractCommand
                     var nep17 = await expressNode.IsNep17CompliantAsync(scriptHash).ConfigureAwait(false);
 
                     var (message, exitCode) = ComplianceResult(scriptHash, "NEP-17", nep17);
-                    await console.Out.WriteLineAsync(message);
+                    await WriteMessageAsync(console, message);
                     return exitCode;
                 }
                 catch (Exception ex)

--- a/src/neoxp/Commands/ContractCommand.Validate.cs
+++ b/src/neoxp/Commands/ContractCommand.Validate.cs
@@ -22,6 +22,13 @@ internal partial class ContractCommand
         typeof(Nep11Compliant))]
     internal class Validate
     {
+        // A validate command must report non-compliance and exit non-zero, so a
+        // script (e.g. CI) does not read an empty stdout with exit 0 as success.
+        internal static (string message, int exitCode) ComplianceResult(UInt160 scriptHash, string standard, bool compliant)
+            => compliant
+                ? ($"{scriptHash} is {standard} compliant.", 0)
+                : ($"{scriptHash} is NOT {standard} compliant.", 1);
+
         [Command("nep11", Description = "Checks if contract is NEP-11 compliant")]
         public class Nep11Compliant
         {
@@ -32,7 +39,7 @@ internal partial class ContractCommand
                 this.chainManagerFactory = chainManagerFactory;
             }
 
-            [Argument(0, Description = "Path to contract .nef file")]
+            [Argument(0, Description = "Contract script hash")]
             [Required]
             internal string ContractHash { get; init; } = string.Empty;
 
@@ -50,10 +57,9 @@ internal partial class ContractCommand
                     using var expressNode = chainManager.GetExpressNode();
                     var nep11 = await expressNode.IsNep11CompliantAsync(scriptHash).ConfigureAwait(false);
 
-                    if (nep11)
-                        await console.Out.WriteLineAsync($"{scriptHash} is NEP-11 compliant.");
-
-                    return 0;
+                    var (message, exitCode) = ComplianceResult(scriptHash, "NEP-11", nep11);
+                    await console.Out.WriteLineAsync(message);
+                    return exitCode;
                 }
                 catch (Exception ex)
                 {
@@ -73,7 +79,7 @@ internal partial class ContractCommand
                 this.chainManagerFactory = chainManagerFactory;
             }
 
-            [Argument(0, Description = "Path to contract .nef file")]
+            [Argument(0, Description = "Contract script hash")]
             [Required]
             internal string ContractHash { get; init; } = string.Empty;
 
@@ -91,10 +97,9 @@ internal partial class ContractCommand
                     using var expressNode = chainManager.GetExpressNode();
                     var nep17 = await expressNode.IsNep17CompliantAsync(scriptHash).ConfigureAwait(false);
 
-                    if (nep17)
-                        await console.Out.WriteLineAsync($"{scriptHash} is NEP-17 compliant.");
-
-                    return 0;
+                    var (message, exitCode) = ComplianceResult(scriptHash, "NEP-17", nep17);
+                    await console.Out.WriteLineAsync(message);
+                    return exitCode;
                 }
                 catch (Exception ex)
                 {

--- a/test/test.workflowvalidation/ContractValidateTests.cs
+++ b/test/test.workflowvalidation/ContractValidateTests.cs
@@ -9,8 +9,11 @@
 // modifications are permitted.
 
 using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
 using Neo;
 using NeoExpress.Commands;
+using System;
+using System.IO;
 using Xunit;
 
 namespace test.workflowvalidation;
@@ -35,5 +38,36 @@ public class ContractValidateTests
 
         message.Should().Be($"{Hash} is NOT NEP-11 compliant.");
         exitCode.Should().NotBe(0);
+    }
+
+    [Fact]
+    public async Task WriteMessageAsync_skips_empty_messages()
+    {
+        var console = new CapturingConsole();
+
+        await ContractCommand.Validate.WriteMessageAsync(console, string.Empty);
+        await ContractCommand.Validate.WriteMessageAsync(console, "   ");
+
+        console.Text.Should().BeEmpty();
+    }
+
+    sealed class CapturingConsole : IConsole
+    {
+        readonly StringWriter writer = new();
+
+        public string Text => writer.ToString();
+
+        public TextWriter Out => writer;
+        public TextWriter Error => writer;
+        public TextReader In => TextReader.Null;
+        public bool IsInputRedirected => true;
+        public bool IsOutputRedirected => true;
+        public bool IsErrorRedirected => true;
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+
+        public void ResetColor() { }
+
+        public event ConsoleCancelEventHandler? CancelKeyPress { add { } remove { } }
     }
 }

--- a/test/test.workflowvalidation/ContractValidateTests.cs
+++ b/test/test.workflowvalidation/ContractValidateTests.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractValidateTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractValidateTests
+{
+    static readonly UInt160 Hash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+
+    [Fact]
+    public void ComplianceResult_reports_success_for_a_compliant_contract()
+    {
+        var (message, exitCode) = ContractCommand.Validate.ComplianceResult(Hash, "NEP-17", true);
+
+        message.Should().Be($"{Hash} is NEP-17 compliant.");
+        exitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public void ComplianceResult_reports_failure_for_a_noncompliant_contract()
+    {
+        var (message, exitCode) = ContractCommand.Validate.ComplianceResult(Hash, "NEP-11", false);
+
+        message.Should().Be($"{Hash} is NOT NEP-11 compliant.");
+        exitCode.Should().NotBe(0);
+    }
+}


### PR DESCRIPTION
## Problem

`neoxp contract validate nep11` / `nep17` ([ContractCommand.Validate.cs](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Validate.cs)) printed a message **only** when the contract was compliant and **always returned exit code 0**:

```csharp
if (nep17)
    await console.Out.WriteLineAsync($"{scriptHash} is NEP-17 compliant.");
return 0;
```

So a script running `neoxp contract validate nep17 $HASH` against a **non-compliant** contract gets empty stdout and a **success** exit code — the exact opposite of what a validate command should report.

Separately, the positional argument is described as `"Path to contract .nef file"` but is parsed as a contract script hash (`UInt160.TryParse(ContractHash)`).

## Fix

- Print an explicit `"… is NOT <standard> compliant."` message and return a non-zero exit code in the non-compliant case, via a small testable `ComplianceResult` helper shared by both subcommands.
- Correct the argument description to `"Contract script hash"`.

## Tests

`ContractValidateTests` covers both outcomes of `ComplianceResult`: compliant → the "is … compliant." message and exit 0; non-compliant → the "is NOT … compliant." message and a non-zero exit. Reverting the non-compliant branch to exit 0 fails the test. Release build is clean and `dotnet format --verify-no-changes` reports no changes.