### PR TITLE
Use the correct --seconds-per-block option name in the settings doc

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -7,10 +7,10 @@ This document details the values that Neo-Express reads from the `settings` obje
 
 The `chain.SecondsPerBlock` Neo-Express setting corresponds to the `MillisecondsPerBlock`
 [config.json property](https://github.com/neo-project/neo-node/blob/5e3ffcb957e4e8fd8182307f68a70e653557e7d0/neo-cli/config.json#L28)
-and the `--secondsPerBlock` option for the Neo-Express `run` command. 
+and the `--seconds-per-block` option for the Neo-Express `run` command. 
 
 By default, Neo-Express mints a new block every 15 seconds. The `chain.SecondsPerBlock` setting can
-be used to override the default behavior. If the `run` command `--secondsPerBlock` option is specified,
+be used to override the default behavior. If the `run` command `--seconds-per-block` option is specified,
 the `chain.SecondsPerBlock` setting is ignored.
 
 `chain.SecondsPerBlock` is specified as an unsigned integer. If you specify an invalid unsigned integer


### PR DESCRIPTION
## Problem

`docs/settings.md` refers to the `run` command option as **`--secondsPerBlock`** ([settings.md:10](https://github.com/neo-project/neo-express/blob/master/docs/settings.md#L10), [:13](https://github.com/neo-project/neo-express/blob/master/docs/settings.md#L13)), but the actual option is **`--seconds-per-block`** — McMaster derives the kebab-case name from the `SecondsPerBlock` property, and the command reference's `run` usage block ([command-reference.md](https://github.com/neo-project/neo-express/blob/master/docs/command-reference.md#L93)) shows `-s|--seconds-per-block`. A user following the settings doc as written gets an unrecognized-option error.

## Fix

Correct both references to `--seconds-per-block`. Documentation-only.

## Verification

`grep` of `docs/settings.md` now shows only `--seconds-per-block`, matching the command reference and the `run` command's actual option.