### PR TITLE
Constrain the expresscreatecheckpoint RPC path to the working directory

### DIFF
--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -249,6 +249,10 @@ namespace NeoExpress.Node
             {
                 try
                 {
+                    // The filename comes straight from the RPC request. Constrain it to the
+                    // node's working directory (the same restriction the CLI applies before
+                    // sending) so a caller cannot create a checkpoint at an arbitrary path.
+                    filename = EnsureCheckpointPathWithinDirectory(filename, System.IO.Directory.GetCurrentDirectory());
                     rocksDbExpressStorage.CreateCheckpoint(filename, neoSystem.Settings.Network, neoSystem.Settings.AddressVersion, nodeAccountAddress);
                 }
                 catch (Exception ex) when (ex is ArgumentException
@@ -262,6 +266,24 @@ namespace NeoExpress.Node
             }
 
             throw new NotSupportedException($"Checkpoint create is only supported for {nameof(RocksDbExpressStorage)}");
+        }
+
+        // Resolves a checkpoint filename and rejects any path that escapes the given base
+        // directory (path traversal or an absolute path outside it).
+        internal static string EnsureCheckpointPathWithinDirectory(string filename, string baseDirectory)
+        {
+            var fullPath = System.IO.Path.GetFullPath(filename);
+            var prefix = System.IO.Path.GetFullPath(baseDirectory)
+                .TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar)
+                + System.IO.Path.DirectorySeparatorChar;
+            var comparison = System.IO.Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!fullPath.StartsWith(prefix, comparison))
+                throw new ArgumentException("Checkpoint path must stay within the current directory", nameof(filename));
+
+            return fullPath;
         }
 
         [RpcMethod]

--- a/test/test.workflowvalidation/ExpressCreateCheckpointPathTests.cs
+++ b/test/test.workflowvalidation/ExpressCreateCheckpointPathTests.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExpressCreateCheckpointPathTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Node;
+using System;
+using System.IO;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ExpressCreateCheckpointPathTests
+{
+    static string NewBaseDirectory() =>
+        Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"neoxp-base-{Guid.NewGuid():N}"));
+
+    [Fact]
+    public void Accepts_a_path_inside_the_base_directory()
+    {
+        var baseDir = NewBaseDirectory();
+        var inside = Path.Combine(baseDir, "checkpoint.neoxp-checkpoint");
+
+        ExpressRpcServerPlugin.EnsureCheckpointPathWithinDirectory(inside, baseDir)
+            .Should().Be(Path.GetFullPath(inside));
+    }
+
+    [Fact]
+    public void Rejects_a_directory_traversal_path()
+    {
+        var baseDir = NewBaseDirectory();
+        var traversal = Path.Combine(baseDir, "..", "escape.neoxp-checkpoint");
+
+        var act = () => ExpressRpcServerPlugin.EnsureCheckpointPathWithinDirectory(traversal, baseDir);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Rejects_an_absolute_path_outside_the_base_directory()
+    {
+        var baseDir = NewBaseDirectory();
+        var outside = Path.Combine(Path.GetFullPath(Path.GetTempPath()), $"neoxp-other-{Guid.NewGuid():N}", "x.neoxp-checkpoint");
+
+        var act = () => ExpressRpcServerPlugin.EnsureCheckpointPathWithinDirectory(outside, baseDir);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Problem

`ExpressCreateCheckpoint` ([ExpressRpcServerPlugin.cs:241](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs#L241)) takes the checkpoint `filename` straight from the RPC request and passes it to `RocksDbExpressStorage.CreateCheckpoint` with **no path validation**. A caller can therefore create a checkpoint directory at an arbitrary location via path traversal (`../../…`) or an absolute path (`/tmp/…`).

The CLI path is already restricted — `ExpressChainManager.CreateCheckpointAsync` runs `ResolveCheckpointFileName`, which enforces the checkpoint stays within the current directory ([ExpressChainManager.cs:139](https://github.com/neo-project/neo-express/blob/master/src/neoxp/ExpressChainManager.cs#L139)) before sending the request. The RPC handler applied no equivalent check.

## Fix

Resolve the filename and reject any path that escapes the node's working directory before creating the checkpoint, mirroring the CLI restriction. The check is an `internal static` helper (`EnsureCheckpointPathWithinDirectory`) that rejects both directory-traversal and absolute-outside paths and returns the resolved full path. The thrown `ArgumentException` is wrapped into the existing `InvalidParams` RPC error.

## Behavior note (please review)

This mirrors the CLI's existing within-directory model, with one honest caveat: the RPC now validates against the **node's** working directory (where `neoxp run` was started). In the common case the node and the `checkpoint create` process share that directory, so legitimate checkpoints are unaffected. The only legitimate scenario affected is creating a checkpoint from a directory **outside** the node's working-directory tree, which is uncommon. The node cannot know the calling CLI process's working directory, so this is the closest safe restriction without a larger redesign of where RPC checkpoints may be written.

## Tests

`ExpressCreateCheckpointPathTests` covers the helper: a path inside the base directory is accepted and returned as a full path; a traversal path and an absolute path outside the base directory both throw `ArgumentException`. Removing the check makes the two rejection tests fail. Release build is clean and `dotnet format --verify-no-changes` reports no changes.