### PR TITLE
Correct two incorrect user-facing CLI strings

### DIFF
--- a/src/neoxp/Commands/CreateCommand.cs
+++ b/src/neoxp/Commands/CreateCommand.cs
@@ -67,7 +67,7 @@ namespace NeoExpress.Commands
                 chainManager.SaveChain(outputPath);
 
                 await console.Out.WriteLineAsync($"Created {Count} node privatenet at {outputPath}").ConfigureAwait(false);
-                await console.Out.WriteLineAsync("\x1b[33m   Note: The private keys for the accounts in this file are are *not* encrypted.").ConfigureAwait(false);
+                await console.Out.WriteLineAsync("\x1b[33m   Note: The private keys for the accounts in this file are *not* encrypted.").ConfigureAwait(false);
                 await console.Out.WriteLineAsync("         Do not use these accounts on MainNet or in any other system where security is a concern.\x1b[0m\n").ConfigureAwait(false);
 
                 if (fileSystem.File.Exists(BatchFilename))

--- a/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
+++ b/src/neoxp/Commands/PolicyCommand.IsBlocked.cs
@@ -17,7 +17,7 @@ namespace NeoExpress.Commands
 {
     partial class PolicyCommand
     {
-        [Command("isBlocked", "blocked", Description = "Unblock account for usage")]
+        [Command("isBlocked", "blocked", Description = "Check whether an account is blocked")]
         internal class IsBlocked
         {
             readonly ExpressChainManagerFactory chainManagerFactory;


### PR DESCRIPTION
## Problem

- `neoxp policy isBlocked` checks whether an account is blocked, but its command description read **"Unblock account for usage"** ([PolicyCommand.IsBlocked.cs:20](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/PolicyCommand.IsBlocked.cs#L20)) — copied from the `unblock` command, so `--help` describes the wrong action.
- `neoxp create`'s note about unencrypted keys has a duplicated word: "…in this file **are are** *not* encrypted." ([CreateCommand.cs:70](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/CreateCommand.cs#L70)).

## Fix

Describe `isBlocked` as "Check whether an account is blocked" and remove the duplicated "are". Text-only.

## Verification

`grep` confirms neither "are are" nor the wrong `isBlocked` description remains in `src/neoxp/Commands`. Release build is clean and `dotnet format --verify-no-changes` reports no changes.