### PR TITLE
Surface malformed base64 when persisting a contract storage pair

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -535,21 +535,24 @@ namespace NeoExpress.Node
             if (dirty)
                 snapshot.Commit();
             return localContract.Id;
+        }
 
-            static bool PersistStoragePair(DataCache snapshot, int contractId, (string key, string value) storagePair)
+        internal static bool PersistStoragePair(DataCache snapshot, int contractId, (string key, string value) storagePair)
+        {
+            // Decode outside the try so a malformed base64 key/value surfaces as a
+            // FormatException instead of being reported as a benign "already exists".
+            var key = Convert.FromBase64String(storagePair.key);
+            var value = Convert.FromBase64String(storagePair.value);
+            try
             {
-                try
-                {
-                    snapshot.Add(
-                        new StorageKey { Id = contractId, Key = Convert.FromBase64String(storagePair.key) },
-                        new StorageItem(Convert.FromBase64String(storagePair.value)));
-
-                    return true;
-                }
-                catch
-                {
-                    return false;
-                }
+                snapshot.Add(new StorageKey { Id = contractId, Key = key }, new StorageItem(value));
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                // DataCache.Add throws ArgumentException when the key already exists; in the
+                // no-overwrite path this means "the key is present, leave the existing value".
+                return false;
             }
         }
 

--- a/test/test.workflowvalidation/PersistStoragePairTests.cs
+++ b/test/test.workflowvalidation/PersistStoragePairTests.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// PersistStoragePairTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using NeoExpress.Node;
+using System;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class PersistStoragePairTests
+{
+    const int ContractId = 1;
+
+    // A malformed base64 key/value is a user input error and must surface, not be reported
+    // as the benign "already exists" result.
+    [Fact]
+    public void PersistStoragePair_throws_on_malformed_base64()
+    {
+        using var store = new MemoryStore();
+        using var snapshot = new StoreCache(store.GetSnapshot());
+
+        var act = () => NodeUtility.PersistStoragePair(snapshot, ContractId, ("###not-base64###", "AQI="));
+
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void PersistStoragePair_returns_false_when_the_key_already_exists()
+    {
+        using var store = new MemoryStore();
+        using var snapshot = new StoreCache(store.GetSnapshot());
+
+        NodeUtility.PersistStoragePair(snapshot, ContractId, ("AQ==", "Ag==")).Should().BeTrue();
+        NodeUtility.PersistStoragePair(snapshot, ContractId, ("AQ==", "Aw==")).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Problem

`NodeUtility.PersistStoragePair` (a local function inside `PersistStorageKeyValuePair`, [NodeUtility.cs:539](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/NodeUtility.cs#L539)) decoded the base64 key and value **inside** a `try` whose `catch` returned `false` for anything:

```csharp
try {
    snapshot.Add(new StorageKey { Id = contractId, Key = Convert.FromBase64String(storagePair.key) },
                 new StorageItem(Convert.FromBase64String(storagePair.value)));
    return true;
} catch { return false; }
```

This collapses two unrelated outcomes into the same `false`:
1. a **malformed-base64** input error (`FormatException`), and
2. the legitimate **"key already exists"** result (`DataCache.Add` throws `ArgumentException`), which the no-overwrite path uses to mean "leave the existing value".

The `expresspersiststorage` RPC forwards JSON `key`/`value` strings directly with no validation, so a bad base64 value looks like a benign no-op — and on the overwrite path the failure is ignored **after** the contract's existing storage was already cleared, reporting success while having wiped/skipped data. (The CLI path is unaffected: it re-encodes via `Convert.ToBase64String` before calling, so input is always valid there.)

## Fix

Decode the base64 **outside** the `try` so a `FormatException` surfaces, and narrow the `catch` to the `ArgumentException` that `DataCache.Add` raises for an existing key. The method is promoted to an `internal static` helper (same name/signature, so the two call sites bind unchanged) so the behavior is unit-testable.

## Tests

`PersistStoragePairTests` (MemoryStore + StoreCache, no node): a malformed base64 key throws `FormatException`; a valid pair returns `true`, and a second write to the same key returns `false` (pinning the preserved no-overwrite path). Reverting to the catch-all form makes the malformed case return `false` instead of throwing, failing the test. Release build is clean and `dotnet format --verify-no-changes` reports no changes.