### PR TITLE
[debugger 1] Add source breakpoint resolution to DebugInfo

### DIFF
--- a/src/bctklib/models/DebugInfoExtensions.cs
+++ b/src/bctklib/models/DebugInfoExtensions.cs
@@ -1,0 +1,104 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DebugInfoExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+
+namespace Neo.BlockchainToolkit.Models
+{
+    /// <summary>A source breakpoint bound to a concrete NeoVM instruction address.</summary>
+    /// <param name="Address">The instruction pointer the breakpoint binds to.</param>
+    /// <param name="Line">The source line the breakpoint actually bound to (1-based).</param>
+    /// <param name="Column">The source column the bound sequence point starts at (1-based).</param>
+    /// <param name="Document">The index into <see cref="DebugInfo.Documents"/> of the bound document.</param>
+    public readonly record struct ResolvedBreakpoint(int Address, int Line, int Column, int Document);
+
+    /// <summary>
+    /// Maps source-level breakpoints (a document path + line number) onto the NeoVM instruction
+    /// addresses recorded in a contract's <see cref="DebugInfo"/>. This is the source-map lookup a
+    /// source-level debugger performs when an editor sets a breakpoint.
+    /// </summary>
+    public static class DebugInfoExtensions
+    {
+        /// <summary>
+        /// Resolves a source breakpoint to the NeoVM instruction it should stop on. A breakpoint set on
+        /// a line that carries no sequence point (a blank line, a brace, a comment) snaps forward to the
+        /// next sequence point in the same document, matching how mainstream debuggers bind breakpoints.
+        /// </summary>
+        /// <param name="debugInfo">The contract debug information to search.</param>
+        /// <param name="source">The source document path the breakpoint was set in.</param>
+        /// <param name="line">The 1-based source line the breakpoint was set on.</param>
+        /// <param name="resolved">The bound breakpoint, when this method returns <see langword="true"/>.</param>
+        /// <returns><see langword="true"/> if a sequence point at or after <paramref name="line"/> was found.</returns>
+        public static bool TryResolveBreakpoint(this DebugInfo debugInfo, string source, int line, out ResolvedBreakpoint resolved)
+        {
+            ArgumentNullException.ThrowIfNull(debugInfo);
+
+            ResolvedBreakpoint? best = null;
+            for (var document = 0; document < debugInfo.Documents.Count; document++)
+            {
+                if (!DocumentMatches(debugInfo.Documents[document], source))
+                    continue;
+
+                foreach (var method in debugInfo.Methods)
+                {
+                    foreach (var sp in method.SequencePoints)
+                    {
+                        if (sp.Document != document || sp.Start.Line < line)
+                            continue;
+
+                        // Prefer the earliest line at or after the request, then the lowest address on it,
+                        // so a breakpoint binds to the first instruction of the closest executable line.
+                        if (best is null
+                            || sp.Start.Line < best.Value.Line
+                            || (sp.Start.Line == best.Value.Line && sp.Address < best.Value.Address))
+                        {
+                            best = new ResolvedBreakpoint(sp.Address, sp.Start.Line, sp.Start.Column, document);
+                        }
+                    }
+                }
+            }
+
+            resolved = best ?? default;
+            return best is not null;
+        }
+
+        /// <summary>
+        /// Resolves a source breakpoint to the NeoVM instruction it should stop on, or <see langword="null"/>
+        /// when the document carries no sequence point at or after <paramref name="line"/>.
+        /// </summary>
+        public static ResolvedBreakpoint? ResolveBreakpoint(this DebugInfo debugInfo, string source, int line)
+            => debugInfo.TryResolveBreakpoint(source, line, out var resolved) ? resolved : null;
+
+        static bool DocumentMatches(string document, string requested)
+        {
+            var normalizedDocument = Normalize(document);
+            var normalizedRequested = Normalize(requested);
+            if (string.Equals(normalizedDocument, normalizedRequested, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Fall back to a file-name match so a breakpoint still binds when the editor and the debug
+            // info disagree on the absolute path (a common case with relocated or source-mapped trees).
+            return string.Equals(
+                FileName(normalizedDocument),
+                FileName(normalizedRequested),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Both separators are handled explicitly: debug info produced on Windows carries '\' paths that
+        // Path.GetFileName would not split on a Unix host, so the comparison is normalized first.
+        static string Normalize(string path) => path.Replace('\\', '/');
+
+        static string FileName(string normalizedPath)
+        {
+            var slash = normalizedPath.LastIndexOf('/');
+            return slash < 0 ? normalizedPath : normalizedPath[(slash + 1)..];
+        }
+    }
+}

--- a/test/test.bctklib/DebugInfoBreakpointTests.cs
+++ b/test/test.bctklib/DebugInfoBreakpointTests.cs
@@ -1,0 +1,120 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DebugInfoBreakpointTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using System;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class DebugInfoBreakpointTests
+    {
+        const string SourcePath = "/src/Contract.cs";
+
+        // A single method whose statements live on source lines 5, 7, 7 and 9. Two sequence points
+        // share line 7 (addresses 4 and 8) so the lowest-address tie-break can be exercised.
+        static DebugInfo MakeDebugInfo(string documentPath = SourcePath) => new(
+            ScriptHash: UInt160.Zero,
+            DocumentRoot: "",
+            Documents: new[] { documentPath },
+            Methods: new[]
+            {
+                new DebugInfo.Method(
+                    Id: "Contract.Run",
+                    Namespace: "Contract",
+                    Name: "Run",
+                    Range: (0, 12),
+                    ReturnType: "Integer",
+                    Parameters: Array.Empty<DebugInfo.SlotVariable>(),
+                    Variables: Array.Empty<DebugInfo.SlotVariable>(),
+                    SequencePoints: new[]
+                    {
+                        new DebugInfo.SequencePoint(0, 0, (5, 9), (5, 20)),
+                        new DebugInfo.SequencePoint(4, 0, (7, 9), (7, 18)),
+                        new DebugInfo.SequencePoint(8, 0, (7, 20), (7, 30)),
+                        new DebugInfo.SequencePoint(12, 0, (9, 9), (9, 17)),
+                    }),
+            },
+            Events: Array.Empty<DebugInfo.Event>(),
+            StaticVariables: Array.Empty<DebugInfo.SlotVariable>());
+
+        [Fact]
+        public void resolves_exact_line_to_its_sequence_point()
+        {
+            var ok = MakeDebugInfo().TryResolveBreakpoint(SourcePath, 5, out var bp);
+
+            Assert.True(ok);
+            Assert.Equal(0, bp.Address);
+            Assert.Equal(5, bp.Line);
+            Assert.Equal(9, bp.Column);
+            Assert.Equal(0, bp.Document);
+        }
+
+        [Fact]
+        public void snaps_forward_when_line_has_no_sequence_point()
+        {
+            // Line 6 carries no sequence point, so the breakpoint binds to the next line that does (7).
+            var ok = MakeDebugInfo().TryResolveBreakpoint(SourcePath, 6, out var bp);
+
+            Assert.True(ok);
+            Assert.Equal(7, bp.Line);
+            Assert.Equal(4, bp.Address);
+        }
+
+        [Fact]
+        public void prefers_lowest_address_when_a_line_has_multiple_sequence_points()
+        {
+            var ok = MakeDebugInfo().TryResolveBreakpoint(SourcePath, 7, out var bp);
+
+            Assert.True(ok);
+            Assert.Equal(7, bp.Line);
+            Assert.Equal(4, bp.Address);
+        }
+
+        [Fact]
+        public void does_not_resolve_a_line_past_every_sequence_point()
+        {
+            var ok = MakeDebugInfo().TryResolveBreakpoint(SourcePath, 10, out var bp);
+
+            Assert.False(ok);
+            Assert.Equal(default, bp);
+        }
+
+        [Fact]
+        public void matches_documents_by_file_name_when_the_full_path_differs()
+        {
+            var debugInfo = MakeDebugInfo(@"C:\build\agent\work\Contract.cs");
+
+            var ok = debugInfo.TryResolveBreakpoint("/home/dev/project/Contract.cs", 5, out var bp);
+
+            Assert.True(ok);
+            Assert.Equal(0, bp.Address);
+        }
+
+        [Fact]
+        public void does_not_resolve_against_an_unrelated_document()
+        {
+            var ok = MakeDebugInfo().TryResolveBreakpoint("/src/Other.cs", 5, out _);
+
+            Assert.False(ok);
+        }
+
+        [Fact]
+        public void resolve_breakpoint_returns_null_when_unresolved()
+        {
+            Assert.Null(MakeDebugInfo().ResolveBreakpoint(SourcePath, 10));
+
+            var resolved = MakeDebugInfo().ResolveBreakpoint(SourcePath, 5);
+            Assert.NotNull(resolved);
+            Assert.Equal(0, resolved.Value.Address);
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds source-level breakpoint resolution to `bctklib`'s `DebugInfo`: given a source document path and a 1-based line number, return the NeoVM instruction address the breakpoint should bind to.

```csharp
if (debugInfo.TryResolveBreakpoint("/src/Contract.cs", line, out var bp))
    // bp.Address is the instruction pointer; bp.Line is the line it actually bound to
```

A convenience `ResolveBreakpoint(...)` overload returns a nullable `ResolvedBreakpoint?`.

## Why

This is the source-map lookup a source-level debugger performs every time an editor sets a breakpoint, and it is the primitive the rest of the DAP debugger builds on (see #708). `DebugInfo` already parses the sequence points; this turns them into a line → address query. It's pure, allocation-light, and engine-agnostic, so it can be unit-tested without a VM or a running node.

## Behavior

- **Exact match** — binds to the lowest instruction address of the requested line.
- **Snap forward** — a breakpoint on a line with no sequence point (blank line, brace, comment) binds to the next executable line in the same document, matching mainstream debuggers.
- **Document matching** — by normalized full path, falling back to file name so a breakpoint still binds when the editor and the debug info disagree on the absolute path (relocated / source-mapped trees, Windows-built `\\` paths on a Unix host).
- **No match** — returns `false` / `null` when no sequence point exists at or after the line.

## Tests

`DebugInfoBreakpointTests` (7 tests, all passing): exact line, snap-forward, lowest-address tie-break, line past every sequence point, file-name fallback across differing paths, unrelated document, and the nullable overload.

Part of #708.