### PR TITLE
Document that a non-loopback RPC BindAddress exposes unauthenticated node control

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -42,6 +42,14 @@ a Neo-Express instance, you would specify the `rpc.BindAddress` to be `0.0.0.0`.
 If you specify an invalid IP Address, Neo-Express reverts to the default loopback `BindAddress`
 (aka `127.0.0.1`).
 
+> **Security note:** The Neo-Express RPC server exposes unauthenticated administrative methods
+> that control the node, including `expressshutdown` (stops the node), `expresscreatecheckpoint`,
+> `expresspersiststorage` and `expresspersistcontract` (modify chain state). The default loopback
+> `BindAddress` limits these to processes on the same machine. Binding to any other address (for
+> example `0.0.0.0`) makes them reachable, without authentication, by any host that can route to
+> that address. Only override the default on a trusted network and only for the duration of the
+> testing scenario that requires it.
+
 Example usage:
 
 ``` json


### PR DESCRIPTION
## Problem

The Neo-Express RPC server registers administrative methods that control the node and modify chain state — `expressshutdown`, `expresscreatecheckpoint`, `expresspersiststorage`, `expresspersistcontract` — and none of them are authenticated. This is acceptable under the default loopback `BindAddress`, where only local processes can reach them.

[`docs/settings.md`](https://github.com/neo-project/neo-express/blob/master/docs/settings.md) documents overriding `rpc.BindAddress` to `0.0.0.0` for cross-machine testing, but does not state the security consequence: once bound beyond loopback, those destructive methods become reachable, **without authentication**, by any host that can route to the address.

## Fix

Add a security note to the `rpc.BindAddress` section that names the unauthenticated administrative methods and advises overriding the default only on a trusted network and only for the duration of the testing scenario that needs it. Documentation only — no behavior change.

## Why documentation rather than code

The loopback default is already the safe posture, and the methods are required by the CLI (for example `neoxp stop` calls `expressshutdown`; the checkpoint flow calls `expresscreatecheckpoint`), so adding authentication would break the normal local workflow for no benefit in the default configuration. The residual risk is entirely a function of the user opting into a non-loopback bind, so informed consent at the point of that decision is the appropriate mitigation.