### PR TITLE
[debugger 2] Add a streaming trace reader/cursor to bctklib

### DIFF
--- a/src/bctklib/trace-models/TraceDebugReader.cs
+++ b/src/bctklib/trace-models/TraceDebugReader.cs
@@ -1,0 +1,153 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TraceDebugReader.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using MessagePack;
+using MessagePack.Resolvers;
+using Neo.SmartContract;
+using Neo.VM;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Neo.BlockchainToolkit.TraceDebug
+{
+    /// <summary>
+    /// Reads a <c>.neo-trace</c> stream of MessagePack <see cref="ITraceDebugRecord"/> records (as written
+    /// by <see cref="TraceDebugStream"/> / the <c>neotrace</c> tool) and exposes a forward/backward cursor
+    /// over them. This is the replay counterpart to the trace writer: a debugger steps the cursor to move
+    /// through a recorded execution in either direction.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ScriptRecord"/> and <see cref="ProtocolSettingsRecord"/> are side records consumed silently
+    /// as the stream advances — their contents surface through <see cref="TryGetContract"/>,
+    /// <see cref="Network"/>, and <see cref="AddressVersion"/>. Every other record kind (trace, notify, log,
+    /// results, fault, storage) is returned from <see cref="TryGetNext"/>. Backward movement is served from a
+    /// history of already-read records, so the underlying stream is only ever read forward once.
+    /// </remarks>
+    public sealed class TraceDebugReader : IDisposable
+    {
+        private static readonly MessagePackSerializerOptions s_options = MessagePackSerializerOptions.Standard
+            .WithResolver(TraceDebugResolver.Instance);
+
+        private readonly Stream _stream;
+        private readonly bool _leaveOpen;
+        private readonly Stack<ITraceDebugRecord> _previous = new();
+        private readonly Stack<ITraceDebugRecord> _next = new();
+        private readonly Dictionary<UInt160, Script> _contracts = new();
+        private bool _disposed;
+
+        /// <summary>The network magic recorded in the trace, or 0 until a protocol-settings record is read.</summary>
+        public uint Network { get; private set; }
+
+        /// <summary>The address version recorded in the trace, or 0 until a protocol-settings record is read.</summary>
+        public byte AddressVersion { get; private set; }
+
+        /// <summary>Opens a trace file for reading.</summary>
+        /// <param name="traceFilePath">Path to a <c>.neo-trace</c> file.</param>
+        /// <param name="knownContracts">Scripts to seed the contract table with (for example, from NEF files) so
+        /// <see cref="TryGetContract"/> resolves them even before their script record is read.</param>
+        public TraceDebugReader(string traceFilePath, IEnumerable<KeyValuePair<UInt160, Script>>? knownContracts = null)
+            : this(File.OpenRead(traceFilePath), leaveOpen: false, knownContracts)
+        {
+        }
+
+        /// <summary>Reads a trace from an existing stream.</summary>
+        /// <param name="stream">A stream positioned at the start of the trace records.</param>
+        /// <param name="leaveOpen"><see langword="true"/> to leave <paramref name="stream"/> open when this reader is disposed.</param>
+        /// <param name="knownContracts">Scripts to seed the contract table with.</param>
+        public TraceDebugReader(Stream stream, bool leaveOpen = false, IEnumerable<KeyValuePair<UInt160, Script>>? knownContracts = null)
+        {
+            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            _leaveOpen = leaveOpen;
+            if (knownContracts is not null)
+            {
+                foreach (var (hash, script) in knownContracts)
+                    _contracts[hash] = script;
+            }
+        }
+
+        /// <summary><see langword="true"/> when the cursor is before the first returned record.</summary>
+        public bool AtStart => _previous.Count == 0;
+
+        /// <summary>Advances the cursor to the next record, skipping (but absorbing) script/protocol-settings side records.</summary>
+        public bool TryGetNext([MaybeNullWhen(false)] out ITraceDebugRecord record)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_next.TryPop(out record))
+            {
+                _previous.Push(record);
+                return true;
+            }
+
+            while (_stream.Position < _stream.Length)
+            {
+                record = MessagePackSerializer.Deserialize<ITraceDebugRecord>(_stream, s_options);
+                switch (record)
+                {
+                    case ScriptRecord script:
+                        _contracts.TryAdd(script.ScriptHash, script.Script);
+                        break;
+                    case ProtocolSettingsRecord protocol:
+                        Network = protocol.Network;
+                        AddressVersion = protocol.AddressVersion;
+                        break;
+                    default:
+                        _previous.Push(record);
+                        return true;
+                }
+            }
+
+            record = null;
+            return false;
+        }
+
+        /// <summary>Moves the cursor back to the previously returned record.</summary>
+        public bool TryGetPrev([MaybeNullWhen(false)] out ITraceDebugRecord record)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_previous.TryPop(out record))
+            {
+                _next.Push(record);
+                return true;
+            }
+
+            record = null;
+            return false;
+        }
+
+        /// <summary>Resolves a contract script by hash from the script records seen so far (and any seeded contracts).</summary>
+        public bool TryGetContract(UInt160 scriptHash, [MaybeNullWhen(false)] out Script script)
+            => _contracts.TryGetValue(scriptHash, out script);
+
+        /// <summary>
+        /// Returns the storage entries of <paramref name="scriptHash"/> as of the cursor's current position, taken
+        /// from the most recent storage record at or before it.
+        /// </summary>
+        public IEnumerable<(ReadOnlyMemory<byte> key, StorageItem value)> FindStorage(UInt160 scriptHash)
+        {
+            foreach (var rec in _previous)
+            {
+                if (rec is StorageRecord storage && storage.ScriptHash.Equals(scriptHash))
+                    return storage.Storages.Select(kvp => ((ReadOnlyMemory<byte>)kvp.Key, kvp.Value));
+            }
+
+            return Enumerable.Empty<(ReadOnlyMemory<byte>, StorageItem)>();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            if (!_leaveOpen)
+                _stream.Dispose();
+        }
+    }
+}

--- a/test/test.bctklib/TraceDebugReaderTests.cs
+++ b/test/test.bctklib/TraceDebugReaderTests.cs
@@ -1,0 +1,176 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TraceDebugReaderTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using MessagePack;
+using MessagePack.Resolvers;
+using Neo;
+using Neo.BlockchainToolkit.TraceDebug;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+using StackItem = Neo.VM.Types.StackItem;
+
+namespace test.bctklib
+{
+    public class TraceDebugReaderTests
+    {
+        static readonly UInt160 ContractHash = UInt160.Parse("0x0000000000000000000000000000000000000001");
+        static readonly Script ContractScript = new(new byte[] { (byte)OpCode.PUSH1, (byte)OpCode.RET });
+
+        // ProtocolSettings(7) + Script(5) are side records; Trace(0)/Storage(6)/Results(3) are returned.
+        static byte[] SampleTrace() => Serialize(
+            new ProtocolSettingsRecord(0x1234u, 0x35),
+            new ScriptRecord(ContractHash, ContractScript),
+            Trace(VMState.NONE, 100, instructionPointer: 0),
+            new StorageRecord(ContractHash, new Dictionary<byte[], StorageItem> { [new byte[] { 0x10 }] = new StorageItem(new byte[] { 0x20 }) }),
+            Trace(VMState.NONE, 150, instructionPointer: 2),
+            new ResultsRecord(VMState.HALT, 200, new StackItem[] { new Neo.VM.Types.Integer(42) }));
+
+        static TraceRecord Trace(VMState state, long gas, int instructionPointer)
+        {
+            var frame = new TraceRecord.StackFrame(
+                ContractHash, ContractHash, instructionPointer, hasCatch: false,
+                evaluationStack: new StackItem[] { new Neo.VM.Types.Integer(7) },
+                localVariables: Array.Empty<StackItem>(),
+                staticFields: Array.Empty<StackItem>(),
+                arguments: Array.Empty<StackItem>());
+            return new TraceRecord(state, gas, new[] { frame });
+        }
+
+        static byte[] Serialize(params ITraceDebugRecord[] records)
+        {
+            var options = MessagePackSerializerOptions.Standard.WithResolver(TraceDebugResolver.Instance);
+            using var ms = new MemoryStream();
+            foreach (var record in records)
+                MessagePackSerializer.Serialize<ITraceDebugRecord>(ms, record, options);
+            return ms.ToArray();
+        }
+
+        static TraceDebugReader Open(byte[] trace) => new(new MemoryStream(trace), leaveOpen: false);
+
+        [Fact]
+        public void returns_main_records_in_order_and_absorbs_side_records()
+        {
+            using var reader = Open(SampleTrace());
+
+            var kinds = new List<string>();
+            while (reader.TryGetNext(out var record))
+                kinds.Add(record.GetType().Name);
+
+            Assert.Equal(
+                new[] { nameof(TraceRecord), nameof(StorageRecord), nameof(TraceRecord), nameof(ResultsRecord) },
+                kinds);
+        }
+
+        [Fact]
+        public void lifts_network_and_address_version_from_protocol_settings()
+        {
+            using var reader = Open(SampleTrace());
+
+            Assert.True(reader.TryGetNext(out _));
+            Assert.Equal(0x1234u, reader.Network);
+            Assert.Equal((byte)0x35, reader.AddressVersion);
+        }
+
+        [Fact]
+        public void resolves_contract_script_from_script_record()
+        {
+            using var reader = Open(SampleTrace());
+            reader.TryGetNext(out _);
+
+            Assert.True(reader.TryGetContract(ContractHash, out var script));
+            Assert.NotNull(script);
+            Assert.Equal(ContractScript.Length, script!.Length);
+            Assert.False(reader.TryGetContract(UInt160.Zero, out _));
+        }
+
+        [Fact]
+        public void seeded_contracts_resolve_before_their_script_record()
+        {
+            var seed = new[] { new KeyValuePair<UInt160, Script>(UInt160.Zero, ContractScript) };
+            using var reader = new TraceDebugReader(new MemoryStream(SampleTrace()), leaveOpen: false, seed);
+
+            Assert.True(reader.TryGetContract(UInt160.Zero, out _));
+        }
+
+        [Fact]
+        public void at_start_is_true_only_before_the_first_record()
+        {
+            using var reader = Open(SampleTrace());
+            Assert.True(reader.AtStart);
+
+            Assert.True(reader.TryGetNext(out _));
+            Assert.False(reader.AtStart);
+        }
+
+        [Fact]
+        public void steps_backward_in_reverse_order_to_the_start()
+        {
+            using var reader = Open(SampleTrace());
+            while (reader.TryGetNext(out _)) { }
+
+            var backward = new List<string>();
+            while (reader.TryGetPrev(out var record))
+                backward.Add(record.GetType().Name);
+
+            Assert.Equal(
+                new[] { nameof(ResultsRecord), nameof(TraceRecord), nameof(StorageRecord), nameof(TraceRecord) },
+                backward);
+            Assert.True(reader.AtStart);
+            Assert.False(reader.TryGetPrev(out _));
+        }
+
+        [Fact]
+        public void find_storage_returns_entries_for_the_current_position()
+        {
+            using var reader = Open(SampleTrace());
+
+            // Advance to the storage record (second returned record).
+            reader.TryGetNext(out _);
+            reader.TryGetNext(out _);
+
+            var entries = reader.FindStorage(ContractHash).ToList();
+            Assert.Single(entries);
+            Assert.Equal(new byte[] { 0x10 }, entries[0].key.ToArray());
+            Assert.Equal(new byte[] { 0x20 }, entries[0].value.Value.ToArray());
+
+            Assert.Empty(reader.FindStorage(UInt160.Zero));
+        }
+
+        [Fact]
+        public void preserves_trace_record_state_and_gas()
+        {
+            using var reader = Open(SampleTrace());
+
+            Assert.True(reader.TryGetNext(out var first));
+            var trace = Assert.IsType<TraceRecord>(first);
+            Assert.Equal(VMState.NONE, trace.State);
+            Assert.Equal(100, trace.GasConsumed);
+            Assert.Single(trace.StackFrames);
+            Assert.Equal(0, trace.StackFrames[0].InstructionPointer);
+        }
+
+        [Fact]
+        public void next_after_end_keeps_history_intact_for_step_back()
+        {
+            using var reader = Open(SampleTrace());
+            while (reader.TryGetNext(out _)) { }
+
+            // A failed next must not corrupt the cursor: stepping back still yields the last record.
+            Assert.False(reader.TryGetNext(out _));
+            Assert.True(reader.TryGetPrev(out var record));
+            Assert.IsType<ResultsRecord>(record);
+        }
+    }
+}

--- a/test/test.bctklib/TraceDebugReaderTests.cs
+++ b/test/test.bctklib/TraceDebugReaderTests.cs
@@ -118,7 +118,9 @@ namespace test.bctklib
         public void steps_backward_in_reverse_order_to_the_start()
         {
             using var reader = Open(SampleTrace());
-            while (reader.TryGetNext(out _)) { }
+            while (reader.TryGetNext(out _))
+            {
+            }
 
             var backward = new List<string>();
             while (reader.TryGetPrev(out var record))
@@ -165,7 +167,9 @@ namespace test.bctklib
         public void next_after_end_keeps_history_intact_for_step_back()
         {
             using var reader = Open(SampleTrace());
-            while (reader.TryGetNext(out _)) { }
+            while (reader.TryGetNext(out _))
+            {
+            }
 
             // A failed next must not corrupt the cursor: stepping back still yields the last record.
             Assert.False(reader.TryGetNext(out _));


### PR DESCRIPTION
## What

Adds `TraceDebugReader` to bctklib — the read/replay counterpart to the existing `TraceDebugStream` writer. It streams MessagePack `ITraceDebugRecord` records off a `.neo-trace` and exposes a forward/backward cursor:

```csharp
using var reader = new TraceDebugReader(traceFilePath);
while (reader.TryGetNext(out var record)) { /* step forward */ }
while (reader.TryGetPrev(out var record)) { /* step backward (time-travel) */ }
```

- `TryGetNext` / `TryGetPrev` walk the *main* records (trace, notify, log, results, fault, storage).
- `ScriptRecord` and `ProtocolSettingsRecord` are side records, absorbed silently and surfaced via `TryGetContract`, `Network`, and `AddressVersion`.
- `FindStorage(scriptHash)` returns a contract's storage as of the cursor's current position.
- `AtStart` reports whether the cursor is before the first record; backward movement is served from already-read history, so the underlying stream is read forward only once.

## Why

bctklib already had everything to *produce* a trace (`TraceDebugStream`, the record schema, `TraceDebugResolver`) but nothing to *consume* one — there was no `Deserialize<ITraceDebugRecord>` cursor. A source-level (DAP) debugger replays a recorded execution by stepping such a cursor, so this is the foundational primitive the replay backend builds on (tracking issue #708). It's wire-compatible with the traces `neotrace` already writes.

## Tests

`TraceDebugReaderTests` (9 tests, all passing), built hermetically by serializing a known record sequence through the existing `TraceDebugResolver` and reading it back: record order with side-records absorbed, network/address-version lift, script resolution (incl. seeded contracts), `AtStart` semantics, reverse stepping back to the start, `FindStorage` at the current position, trace state/gas round-trip, and that a failed `TryGetNext` leaves the cursor intact for step-back.

Part of #708.