### PR TITLE
Use a reference set for StackItem.GetSize cycle detection

### DIFF
--- a/src/bctklib/Extensions.cs
+++ b/src/bctklib/Extensions.cs
@@ -300,7 +300,8 @@ namespace Neo.BlockchainToolkit
         {
             maxSize ??= ExecutionEngineLimits.Default.MaxItemSize;
             int size = 0;
-            var serialized = new List<VM.Types.CompoundType>();
+            // reference set for cycle detection: O(1) membership instead of an O(n) scan per node
+            var serialized = new HashSet<VM.Types.CompoundType>(ReferenceEqualityComparer.Instance);
             var unserialized = new Stack<StackItem>();
             unserialized.Push(item);
             while (unserialized.Count > 0)
@@ -324,17 +325,15 @@ namespace Neo.BlockchainToolkit
                         }
                         break;
                     case VM.Types.Array array:
-                        if (serialized.Any(p => ReferenceEquals(p, array)))
+                        if (!serialized.Add(array))
                             throw new NotSupportedException();
-                        serialized.Add(array);
                         size += array.Count.GetVarSize();
                         for (int i = array.Count - 1; i >= 0; i--)
                             unserialized.Push(array[i]);
                         break;
                     case VM.Types.Map map:
-                        if (serialized.Any(p => ReferenceEquals(p, map)))
+                        if (!serialized.Add(map))
                             throw new NotSupportedException();
-                        serialized.Add(map);
                         size += map.Count.GetVarSize();
                         foreach (var pair in map.Reverse())
                         {

--- a/src/bctklib/Extensions.cs
+++ b/src/bctklib/Extensions.cs
@@ -326,14 +326,14 @@ namespace Neo.BlockchainToolkit
                         break;
                     case VM.Types.Array array:
                         if (!serialized.Add(array))
-                            throw new NotSupportedException();
+                            throw new NotSupportedException("StackItem graph contains a circular reference.");
                         size += array.Count.GetVarSize();
                         for (int i = array.Count - 1; i >= 0; i--)
                             unserialized.Push(array[i]);
                         break;
                     case VM.Types.Map map:
                         if (!serialized.Add(map))
-                            throw new NotSupportedException();
+                            throw new NotSupportedException("StackItem graph contains a circular reference.");
                         size += map.Count.GetVarSize();
                         foreach (var pair in map.Reverse())
                         {

--- a/test/test.bctklib/StackItemGetSizeTests.cs
+++ b/test/test.bctklib/StackItemGetSizeTests.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StackItemGetSizeTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Neo.VM;
+using System;
+using System.Numerics;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+using NeoByteString = Neo.VM.Types.ByteString;
+using NeoInteger = Neo.VM.Types.Integer;
+
+namespace test.bctklib
+{
+    public class StackItemGetSizeTests
+    {
+        [Fact]
+        public void GetSize_computes_the_size_of_a_nested_structure()
+        {
+            var inner = new NeoArray(new Neo.VM.Types.StackItem[]
+            {
+                new NeoInteger(new BigInteger(1)),
+                new NeoByteString(new byte[] { 1, 2, 3 }),
+            });
+            var outer = new NeoArray(new Neo.VM.Types.StackItem[] { inner, new NeoInteger(new BigInteger(42)) });
+
+            outer.GetSize(ExecutionEngineLimits.Default.MaxItemSize).Should().Be(15);
+        }
+
+        [Fact]
+        public void GetSize_throws_on_a_circular_reference()
+        {
+            var array = new NeoArray();
+            array.Add(array);
+
+            var act = () => array.GetSize(ExecutionEngineLimits.Default.MaxItemSize);
+
+            act.Should().Throw<NotSupportedException>();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Extensions.GetSize` tracks already-visited compound items in a `List<CompoundType>` and checks membership with an O(n) scan **per node** ([Extensions.cs:327](https://github.com/neo-project/neo-express/blob/master/src/bctklib/Extensions.cs#L327), [:335](https://github.com/neo-project/neo-express/blob/master/src/bctklib/Extensions.cs#L335)):

```csharp
if (serialized.Any(p => ReferenceEquals(p, array)))
    throw new NotSupportedException();
serialized.Add(array);
```

For a StackItem graph with *n* compound nodes this is **O(n²)**. `GetSize` runs on the `NotificationRecord.Size` serialization path (every persisted notification), so a large or deeply nested notification state pays the quadratic cost.

## Fix

Track visited items in a `HashSet<CompoundType>` keyed by `ReferenceEqualityComparer`, using `!serialized.Add(item)` for the cycle check — O(1) membership. Cycle detection (by reference) and the computed size are unchanged.

## Tests

`StackItemGetSizeTests` pins the computed size of a nested array/byte-string/integer structure (identical to the previous logic) and confirms a self-referential array still throws `NotSupportedException`. Both hold on master and with the change (behavior-preserving). Full `test.bctklib` suite (313) passes; format clean.