### PR TITLE
Remove the unused positional argument from show state

### DIFF
--- a/src/neoxp/Commands/ShowCommand.State.cs
+++ b/src/neoxp/Commands/ShowCommand.State.cs
@@ -24,9 +24,6 @@ namespace NeoExpress.Commands
                 this.chainManagerFactory = chainManagerFactory;
             }
 
-            [Argument(0, Description = "Optional block hash or index. Show most recent block if unspecified")]
-            internal string BlockHash { get; init; } = string.Empty;
-
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 

--- a/test/test.workflowvalidation/ShowStateCommandTests.cs
+++ b/test/test.workflowvalidation/ShowStateCommandTests.cs
@@ -1,0 +1,32 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ShowStateCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ShowStateCommandTests
+{
+    // show state reports chain-level state (block height, running, config file) and takes
+    // no positional argument; a stray positional must be rejected, not silently ignored.
+    [Fact]
+    public void State_does_not_accept_a_positional_argument()
+    {
+        var app = new CommandLineApplication<ShowCommand.State>();
+        app.Conventions.UseDefaultConventions();
+
+        var act = () => app.Parse("0");
+
+        act.Should().Throw<CommandParsingException>();
+    }
+}


### PR DESCRIPTION
## Problem

`neoxp show state` declares a positional argument ([ShowCommand.State.cs:27](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ShowCommand.State.cs#L27)):

```csharp
[Argument(0, Description = "Optional block hash or index. Show most recent block if unspecified")]
internal string BlockHash { get; init; } = string.Empty;
```

but `OnExecuteAsync` only ever calls `GetLatestBlockAsync()` and **never reads `BlockHash`** — it's a copy-paste from `show block` and is silently ignored. The command reports chain-level state (block height, running status, config file), for which there is no per-block variant, and the command reference already documents `show state` with **no** argument.

So `neoxp show state <anything>` exits 0 having ignored the argument, advertising a capability that doesn't exist.

## Fix

Remove the dead argument. `show state` now takes no positional argument (matching the docs); a stray argument is rejected rather than silently ignored.

## Tests

`ShowStateCommandTests` parses the command with an extra positional and asserts it throws `CommandParsingException`. With the argument still present the positional binds to `BlockHash` and no exception is thrown, so the test fails; after removal it passes. Release build is clean and `dotnet format --verify-no-changes` reports no changes.