### PR TITLE
Preserve the original stack trace when opening a RocksDB fails

### DIFF
--- a/src/bctklib/persistence/RocksDbUtility.cs
+++ b/src/bctklib/persistence/RocksDbUtility.cs
@@ -83,7 +83,10 @@ namespace Neo.BlockchainToolkit.Persistence
             }
             catch (Exception ex)
             {
-                throw ex.InnerException ?? ex;
+                // surface the underlying cause but keep its original stack trace; a plain
+                // throw of the (inner) exception would reset it and lose the failure site
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException ?? ex).Throw();
+                throw; // unreachable, satisfies the compiler's definite-return analysis
             }
         }
 
@@ -96,7 +99,10 @@ namespace Neo.BlockchainToolkit.Persistence
             }
             catch (Exception ex)
             {
-                throw ex.InnerException ?? ex;
+                // surface the underlying cause but keep its original stack trace; a plain
+                // throw of the (inner) exception would reset it and lose the failure site
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException ?? ex).Throw();
+                throw; // unreachable, satisfies the compiler's definite-return analysis
             }
         }
 

--- a/test/test.bctklib/RocksDbUtilityOpenTests.cs
+++ b/test/test.bctklib/RocksDbUtilityOpenTests.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RocksDbUtilityOpenTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.Persistence;
+using System;
+using System.IO;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class RocksDbUtilityOpenTests
+    {
+        // Opening a read-only database that does not exist fails. The thrown exception must
+        // keep its original stack trace rather than being reset by a plain re-throw.
+        [Fact]
+        public void OpenReadOnlyDb_failure_preserves_the_original_stack_trace()
+        {
+            var missingPath = Path.Combine(Path.GetTempPath(), $"neo-express-missing-{Guid.NewGuid():N}");
+
+            var act = () => RocksDbUtility.OpenReadOnlyDb(missingPath);
+
+            var ex = act.Should().Throw<Exception>().Which;
+            // ExceptionDispatchInfo inserts this marker when it rethrows while preserving the
+            // captured stack; a plain `throw ex;` would reset the stack and omit it.
+            ex.StackTrace.Should().Contain("End of stack trace from previous location");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`RocksDbUtility.OpenDb` and `OpenReadOnlyDb` re-throw an open failure with ([RocksDbUtility.cs:86](https://github.com/neo-project/neo-express/blob/master/src/bctklib/persistence/RocksDbUtility.cs#L86), [:99](https://github.com/neo-project/neo-express/blob/master/src/bctklib/persistence/RocksDbUtility.cs#L99)):

```csharp
catch (Exception ex)
{
    throw ex.InnerException ?? ex;
}
```

`throw <expr>;` **resets** the thrown exception's stack trace to this `catch` site, discarding the original failure location. A database-open failure (a locked DB, a corrupt store, a permissions problem) is one of the more common support issues, and this throws away the stack that would point at the real cause.

## Fix

Rethrow through `ExceptionDispatchInfo` so the underlying exception (the inner one if present, otherwise the original) still surfaces but **keeps its original stack trace**.

## Tests

`RocksDbUtilityOpenTests` opens a non-existent read-only database (a deterministic failure) and asserts the thrown exception's stack trace contains the preserved-stack marker that `ExceptionDispatchInfo` inserts. Reverting to the plain `throw` removes the marker and fails the test. Full `test.bctklib` suite passes; format clean.