### PR TITLE
[debugger 5] Add the variable and scope rendering pipeline

### DIFF
--- a/src/neodebug/DebugSession.Prefixes.cs
+++ b/src/neodebug/DebugSession.Prefixes.cs
@@ -1,0 +1,25 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DebugSession.Prefixes.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace NeoDebug.Neo3
+{
+    // The expression prefixes that name the VM's slots and storage in scopes and evaluate expressions
+    // (for example "#local0" or "#storage[..]"). Defined here so the variable containers can reference them
+    // before the rest of DebugSession exists; the session behaviour is added in the same partial class later.
+    internal partial class DebugSession
+    {
+        public const string EVAL_STACK_PREFIX = "#eval";
+        public const string RESULT_STACK_PREFIX = "#result";
+        public const string STORAGE_PREFIX = "#storage";
+        public const string ARG_SLOTS_PREFIX = "#arg";
+        public const string LOCAL_SLOTS_PREFIX = "#local";
+        public const string STATIC_SLOTS_PREFIX = "#static";
+    }
+}

--- a/src/neodebug/Extensions.cs
+++ b/src/neodebug/Extensions.cs
@@ -120,6 +120,17 @@ namespace NeoDebug.Neo3
 
         public static int GetSequenceHashCode(this byte[] array) => GetSequenceHashCode(array.AsSpan());
 
+        public static string ToMapKeyString(this Neo.VM.Types.PrimitiveType item)
+        {
+            return item switch
+            {
+                Neo.VM.Types.Boolean @bool => @bool.GetBoolean().ToString(),
+                Neo.VM.Types.ByteString byteString => byteString.GetSpan().ToHexString(),
+                Neo.VM.Types.Integer @int => @int.GetInteger().ToString(),
+                _ => item.GetSpan().ToHexString(),
+            };
+        }
+
         public static JToken ToJson(this StackItem item)
         {
             return item switch

--- a/src/neodebug/Extensions.cs
+++ b/src/neodebug/Extensions.cs
@@ -104,22 +104,6 @@ namespace NeoDebug.Neo3
             return false;
         }
 
-        // https://stackoverflow.com/a/1646913 — a deterministic hash over the bytes, used to address storage rows.
-        public static int GetSequenceHashCode(this ReadOnlySpan<byte> span)
-        {
-            unchecked
-            {
-                int hash = 17;
-                for (int i = 0; i < span.Length; i++)
-                {
-                    hash = (hash * 31) + span[i];
-                }
-                return hash;
-            }
-        }
-
-        public static int GetSequenceHashCode(this byte[] array) => GetSequenceHashCode(array.AsSpan());
-
         public static string ToMapKeyString(this Neo.VM.Types.PrimitiveType item)
         {
             return item switch

--- a/src/neodebug/Extensions.cs
+++ b/src/neodebug/Extensions.cs
@@ -1,0 +1,226 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Extensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using Neo.SmartContract;
+using Newtonsoft.Json.Linq;
+using System.Diagnostics.CodeAnalysis;
+using ByteString = Neo.VM.Types.ByteString;
+using StackItem = Neo.VM.Types.StackItem;
+using StackItemType = Neo.VM.Types.StackItemType;
+
+namespace NeoDebug.Neo3
+{
+    internal static class Extensions
+    {
+        public static bool StartsWith<T>(this ReadOnlyMemory<T> @this, ReadOnlySpan<T> value)
+            where T : IEquatable<T>
+        {
+            return @this.Length >= value.Length
+                && @this[..value.Length].Span.SequenceEqual(value);
+        }
+
+        public static bool TryGetMethod(this DebugInfo? debugInfo, int instructionPointer, [MaybeNullWhen(false)] out DebugInfo.Method method)
+        {
+            if (debugInfo is not null)
+            {
+                foreach (var m in debugInfo.Methods)
+                {
+                    if (m.Range.Start <= instructionPointer && instructionPointer <= m.Range.End)
+                    {
+                        method = m;
+                        return true;
+                    }
+                }
+            }
+            method = default;
+            return false;
+        }
+
+        public static bool TryGetDocumentPath(this DebugInfo.SequencePoint @this, DebugInfo? debugInfo, out string path)
+        {
+            if (debugInfo is not null && @this.Document < debugInfo.Documents.Count)
+            {
+                path = debugInfo.Documents[@this.Document];
+                return true;
+            }
+
+            path = "";
+            return false;
+        }
+
+        public static bool PathEquals(this DebugInfo.SequencePoint @this, DebugInfo? debugInfo, string path)
+        {
+            return @this.TryGetDocumentPath(debugInfo, out var documentPath)
+                && string.Equals(path, documentPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool TryGetCurrentSequencePoint(this DebugInfo.Method? method, int instructionPointer, out DebugInfo.SequencePoint sequencePoint)
+        {
+            if (method.HasValue)
+            {
+                var sequencePoints = method.Value.SequencePoints;
+                if (sequencePoints.Count > 0)
+                {
+                    for (int i = sequencePoints.Count - 1; i >= 0; i--)
+                    {
+                        if (instructionPointer >= sequencePoints[i].Address)
+                        {
+                            sequencePoint = sequencePoints[i];
+                            return true;
+                        }
+                    }
+
+                    sequencePoint = sequencePoints[0];
+                    return true;
+                }
+            }
+            sequencePoint = default;
+            return false;
+        }
+
+        public static bool TryFind<T>(this IEnumerable<T> @this, Predicate<T> predicate, [MaybeNullWhen(false)] out T value)
+        {
+            foreach (var v in @this)
+            {
+                if (predicate(v))
+                {
+                    value = v;
+                    return true;
+                }
+            }
+            value = default;
+            return false;
+        }
+
+        // https://stackoverflow.com/a/1646913 — a deterministic hash over the bytes, used to address storage rows.
+        public static int GetSequenceHashCode(this ReadOnlySpan<byte> span)
+        {
+            unchecked
+            {
+                int hash = 17;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    hash = (hash * 31) + span[i];
+                }
+                return hash;
+            }
+        }
+
+        public static int GetSequenceHashCode(this byte[] array) => GetSequenceHashCode(array.AsSpan());
+
+        public static JToken ToJson(this StackItem item)
+        {
+            return item switch
+            {
+                Neo.VM.Types.Boolean _ => item.GetBoolean(),
+                Neo.VM.Types.Buffer buffer => buffer.GetSpan().ToHexString(),
+                Neo.VM.Types.ByteString byteString => byteString.GetSpan().ToHexString(),
+                Neo.VM.Types.Integer @int => @int.GetInteger().ToString(),
+                Neo.VM.Types.Map map => MapToJson(map),
+                Neo.VM.Types.Null _ => new JValue((object?)null),
+                Neo.VM.Types.Array array => new JArray(array.Select(i => i.ToJson())),
+                _ => throw new NotSupportedException(),
+            };
+
+            static JObject MapToJson(Neo.VM.Types.Map map)
+            {
+                var json = new JObject();
+                foreach (var (key, value) in map)
+                {
+                    json.Add(PrimitiveTypeToString(key), value.ToJson());
+                }
+                return json;
+            }
+
+            static string PrimitiveTypeToString(Neo.VM.Types.PrimitiveType item)
+            {
+                try
+                {
+                    return item.GetString() ?? throw new Exception();
+                }
+                catch
+                {
+                    return Convert.ToHexString(item.GetSpan());
+                }
+            }
+        }
+
+        public static Variable ToVariable(this StackItem item, IVariableManager manager, string name, ContractParameterType parameterType)
+        {
+            try
+            {
+                Variable? variable = parameterType switch
+                {
+                    ContractParameterType.Boolean => NewVariable(item.GetBoolean()),
+                    ContractParameterType.ByteArray => ConvertByteArray(),
+                    ContractParameterType.Hash160 => NewVariable(new UInt160(item.GetSpan())),
+                    ContractParameterType.Hash256 => NewVariable(new UInt256(item.GetSpan())),
+                    ContractParameterType.Integer => NewVariable(item.GetInteger()),
+                    ContractParameterType.PublicKey => NewVariable(ECPoint.DecodePoint(item.GetSpan(), ECCurve.Secp256r1)),
+                    ContractParameterType.Signature => ConvertByteArray(),
+                    ContractParameterType.String => NewVariable(item.GetString()),
+                    _ => null,
+                };
+
+                if (variable != null)
+                    return variable;
+            }
+            catch { }
+
+            return item.ToVariable(manager, name);
+
+            Variable? NewVariable(object? obj) => obj == null ? null : new Variable { Name = name, Value = obj.ToString(), Type = parameterType.ToString() };
+
+            Variable? ConvertByteArray()
+            {
+                if (item.IsNull)
+                    return new Variable { Name = name, Value = "<null>", Type = parameterType.ToString() };
+                if (item is Neo.VM.Types.Buffer buffer)
+                    return ByteArrayContainer.Create(manager, buffer, name);
+                if (item is ByteString byteString)
+                    return ByteArrayContainer.Create(manager, byteString, name);
+                if (item is Neo.VM.Types.PrimitiveType)
+                {
+                    byteString = (ByteString)item.ConvertTo(StackItemType.ByteString);
+                    return ByteArrayContainer.Create(manager, (ReadOnlyMemory<byte>)byteString, name);
+                }
+                return null;
+            }
+        }
+
+        public static Variable ToVariable(this StackItem item, IVariableManager manager, string name)
+        {
+            return item switch
+            {
+                Neo.VM.Types.Array array => NeoArrayContainer.Create(manager, array, name),
+                Neo.VM.Types.Boolean _ => new Variable { Name = name, Value = $"{item.GetBoolean()}", Type = "Boolean" },
+                Neo.VM.Types.Buffer buffer => ByteArrayContainer.Create(manager, buffer, name),
+                Neo.VM.Types.ByteString byteString => ByteArrayContainer.Create(manager, byteString, name),
+                Neo.VM.Types.Integer @int => new Variable { Name = name, Value = $"{@int.GetInteger()}", Type = "Integer" },
+                Neo.VM.Types.InteropInterface _ => new Variable { Name = name, Value = "InteropInterface" },
+                Neo.VM.Types.Map map => NeoMapContainer.Create(manager, map, name),
+                Neo.VM.Types.Null _ => new Variable { Name = name, Value = "<null>", Type = "Null" },
+                Neo.VM.Types.Pointer _ => new Variable { Name = name, Value = "Pointer" },
+                _ => throw new NotSupportedException(),
+            };
+        }
+
+        public static BigDecimal AsBigDecimal(this long value, byte? decimals = null)
+        {
+            decimals ??= Neo.SmartContract.Native.NativeContract.GAS.Decimals;
+            return new BigDecimal((System.Numerics.BigInteger)value, decimals.Value);
+        }
+    }
+}

--- a/src/neodebug/IApplicationEngine.cs
+++ b/src/neodebug/IApplicationEngine.cs
@@ -37,8 +37,6 @@ namespace NeoDebug.Neo3
 
         /// <summary>Returns whether the current invocation stack contains a catch block.</summary>
         bool CatchBlockOnStack();
-
-        /// <summary>Advances execution to the next VM instruction and updates the current engine state.</summary>
         bool ExecuteNextInstruction();
 
         /// <summary>Moves execution back to the previous VM instruction when the backend supports it.</summary>

--- a/src/neodebug/IApplicationEngine.cs
+++ b/src/neodebug/IApplicationEngine.cs
@@ -37,6 +37,8 @@ namespace NeoDebug.Neo3
 
         /// <summary>Returns whether the current invocation stack contains a catch block.</summary>
         bool CatchBlockOnStack();
+
+        /// <summary>Advances execution to the next VM instruction and updates the current engine state.</summary>
         bool ExecuteNextInstruction();
 
         /// <summary>Moves execution back to the previous VM instruction when the backend supports it.</summary>

--- a/src/neodebug/IVariableContainer.cs
+++ b/src/neodebug/IVariableContainer.cs
@@ -1,0 +1,20 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// IVariableContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>A node in the debug variable tree that can lazily expand into child <see cref="Variable"/>s.</summary>
+    public interface IVariableContainer
+    {
+        IEnumerable<Variable> Enumerate(IVariableManager manager);
+    }
+}

--- a/src/neodebug/IVariableManager.cs
+++ b/src/neodebug/IVariableManager.cs
@@ -1,0 +1,18 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// IVariableManager.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>Hands out the DAP <c>variablesReference</c> handles that tie a parent variable to its child container.</summary>
+    public interface IVariableManager
+    {
+        int Add(IVariableContainer container);
+    }
+}

--- a/src/neodebug/VariableContainers/ByteArrayContainer.cs
+++ b/src/neodebug/VariableContainers/ByteArrayContainer.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ByteArrayContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using Buffer = Neo.VM.Types.Buffer;
+using ByteString = Neo.VM.Types.ByteString;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>Expands a byte sequence (a <see cref="ByteString"/> or <see cref="Buffer"/>) into per-byte child variables.</summary>
+    internal class ByteArrayContainer : IVariableContainer
+    {
+        private readonly ReadOnlyMemory<byte> _memory;
+
+        private ByteArrayContainer(ReadOnlyMemory<byte> memory)
+        {
+            _memory = memory;
+        }
+
+        public static Variable Create(IVariableManager manager, ByteString byteString, string name)
+            => ToVariable(manager, new ByteArrayContainer(byteString), name, "ByteString");
+
+        public static Variable Create(IVariableManager manager, Buffer buffer, string name)
+            => ToVariable(manager, new ByteArrayContainer(buffer.InnerBuffer), name, "Buffer");
+
+        public static Variable Create(IVariableManager manager, ReadOnlyMemory<byte> memory, string name)
+            => ToVariable(manager, new ByteArrayContainer(memory), name, "ByteString");
+
+        private static Variable ToVariable(IVariableManager manager, ByteArrayContainer container, string name, string type)
+        {
+            return new Variable()
+            {
+                Name = name,
+                Value = $"{type}[{container._memory.Length}]",
+                VariablesReference = manager.Add(container),
+                IndexedVariables = container._memory.Length,
+            };
+        }
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            for (int i = 0; i < _memory.Length; i++)
+            {
+                yield return new Variable()
+                {
+                    Name = i.ToString(),
+                    Value = "0x" + _memory.Span[i].ToString("x"),
+                    Type = "Byte",
+                };
+            }
+        }
+    }
+}

--- a/src/neodebug/VariableContainers/EngineContainer.cs
+++ b/src/neodebug/VariableContainers/EngineContainer.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// EngineContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>Exposes engine-wide state (such as gas consumed) as a debug scope.</summary>
+    internal class EngineContainer : IVariableContainer
+    {
+        private readonly IApplicationEngine _engine;
+
+        public EngineContainer(IApplicationEngine engine)
+        {
+            _engine = engine;
+        }
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            yield return new Variable
+            {
+                Name = nameof(IApplicationEngine.GasConsumed),
+                Value = _engine.GasConsumed.AsBigDecimal().ToString(),
+            };
+        }
+    }
+}

--- a/src/neodebug/VariableContainers/ExecutionContextContainer.cs
+++ b/src/neodebug/VariableContainers/ExecutionContextContainer.cs
@@ -43,8 +43,8 @@ namespace NeoDebug.Neo3
 
             static IEnumerable<Variable> EnumerateSlot(IVariableManager manager, string prefix, IReadOnlyList<StackItem>? slot, IReadOnlyList<DebugInfo.SlotVariable>? variableList = null)
             {
-                variableList ??= Array.Empty<DebugInfo.SlotVariable>();
-                slot ??= Array.Empty<StackItem>();
+                variableList ??= [];
+                slot ??= [];
 
                 for (int i = 0; i < variableList.Count; i++)
                 {

--- a/src/neodebug/VariableContainers/ExecutionContextContainer.cs
+++ b/src/neodebug/VariableContainers/ExecutionContextContainer.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExecutionContextContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using Neo.BlockchainToolkit.Models;
+using Neo.SmartContract;
+using StackItem = Neo.VM.Types.StackItem;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>
+    /// Renders a frame's named arguments, locals and statics by pairing each VM slot with the matching
+    /// debug-info variable (name, type and slot index), falling back to typeless rendering without debug info.
+    /// </summary>
+    internal class ExecutionContextContainer : IVariableContainer
+    {
+        private readonly IExecutionContext _context;
+        private readonly DebugInfo? _debugInfo;
+
+        public ExecutionContextContainer(IExecutionContext context, DebugInfo? debugInfo)
+        {
+            _context = context;
+            _debugInfo = debugInfo;
+        }
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            DebugInfo.Method? method = _debugInfo.TryGetMethod(_context.InstructionPointer, out var foundMethod)
+                ? foundMethod : null;
+
+            var args = EnumerateSlot(manager, DebugSession.ARG_SLOTS_PREFIX, _context.Arguments, method?.Parameters);
+            var locals = EnumerateSlot(manager, DebugSession.LOCAL_SLOTS_PREFIX, _context.LocalVariables, method?.Variables);
+            var statics = EnumerateSlot(manager, DebugSession.STATIC_SLOTS_PREFIX, _context.StaticFields, _debugInfo?.StaticVariables);
+
+            return args.Concat(locals).Concat(statics);
+
+            static IEnumerable<Variable> EnumerateSlot(IVariableManager manager, string prefix, IReadOnlyList<StackItem>? slot, IReadOnlyList<DebugInfo.SlotVariable>? variableList = null)
+            {
+                variableList ??= Array.Empty<DebugInfo.SlotVariable>();
+                slot ??= Array.Empty<StackItem>();
+
+                for (int i = 0; i < variableList.Count; i++)
+                {
+                    var slotIndex = variableList[i].Index;
+                    var type = Enum.TryParse<ContractParameterType>(variableList[i].Type, out var parsedType)
+                        ? parsedType
+                        : ContractParameterType.Any;
+                    var item = slotIndex < slot.Count ? slot[slotIndex] : StackItem.Null;
+                    var variable = item.ToVariable(manager, variableList[i].Name, type);
+                    variable.EvaluateName = variable.Name;
+                    yield return variable;
+                }
+            }
+        }
+    }
+}

--- a/src/neodebug/VariableContainers/NeoArrayContainer.cs
+++ b/src/neodebug/VariableContainers/NeoArrayContainer.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NeoArrayContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using NeoArray = Neo.VM.Types.Array;
+using NeoStruct = Neo.VM.Types.Struct;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>Expands a NeoVM array or struct into its indexed child elements.</summary>
+    internal class NeoArrayContainer : IVariableContainer
+    {
+        private readonly NeoArray _array;
+
+        public NeoArrayContainer(NeoArray array)
+        {
+            _array = array;
+        }
+
+        public static Variable Create(IVariableManager manager, NeoArray array, string name)
+        {
+            var typeName = array is NeoStruct ? "Struct" : "Array";
+            var container = new NeoArrayContainer(array);
+            return new Variable()
+            {
+                Name = name,
+                Value = $"{typeName}[{array.Count}]",
+                VariablesReference = manager.Add(container),
+                IndexedVariables = array.Count,
+            };
+        }
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            for (int i = 0; i < _array.Count; i++)
+            {
+                yield return _array[i].ToVariable(manager, $"{i}");
+            }
+        }
+    }
+}

--- a/src/neodebug/VariableContainers/NeoMapContainer.cs
+++ b/src/neodebug/VariableContainers/NeoMapContainer.cs
@@ -9,7 +9,6 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
-using Neo.Extensions;
 using NeoMap = Neo.VM.Types.Map;
 
 namespace NeoDebug.Neo3
@@ -40,18 +39,8 @@ namespace NeoDebug.Neo3
         {
             foreach (var key in _map.Keys)
             {
-                // Map keys are always primitive types; render the common ones, and fall back to a hex dump
-                // of the key bytes for anything else rather than failing the whole map.
-                var keyString = key switch
-                {
-                    Neo.VM.Types.Boolean @bool => @bool.GetBoolean().ToString(),
-                    Neo.VM.Types.ByteString byteString => byteString.GetSpan().ToHexString(),
-                    Neo.VM.Types.Integer @int => @int.GetInteger().ToString(),
-                    Neo.VM.Types.PrimitiveType primitive => primitive.GetSpan().ToHexString(),
-                    _ => key.ToString() ?? key.Type.ToString(),
-                };
-
-                yield return _map[key].ToVariable(manager, keyString);
+                // A map key becomes the child name; keep its scalar value instead of an expandable ByteString label.
+                yield return _map[key].ToVariable(manager, key.ToMapKeyString());
             }
         }
     }

--- a/src/neodebug/VariableContainers/NeoMapContainer.cs
+++ b/src/neodebug/VariableContainers/NeoMapContainer.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NeoMapContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using Neo.Extensions;
+using NeoMap = Neo.VM.Types.Map;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>Expands a NeoVM map into one child variable per entry, keyed by the rendered map key.</summary>
+    internal class NeoMapContainer : IVariableContainer
+    {
+        private readonly NeoMap _map;
+
+        public NeoMapContainer(NeoMap map)
+        {
+            _map = map;
+        }
+
+        public static Variable Create(IVariableManager manager, NeoMap map, string name)
+        {
+            var container = new NeoMapContainer(map);
+            return new Variable()
+            {
+                Name = name,
+                Value = $"Map[{map.Count}]",
+                VariablesReference = manager.Add(container),
+                NamedVariables = map.Count,
+            };
+        }
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            foreach (var key in _map.Keys)
+            {
+                // Map keys are always primitive types; render the common ones, and fall back to a hex dump
+                // of the key bytes for anything else rather than failing the whole map.
+                var keyString = key switch
+                {
+                    Neo.VM.Types.Boolean @bool => @bool.GetBoolean().ToString(),
+                    Neo.VM.Types.ByteString byteString => byteString.GetSpan().ToHexString(),
+                    Neo.VM.Types.Integer @int => @int.GetInteger().ToString(),
+                    Neo.VM.Types.PrimitiveType primitive => primitive.GetSpan().ToHexString(),
+                    _ => key.ToString() ?? key.Type.ToString(),
+                };
+
+                yield return _map[key].ToVariable(manager, keyString);
+            }
+        }
+    }
+}

--- a/src/neodebug/VariableContainers/SlotContainer.cs
+++ b/src/neodebug/VariableContainers/SlotContainer.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SlotContainer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using System.Collections.Immutable;
+using StackItem = Neo.VM.Types.StackItem;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>Renders a raw VM slot (evaluation stack, arguments, locals, statics, result stack) as indexed variables.</summary>
+    internal class SlotContainer : IVariableContainer
+    {
+        private readonly IReadOnlyList<StackItem> _slot;
+        private readonly string _prefix;
+
+        public SlotContainer(string prefix, IReadOnlyList<StackItem>? slot)
+        {
+            _slot = slot ?? ImmutableList<StackItem>.Empty;
+            _prefix = prefix;
+        }
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            for (int i = 0; i < _slot.Count; i++)
+            {
+                var variable = _slot[i].ToVariable(manager, $"{_prefix}{i}");
+                variable.EvaluateName = variable.Name;
+                yield return variable;
+            }
+        }
+    }
+}

--- a/src/neodebug/VariableContainers/StorageContainerBase.cs
+++ b/src/neodebug/VariableContainers/StorageContainerBase.cs
@@ -10,14 +10,13 @@
 
 using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
 using Neo.SmartContract;
-using System.Globalization;
 using StackItem = Neo.VM.Types.StackItem;
 
 namespace NeoDebug.Neo3
 {
     /// <summary>
     /// Renders a contract's storage as debug variables (one entry per key, each expandable into its key and
-    /// value bytes) and resolves <c>#storage[hash].key|item</c> evaluate expressions. Subclasses supply the
+    /// value bytes) and resolves <c>#storage[key-hex].key|item</c> evaluate expressions. Subclasses supply the
     /// storage rows for a given backend.
     /// </summary>
     internal abstract class StorageContainerBase : IVariableContainer
@@ -28,11 +27,11 @@ namespace NeoDebug.Neo3
         {
             foreach (var (key, item) in GetStorages())
             {
-                var keyHashCode = key.Span.GetSequenceHashCode().ToString("x8");
-                var kvp = new KvpContainer(key, item, keyHashCode);
+                var keyIdentifier = Convert.ToHexString(key.Span).ToLowerInvariant();
+                var kvp = new KvpContainer(key, item, keyIdentifier);
                 yield return new Variable()
                 {
-                    Name = keyHashCode,
+                    Name = keyIdentifier,
                     Value = string.Empty,
                     VariablesReference = manager.Add(kvp),
                     NamedVariables = 2,
@@ -42,10 +41,10 @@ namespace NeoDebug.Neo3
 
         public (StackItem? item, ReadOnlyMemory<char> remaining) Evaluate(ReadOnlyMemory<char> expression)
         {
-            if (TryGetKeyHash(expression, out var keyHash)
-                && TryFindStorage(GetStorages(), keyHash, out var storage))
+            if (TryGetKeyIdentifier(expression, out var keyIdentifier, out var remainingOffset)
+                && TryFindStorage(GetStorages(), keyIdentifier.Span, out var storage))
             {
-                var remain = expression.Slice(19);
+                var remain = expression.Slice(remainingOffset);
                 if (remain.Length >= 3 && remain.Span.Slice(0, 3).SequenceEqual("key"))
                 {
                     return (storage.key, remain.Slice(3));
@@ -58,27 +57,54 @@ namespace NeoDebug.Neo3
 
             throw new InvalidOperationException("Invalid storage evaluation");
 
-            static bool TryGetKeyHash(ReadOnlyMemory<char> expression, out int value)
+            static bool TryGetKeyIdentifier(ReadOnlyMemory<char> expression,
+                out ReadOnlyMemory<char> keyIdentifier, out int remainingOffset)
             {
-                if (expression.Length >= 19
+                var prefixLength = DebugSession.STORAGE_PREFIX.Length;
+                var keyStart = prefixLength + 1;
+                if (expression.Length >= keyStart + 2
                     && expression.StartsWith(DebugSession.STORAGE_PREFIX)
-                    && expression.Span[8] == '['
-                    && expression.Span[17] == ']'
-                    && expression.Span[18] == '.'
-                    && int.TryParse(expression.Slice(9, 8).Span, NumberStyles.HexNumber, null, out value))
+                    && expression.Span[prefixLength] == '[')
                 {
-                    return true;
+                    var closingOffset = expression.Span[keyStart..].IndexOf(']');
+                    if (closingOffset >= 0)
+                    {
+                        var closingIndex = keyStart + closingOffset;
+                        var candidate = expression.Slice(keyStart, closingOffset);
+                        if (closingIndex + 1 < expression.Length
+                            && expression.Span[closingIndex + 1] == '.'
+                            && candidate.Length % 2 == 0
+                            && IsHexIdentifier(candidate.Span))
+                        {
+                            keyIdentifier = candidate;
+                            remainingOffset = closingIndex + 2;
+                            return true;
+                        }
+                    }
                 }
 
-                value = default;
+                keyIdentifier = default;
+                remainingOffset = default;
                 return false;
             }
 
-            static bool TryFindStorage(IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> storages, int hashCode, out (ReadOnlyMemory<byte> key, StorageItem item) storage)
+            static bool IsHexIdentifier(ReadOnlySpan<char> value)
+            {
+                foreach (var character in value)
+                {
+                    if (!char.IsAsciiHexDigit(character))
+                        return false;
+                }
+
+                return true;
+            }
+
+            static bool TryFindStorage(IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> storages,
+                ReadOnlySpan<char> keyIdentifier, out (ReadOnlyMemory<byte> key, StorageItem item) storage)
             {
                 foreach (var (key, item) in storages)
                 {
-                    if (hashCode == key.Span.GetSequenceHashCode())
+                    if (keyIdentifier.Equals(Convert.ToHexString(key.Span), StringComparison.OrdinalIgnoreCase))
                     {
                         storage = (key, item);
                         return true;

--- a/src/neodebug/VariableContainers/StorageContainerBase.cs
+++ b/src/neodebug/VariableContainers/StorageContainerBase.cs
@@ -1,0 +1,131 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StorageContainerBase.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using Neo.SmartContract;
+using System.Globalization;
+using StackItem = Neo.VM.Types.StackItem;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>
+    /// Renders a contract's storage as debug variables (one entry per key, each expandable into its key and
+    /// value bytes) and resolves <c>#storage[hash].key|item</c> evaluate expressions. Subclasses supply the
+    /// storage rows for a given backend.
+    /// </summary>
+    internal abstract class StorageContainerBase : IVariableContainer
+    {
+        protected abstract IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> GetStorages();
+
+        public IEnumerable<Variable> Enumerate(IVariableManager manager)
+        {
+            foreach (var (key, item) in GetStorages())
+            {
+                var keyHashCode = key.Span.GetSequenceHashCode().ToString("x8");
+                var kvp = new KvpContainer(key, item, keyHashCode);
+                yield return new Variable()
+                {
+                    Name = keyHashCode,
+                    Value = string.Empty,
+                    VariablesReference = manager.Add(kvp),
+                    NamedVariables = 2,
+                };
+            }
+        }
+
+        public (StackItem? item, ReadOnlyMemory<char> remaining) Evaluate(ReadOnlyMemory<char> expression)
+        {
+            if (TryGetKeyHash(expression, out var keyHash)
+                && TryFindStorage(GetStorages(), keyHash, out var storage))
+            {
+                var remain = expression.Slice(19);
+                if (remain.Length >= 3 && remain.Span.Slice(0, 3).SequenceEqual("key"))
+                {
+                    return (storage.key, remain.Slice(3));
+                }
+                else if (remain.Length >= 4 && remain.Span.Slice(0, 4).SequenceEqual("item"))
+                {
+                    return (storage.item.Value, remain.Slice(4));
+                }
+            }
+
+            throw new InvalidOperationException("Invalid storage evaluation");
+
+            static bool TryGetKeyHash(ReadOnlyMemory<char> expression, out int value)
+            {
+                if (expression.Length >= 18
+                    && expression.StartsWith(DebugSession.STORAGE_PREFIX)
+                    && expression.Span[8] == '['
+                    && expression.Span[17] == ']'
+                    && expression.Span[18] == '.'
+                    && int.TryParse(expression.Slice(9, 8).Span, NumberStyles.HexNumber, null, out value))
+                {
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            static bool TryFindStorage(IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> storages, int hashCode, out (ReadOnlyMemory<byte> key, StorageItem item) storage)
+            {
+                foreach (var (key, item) in storages)
+                {
+                    if (hashCode == key.Span.GetSequenceHashCode())
+                    {
+                        storage = (key, item);
+                        return true;
+                    }
+                }
+
+                storage = default;
+                return false;
+            }
+        }
+
+        private class KvpContainer : IVariableContainer
+        {
+            private readonly ReadOnlyMemory<byte> _key;
+            private readonly StorageItem _item;
+            private readonly string _prefix;
+
+            public KvpContainer(ReadOnlyMemory<byte> key, StorageItem item, string hashCode)
+            {
+                _key = key;
+                _item = item;
+                _prefix = $"{DebugSession.STORAGE_PREFIX}[{hashCode}].";
+            }
+
+            public IEnumerable<Variable> Enumerate(IVariableManager manager)
+            {
+                var keyItem = ByteArrayContainer.Create(manager, _key, "key");
+                keyItem.EvaluateName = _prefix + "key";
+                yield return keyItem;
+
+                var valueItem = ByteArrayContainer.Create(manager, _item.Value, "item");
+                valueItem.EvaluateName = _prefix + "item";
+                yield return valueItem;
+            }
+        }
+    }
+
+    /// <summary>A <see cref="StorageContainerBase"/> over an already-materialized set of storage rows.</summary>
+    internal sealed class StorageContainer : StorageContainerBase
+    {
+        private readonly IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> _storages;
+
+        public StorageContainer(IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> storages)
+        {
+            _storages = storages;
+        }
+
+        protected override IEnumerable<(ReadOnlyMemory<byte> key, StorageItem item)> GetStorages() => _storages;
+    }
+}

--- a/src/neodebug/VariableContainers/StorageContainerBase.cs
+++ b/src/neodebug/VariableContainers/StorageContainerBase.cs
@@ -60,7 +60,7 @@ namespace NeoDebug.Neo3
 
             static bool TryGetKeyHash(ReadOnlyMemory<char> expression, out int value)
             {
-                if (expression.Length >= 18
+                if (expression.Length >= 19
                     && expression.StartsWith(DebugSession.STORAGE_PREFIX)
                     && expression.Span[8] == '['
                     && expression.Span[17] == ']'

--- a/src/neodebug/VariableManager.cs
+++ b/src/neodebug/VariableManager.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// VariableManager.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace NeoDebug.Neo3
+{
+    /// <summary>
+    /// Tracks the variable containers referenced in the current stop and assigns each a stable, non-zero
+    /// <c>variablesReference</c> handle. The table is cleared each time execution stops.
+    /// </summary>
+    public class VariableManager : IVariableManager
+    {
+        private readonly Dictionary<int, IVariableContainer> _containers = new();
+        private int _nextId = 1;
+
+        public void Clear()
+        {
+            _containers.Clear();
+            _nextId = 1;
+        }
+
+        public bool TryGet(int id, [MaybeNullWhen(false)] out IVariableContainer container)
+            => _containers.TryGetValue(id, out container);
+
+        // A monotonically increasing id avoids the hash-collision failure of keying on GetHashCode, and
+        // keeps every handle non-zero (a variablesReference of 0 means "no children" in the protocol).
+        public int Add(IVariableContainer container)
+        {
+            var id = _nextId++;
+            _containers.Add(id, container);
+            return id;
+        }
+    }
+}

--- a/test/test.neodebug/VariableRenderingTests.cs
+++ b/test/test.neodebug/VariableRenderingTests.cs
@@ -138,6 +138,14 @@ namespace test.neodebug
         }
 
         [Fact]
+        public void storage_container_rejects_short_evaluate_expressions()
+        {
+            var container = new StorageContainer(Array.Empty<(ReadOnlyMemory<byte> key, StorageItem item)>());
+
+            Assert.Throws<InvalidOperationException>(() => container.Evaluate("#storage[00000000]".AsMemory()));
+        }
+
+        [Fact]
         public void execution_context_renders_named_locals_from_debug_info()
         {
             var context = new FakeContext

--- a/test/test.neodebug/VariableRenderingTests.cs
+++ b/test/test.neodebug/VariableRenderingTests.cs
@@ -151,6 +151,30 @@ namespace test.neodebug
         }
 
         [Fact]
+        public void storage_container_uses_full_keys_to_disambiguate_hash_collisions()
+        {
+            var rows = new (ReadOnlyMemory<byte> key, StorageItem item)[]
+            {
+                (new byte[] { 0x00, 0x1f }, new StorageItem(new byte[] { 0xaa })),
+                (new byte[] { 0x01, 0x00 }, new StorageItem(new byte[] { 0xbb })),
+            };
+            var container = new StorageContainer(rows);
+
+            var entries = container.Enumerate(_manager).ToList();
+            Assert.Equal(new[] { "001f", "0100" }, entries.Select(entry => entry.Name));
+            Assert.Equal("#storage[001f].item", Expand(entries[0]).Single(child => child.Name == "item").EvaluateName);
+            Assert.Equal("#storage[0100].item", Expand(entries[1]).Single(child => child.Name == "item").EvaluateName);
+
+            var (first, firstRemaining) = container.Evaluate("#storage[001f].item".AsMemory());
+            var (second, secondRemaining) = container.Evaluate("#storage[0100].item".AsMemory());
+
+            Assert.True(firstRemaining.IsEmpty);
+            Assert.True(secondRemaining.IsEmpty);
+            Assert.Equal(new byte[] { 0xaa }, first!.GetSpan().ToArray());
+            Assert.Equal(new byte[] { 0xbb }, second!.GetSpan().ToArray());
+        }
+
+        [Fact]
         public void storage_container_rejects_short_evaluate_expressions()
         {
             var container = new StorageContainer(Array.Empty<(ReadOnlyMemory<byte> key, StorageItem item)>());

--- a/test/test.neodebug/VariableRenderingTests.cs
+++ b/test/test.neodebug/VariableRenderingTests.cs
@@ -1,0 +1,175 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// VariableRenderingTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Neo.SmartContract;
+using Neo.VM;
+using NeoDebug.Neo3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using NeoArray = Neo.VM.Types.Array;
+using NeoMap = Neo.VM.Types.Map;
+using Script = Neo.VM.Script;
+using StackItem = Neo.VM.Types.StackItem;
+
+namespace test.neodebug
+{
+    public class VariableRenderingTests
+    {
+        private readonly VariableManager _manager = new();
+
+        private List<Variable> Expand(Variable parent)
+        {
+            Assert.True(_manager.TryGet(parent.VariablesReference, out var container));
+            return container!.Enumerate(_manager).ToList();
+        }
+
+        [Fact]
+        public void integer_renders_with_the_integer_type()
+        {
+            var variable = ((StackItem)new Neo.VM.Types.Integer(42)).ToVariable(_manager, "n");
+
+            Assert.Equal("n", variable.Name);
+            Assert.Equal("42", variable.Value);
+            Assert.Equal("Integer", variable.Type); // regression: the reference mislabeled integers as "Boolean".
+        }
+
+        [Fact]
+        public void boolean_null_and_pointer_render_their_types()
+        {
+            Assert.Equal("Boolean", StackItem.True.ToVariable(_manager, "b").Type);
+            Assert.Equal("True", StackItem.True.ToVariable(_manager, "b").Value);
+
+            var @null = StackItem.Null.ToVariable(_manager, "z");
+            Assert.Equal("Null", @null.Type);
+            Assert.Equal("<null>", @null.Value);
+
+            var pointer = ((StackItem)new Neo.VM.Types.Pointer(new Script(new byte[] { (byte)OpCode.RET }), 0)).ToVariable(_manager, "p");
+            Assert.Equal("Pointer", pointer.Value);
+        }
+
+        [Fact]
+        public void byte_string_expands_into_per_byte_children()
+        {
+            var bytes = new byte[] { 0x01, 0x0a, 0xff };
+            var variable = ((StackItem)new Neo.VM.Types.ByteString(bytes)).ToVariable(_manager, "data");
+
+            Assert.Equal("ByteString[3]", variable.Value);
+            Assert.Equal(3, variable.IndexedVariables);
+
+            var children = Expand(variable);
+            Assert.Equal(3, children.Count);
+            Assert.Equal("0xff", children[2].Value);
+            Assert.Equal("Byte", children[0].Type);
+        }
+
+        [Fact]
+        public void array_expands_into_indexed_children()
+        {
+            var array = new NeoArray(new StackItem[] { new Neo.VM.Types.Integer(1), new Neo.VM.Types.Integer(2) });
+            var variable = ((StackItem)array).ToVariable(_manager, "arr");
+
+            Assert.Equal("Array[2]", variable.Value);
+            Assert.Equal(2, variable.IndexedVariables);
+            Assert.Equal(2, Expand(variable).Count);
+        }
+
+        [Fact]
+        public void map_renders_mixed_primitive_keys_without_throwing()
+        {
+            var map = new NeoMap
+            {
+                [new Neo.VM.Types.Integer(7)] = new Neo.VM.Types.Integer(70),
+                [new Neo.VM.Types.ByteString(new byte[] { 0xab })] = StackItem.True,
+            };
+            var variable = ((StackItem)map).ToVariable(_manager, "m");
+
+            Assert.Equal("Map[2]", variable.Value);
+            var children = Expand(variable);
+            Assert.Equal(2, children.Count);
+            Assert.Contains(children, c => c.Name == "7");
+        }
+
+        [Fact]
+        public void variable_manager_hands_out_increasing_nonzero_ids_and_resets()
+        {
+            var a = new SlotContainer("#a", Array.Empty<StackItem>());
+            var b = new SlotContainer("#b", Array.Empty<StackItem>());
+
+            var idA = _manager.Add(a);
+            var idB = _manager.Add(b);
+            Assert.Equal(1, idA);
+            Assert.Equal(2, idB);
+            Assert.True(_manager.TryGet(idA, out var got) && ReferenceEquals(got, a));
+
+            _manager.Clear();
+            Assert.False(_manager.TryGet(idA, out _));
+            Assert.Equal(1, _manager.Add(a)); // ids reset after a clear
+        }
+
+        [Fact]
+        public void storage_container_renders_one_entry_per_row_expandable_to_key_and_item()
+        {
+            var rows = new (ReadOnlyMemory<byte> key, StorageItem item)[]
+            {
+                (new byte[] { 0x01 }, new StorageItem(new byte[] { 0x02 })),
+            };
+            var container = new StorageContainer(rows);
+
+            var entries = container.Enumerate(_manager).ToList();
+            Assert.Single(entries);
+            Assert.Equal(2, entries[0].NamedVariables);
+
+            var kvp = Expand(entries[0]);
+            Assert.Equal(2, kvp.Count);
+            Assert.Equal("key", kvp[0].Name);
+            Assert.Equal("item", kvp[1].Name);
+        }
+
+        [Fact]
+        public void execution_context_renders_named_locals_from_debug_info()
+        {
+            var context = new FakeContext
+            {
+                InstructionPointer = 5,
+                LocalVariables = new StackItem[] { new Neo.VM.Types.Integer(99) },
+            };
+            var method = new DebugInfo.Method(
+                Id: "M", Namespace: "N", Name: "Run", Range: (0, 100), ReturnType: "Void",
+                Parameters: Array.Empty<DebugInfo.SlotVariable>(),
+                Variables: new[] { new DebugInfo.SlotVariable("count", "Integer", 0) },
+                SequencePoints: Array.Empty<DebugInfo.SequencePoint>());
+            var debugInfo = new DebugInfo(UInt160.Zero, "", Array.Empty<string>(), new[] { method },
+                Array.Empty<DebugInfo.Event>(), Array.Empty<DebugInfo.SlotVariable>());
+
+            var variables = new ExecutionContextContainer(context, debugInfo).Enumerate(_manager).ToList();
+
+            Assert.Contains(variables, v => v.Name == "count" && v.Value == "99");
+        }
+
+        private sealed class FakeContext : IExecutionContext
+        {
+            public Instruction? CurrentInstruction => null;
+            public int InstructionPointer { get; set; }
+            public UInt160 ScriptHash => UInt160.Zero;
+            public UInt160 ScriptIdentifier => UInt160.Zero;
+            public Script Script => new(Array.Empty<byte>());
+            public MethodToken[] Tokens => Array.Empty<MethodToken>();
+            public IReadOnlyList<StackItem> EvaluationStack { get; set; } = Array.Empty<StackItem>();
+            public IReadOnlyList<StackItem> LocalVariables { get; set; } = Array.Empty<StackItem>();
+            public IReadOnlyList<StackItem> StaticFields { get; set; } = Array.Empty<StackItem>();
+            public IReadOnlyList<StackItem> Arguments { get; set; } = Array.Empty<StackItem>();
+        }
+    }
+}

--- a/test/test.neodebug/VariableRenderingTests.cs
+++ b/test/test.neodebug/VariableRenderingTests.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Xunit;
 using NeoArray = Neo.VM.Types.Array;
 using NeoMap = Neo.VM.Types.Map;
+using NeoStruct = Neo.VM.Types.Struct;
 using Script = Neo.VM.Script;
 using StackItem = Neo.VM.Types.StackItem;
 
@@ -86,6 +87,17 @@ namespace test.neodebug
         }
 
         [Fact]
+        public void struct_preserves_its_type_while_using_indexed_children()
+        {
+            var @struct = new NeoStruct { new Neo.VM.Types.Integer(1) };
+            var variable = ((StackItem)@struct).ToVariable(_manager, "value");
+
+            Assert.Equal("Struct[1]", variable.Value);
+            Assert.Equal(1, variable.IndexedVariables);
+            Assert.Single(Expand(variable));
+        }
+
+        [Fact]
         public void map_renders_mixed_primitive_keys_without_throwing()
         {
             var map = new NeoMap
@@ -99,6 +111,7 @@ namespace test.neodebug
             var children = Expand(variable);
             Assert.Equal(2, children.Count);
             Assert.Contains(children, c => c.Name == "7");
+            Assert.Contains(children, c => c.Name == "ab");
         }
 
         [Fact]


### PR DESCRIPTION
## What

Projects NeoVM `StackItem`s and slot variables into Debug Adapter Protocol `Variable`s and `Scope`s — the value-presentation layer the debug session renders at every stop:

- **`Extensions.ToVariable`** — typed conversion (using the debug-info `ContractParameterType`: hash160/256, public key, integer, string, byte array…) and a typeless fallback.
- **`VariableManager`** — the handle table that assigns each container its DAP `variablesReference`.
- **Containers** — lazily expanding `NeoArrayContainer` (array/struct), `NeoMapContainer`, `ByteArrayContainer` (per-byte), `SlotContainer` (eval stack / args / locals / statics), `ExecutionContextContainer` (named args/locals/statics from debug info), `EngineContainer` (gas), and `StorageContainerBase` + `StorageContainer` (storage rows, with `#storage[..]` evaluate support).

## Bug fixes carried during the port

Three latent bugs in the reference renderer are fixed rather than reproduced:
1. **Integers were mislabeled** with `Type = "Boolean"` → now `"Integer"`.
2. **Maps threw** `NotImplementedException` on any non-(bool/bytestring/integer) key → now render a hex fallback instead of failing the whole map.
3. **The variable handle table keyed on `GetHashCode`** (collisions threw a bare `Exception`, and a 0 hash collides with "no children") → now a monotonically increasing, non-zero id, reset on `Clear`.

## Drift

`ToHexString` moved to `Neo.Extensions` in Neo 3.10 (updated usings).

## Tests

`VariableRenderingTests` (8 tests, all passing): integer/boolean/null/pointer types, byte-string per-byte expansion, array expansion, mixed-key map rendering, the variable-manager id/clear contract, storage rows expanding to key/item, and named locals resolved from debug info.

The disassembly view lands with the debug session that consumes it. **Stacked on #712** (`[debugger 4]`). Part of #708.