### PR TITLE
Stop scanning contract storage twice per traced instruction

### DIFF
--- a/src/bctklib/trace-models/StorageRecord.cs
+++ b/src/bctklib/trace-models/StorageRecord.cs
@@ -40,8 +40,13 @@ namespace Neo.BlockchainToolkit.TraceDebug
 
         public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, UInt160 scriptHash, IEnumerable<(StorageKey key, StorageItem item)> storages)
         {
-            var count = storages.Count();
-            if (count <= 0)
+            // Materialize once. storages is typically a lazy iterator returned by
+            // DataCache.Find (a prefix scan over the snapshot); the previous .Count()
+            // followed by foreach enumerated it twice, scanning the contract storage
+            // twice for every VM instruction while tracing.
+            var materialized = storages as IReadOnlyCollection<(StorageKey key, StorageItem item)>
+                ?? storages.ToList();
+            if (materialized.Count <= 0)
                 return;
 
             var byteArrayFormatter = options.Resolver.GetFormatterWithVerify<byte[]>();
@@ -51,8 +56,8 @@ namespace Neo.BlockchainToolkit.TraceDebug
             writer.WriteInt32(RecordKey);
             writer.WriteArrayHeader(2);
             options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptHash, options);
-            writer.WriteMapHeader(count);
-            foreach (var (key, item) in storages)
+            writer.WriteMapHeader(materialized.Count);
+            foreach (var (key, item) in materialized)
             {
                 writer.Write(key.Key.Span);
                 storageItemFormatter.Serialize(ref writer, item, options);

--- a/test/test.bctklib/TraceDebugTests.cs
+++ b/test/test.bctklib/TraceDebugTests.cs
@@ -120,6 +120,47 @@ namespace test.bctklib
                 Assert.Equal(storages.Length, storageRecord.Storages.Count);
             }
         }
+        [Fact]
+        public void storage_record_write_enumerates_lazy_storages_once()
+        {
+            var scriptHash = UInt160.Parse("0001020304050607080900010203040506070809");
+            var source = new[] {
+                (key: new StorageKey { Key = Convert.FromHexString("01")}, value: new StorageItem(Convert.FromHexString("11121314"))),
+                (key: new StorageKey { Key = Convert.FromHexString("02")}, value: new StorageItem(Convert.FromHexString("21222324")))
+            };
+
+            var enumerateCount = 0;
+            IEnumerable<(StorageKey key, StorageItem item)> Lazy()
+            {
+                foreach (var entry in source)
+                {
+                    enumerateCount++;
+                    yield return entry;
+                }
+            }
+
+            var lazyWriter = new ArrayBufferWriter<byte>();
+            StorageRecord.Write(lazyWriter, options, scriptHash, Lazy());
+
+            // A lazy DataCache.Find iterator must be walked exactly once, not once
+            // for a .Count() and again for the write loop.
+            Assert.Equal(source.Length, enumerateCount);
+
+            // Materializing the iterator must not change the serialized bytes: writing
+            // the same entries from an already-materialized array produces an identical
+            // record, so the optimization is purely a performance change.
+            var arrayWriter = new ArrayBufferWriter<byte>();
+            StorageRecord.Write(arrayWriter, options, scriptHash, source);
+            Assert.Equal(arrayWriter.WrittenMemory.ToArray(), lazyWriter.WrittenMemory.ToArray());
+
+            // And the record still round-trips through deserialization.
+            var record = MessagePackSerializer.Deserialize<ITraceDebugRecord>(lazyWriter.WrittenMemory, options, TestContext.Current.CancellationToken);
+            Assert.IsType<StorageRecord>(record);
+            var storageRecord = (StorageRecord)record;
+            Assert.Equal(scriptHash, storageRecord.ScriptHash);
+            Assert.Equal(source.Length, storageRecord.Storages.Count);
+        }
+
         static void StorageRecord_WriteWithStorageItemArrayHeader(
             IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash,
             IEnumerable<(StorageKey key, StorageItem item)> storages)


### PR DESCRIPTION
## Problem

`StorageRecord.Write` ([StorageRecord.cs:41](https://github.com/neo-project/neo-express/blob/master/src/bctklib/trace-models/StorageRecord.cs#L41)) enumerates its `storages` argument **twice**:

```csharp
var count = storages.Count();        // enumeration 1 (to size the map header)
...
foreach (var (key, item) in storages) // enumeration 2 (to write the entries)
```

That argument is the **lazy iterator returned by `DataCache.Find`** — a prefix scan over the snapshot — passed straight through from `TraceApplicationEngine.WriteStorages`:

```csharp
var storages = SnapshotCache.Find(StorageKey.CreateSearchPrefix(contractState.Id, default));
traceDebugSink.Storages(scriptHash, storages);
```

`WriteStorages` runs on **every executed VM instruction** ([TraceApplicationEngine.cs:83](https://github.com/neo-project/neo-express/blob/master/src/bctklib/smart-contract/TraceApplicationEngine.cs#L83), via `PostExecuteInstruction`). Because the iterator is lazy, the `.Count()` and the `foreach` each trigger a full prefix scan, so a contract with *S* storage items running *N* instructions performs **2·N** scans of *S* items instead of *N*.

## Fix

Materialize the sequence once, then size and write from the materialized copy:

```csharp
var materialized = storages as IReadOnlyCollection<(StorageKey key, StorageItem item)>
    ?? storages.ToList();
```

An already-materialized collection (such as the arrays used in tests) takes the `as IReadOnlyCollection` fast path with no extra allocation; a lazy iterator is walked exactly once. The empty-input early return is preserved.

## Why this is safe

The serialized output is **byte-for-byte identical** — same map-header count, same entry order, same encoding. The external Neo Smart Contract Debugger that consumes `.neo-trace` still receives the full per-instruction storage state; this changes only how many times the source is scanned to produce it, not what is produced.

## Tests

Added `storage_record_write_enumerates_lazy_storages_once` to `TraceDebugTests`. It wraps the storage entries in a counting lazy iterator and asserts:
- the iterator is walked **exactly once** (reverting the fix makes the count 4 instead of 2, so the test fails — verified);
- the bytes written from the lazy iterator are **identical** to those written from a pre-materialized array;
- the record still round-trips through deserialization.

Release build is clean, `dotnet format --verify-no-changes` reports no changes, and the full `TraceDebugTests` suite passes.