### PR TITLE
Fix EnsureLedgerInitialized to actually persist the genesis block

### DIFF
--- a/src/bctklib/Extensions.cs
+++ b/src/bctklib/Extensions.cs
@@ -274,21 +274,39 @@ namespace Neo.BlockchainToolkit
         // replicated logic from Blockchain.OnInitialized + Blockchain.Persist
         public static void EnsureLedgerInitialized(this IStore store, ProtocolSettings settings)
         {
-            using var storeSnapshot = store.GetSnapshot();
-            if (LedgerInitialized(storeSnapshot))
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            if (LedgerInitialized(snapshot))
                 return;
 
             var block = NeoSystem.CreateGenesisBlock(settings);
             if (block.Transactions.Length != 0)
                 throw new Exception("Unexpected Transactions in genesis block");
 
-            // For Neo 3.8.2, we need to create a proper DataCache implementation
-            // Since we can't easily create one from IStoreSnapshot, we'll skip the engine execution
-            // This is a simplified version that just checks if the ledger is initialized
-            // In a full implementation, you would need a proper DataCache implementation
+            // Persist the genesis block by running the native OnPersist and PostPersist scripts, exactly as
+            // the blockchain does for block 0. Without this the ledger is left empty and any ApplicationEngine
+            // constructed over the store throws when it reads LedgerContract.CurrentIndex.
+            using (var engine = ApplicationEngine.Create(TriggerType.OnPersist, null, snapshot, block, settings, 0L))
+            {
+                using var scriptBuilder = new ScriptBuilder();
+                scriptBuilder.EmitSysCall(ApplicationEngine.System_Contract_NativeOnPersist);
+                engine.LoadScript(scriptBuilder.ToArray());
+                if (engine.Execute() != VMState.HALT)
+                    throw new InvalidOperationException("NativeOnPersist operation failed", engine.FaultException);
+            }
+
+            using (var engine = ApplicationEngine.Create(TriggerType.PostPersist, null, snapshot, block, settings, 0L))
+            {
+                using var scriptBuilder = new ScriptBuilder();
+                scriptBuilder.EmitSysCall(ApplicationEngine.System_Contract_NativePostPersist);
+                engine.LoadScript(scriptBuilder.ToArray());
+                if (engine.Execute() != VMState.HALT)
+                    throw new InvalidOperationException("NativePostPersist operation failed", engine.FaultException);
+            }
+
+            snapshot.Commit();
 
             // replicated logic from LedgerContract.Initialized
-            static bool LedgerInitialized(IStoreSnapshot snapshot)
+            static bool LedgerInitialized(DataCache snapshot)
             {
                 const byte Prefix_Block = 5;
                 var key = new KeyBuilder(NativeContract.Ledger.Id, Prefix_Block).ToArray();

--- a/test/test.bctklib/EnsureLedgerInitializedTests.cs
+++ b/test/test.bctklib/EnsureLedgerInitializedTests.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// EnsureLedgerInitializedTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract.Native;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class EnsureLedgerInitializedTests
+    {
+        [Fact]
+        public void persists_genesis_so_an_engine_can_read_the_current_index()
+        {
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(DeployedContractFixture.Default);
+
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            // Constructing an ApplicationEngine reads LedgerContract.CurrentIndex; before the fix the ledger
+            // was never persisted, so this threw KeyNotFoundException.
+            using var engine = new TestApplicationEngine(snapshot, DeployedContractFixture.Default);
+
+            Assert.Equal(0u, NativeContract.Ledger.CurrentIndex(snapshot));
+        }
+
+        [Fact]
+        public void is_idempotent()
+        {
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(DeployedContractFixture.Default);
+            // A second call must be a no-op (the ledger is already initialized), not a double-persist failure.
+            store.EnsureLedgerInitialized(DeployedContractFixture.Default);
+
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            Assert.Equal(0u, NativeContract.Ledger.CurrentIndex(snapshot));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Neo.BlockchainToolkit.Extensions.EnsureLedgerInitialized(this IStore store, ProtocolSettings settings)` created the genesis block but then **skipped persisting it** — its own comment said it would "skip the engine execution" as "a simplified version." As a result the ledger was never initialized, and **any `ApplicationEngine` constructed over the resulting store threw `KeyNotFoundException`** when it read `LedgerContract.CurrentIndex` in its constructor.

The one in-tree caller, `runner/Program.cs`, relies on this to initialize the ledger for a checkpoint-backed invocation, so it was relying on a no-op.

## Fix

Persist the genesis block the way the blockchain does for block 0: over a `StoreCache` (which wraps the `IStoreSnapshot` the old comment claimed couldn't be used), run the native **OnPersist** and **PostPersist** scripts, then `Commit()`. The existing "already initialized" check keeps the call idempotent. This mirrors the working logic in `test/test.bctklib/DeployedContractFixture.cs`.

## Tests

New `EnsureLedgerInitializedTests`:
- after the call, an `ApplicationEngine` constructs and `LedgerContract.CurrentIndex` reads as `0` (previously threw);
- a second call is a no-op.

Full `test.bctklib` suite is green (**327 passed**).