### PR TITLE
Send the required force property when updating storage on a running node

### DIFF
--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -291,19 +291,31 @@ namespace NeoExpress.Node
                 throw new Exception(NodeUtility.ContractNotFoundMessage(scripthash));
             }
 
-            JObject o = new JObject();
-            o["state"] = state.ToJson();
-
-            JArray storage = new JArray();
-            JObject kv = new JObject();
-            kv["key"] = storagePair.key;
-            kv["value"] = storagePair.value;
-            storage.Add(kv);
-
-            o["storage"] = storage;
+            var o = BuildPersistStoragePayload(state.ToJson(), storagePair);
 
             var response = await rpcClient.RpcSendAsync("expresspersiststorage", o).ConfigureAwait(false);
             return (int)response.AsNumber();
+        }
+
+        internal static JObject BuildPersistStoragePayload(JToken state, (string key, string value) storagePair)
+        {
+            var o = new JObject();
+            o["state"] = state;
+
+            var storage = new JArray();
+            var kv = new JObject();
+            kv["key"] = storagePair.key;
+            kv["value"] = storagePair.value;
+            storage.Add(kv);
+            o["storage"] = storage;
+
+            // The ExpressPersistStorage RPC handler requires a "force" property
+            // (it does Enum.Parse<OverwriteForce> on it), and the offline path
+            // always persists storage with OverwriteForce.None. Omitting it made
+            // every storage update against a running node fail with the server
+            // error "Invalid params: missing 'force'".
+            o["force"] = ContractCommand.OverwriteForce.None;
+            return o;
         }
 
         public async IAsyncEnumerable<(uint blockIndex, NotificationRecord notification)> EnumerateNotificationsAsync(IReadOnlySet<UInt160>? contractFilter, IReadOnlySet<string>? eventFilter)

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -11,7 +11,9 @@
 using FluentAssertions;
 using Neo;
 using Neo.BlockchainToolkit.Models;
+using Neo.Json;
 using Neo.Network.RPC;
+using NeoExpress.Commands;
 using NeoExpress.Node;
 using System;
 using System.Reflection;
@@ -54,5 +56,23 @@ public class OnlineNodeTests
         };
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BuildPersistStoragePayload_includes_a_force_the_server_accepts()
+    {
+        var state = new JObject();
+
+        var payload = OnlineNode.BuildPersistStoragePayload(state, ("AQ==", "Ag=="));
+
+        // The ExpressPersistStorage handler rejects the request unless "force"
+        // is present and parses as an OverwriteForce; without it every online
+        // storage update failed with "Invalid params: missing 'force'".
+        var force = Enum.Parse<ContractCommand.OverwriteForce>(payload["force"]!.AsString());
+        force.Should().Be(ContractCommand.OverwriteForce.None);
+
+        payload["state"].Should().BeSameAs(state);
+        payload["storage"]![0]!["key"]!.AsString().Should().Be("AQ==");
+        payload["storage"]![0]!["value"]!.AsString().Should().Be("Ag==");
     }
 }

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -62,7 +62,6 @@ public class OnlineNodeTests
     public void BuildPersistStoragePayload_includes_a_force_the_server_accepts()
     {
         var state = new JObject();
-
         var payload = OnlineNode.BuildPersistStoragePayload(state, ("AQ==", "Ag=="));
 
         // The ExpressPersistStorage handler rejects the request unless "force"


### PR DESCRIPTION
## Problem

`contract storage update` fails **100% of the time against a running node**. `OnlineNode.PersistStorageKeyValueAsync` ([OnlineNode.cs:294-303](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L294)) builds the `expresspersiststorage` payload with only `state` and `storage`:

```csharp
JObject o = new JObject();
o["state"] = state.ToJson();
// ... storage ...
o["storage"] = storage;
// no "force"
```

But the server handler requires `force` ([ExpressRpcServerPlugin.cs:693](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs#L693)):

```csharp
var force = ParseParam(() => Enum.Parse<ContractCommand.OverwriteForce>(RequiredStringProperty(payload, "force")));
```

`RequiredStringProperty` throws `Invalid params: missing 'force'` when the property is absent, so the request is always rejected. The sibling `PersistContractAsync` works precisely because it **does** send `force` ([OnlineNode.cs:275](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L275)); only the storage path omitted it. The offline path is unaffected because `OfflineNode.PersistStorageKeyValueAsync` calls `NodeUtility.PersistStorageKeyValuePair(..., OverwriteForce.None)` directly without going through RPC.

## Fix

Send `OverwriteForce.None` — matching the offline path, which always persists storage with `OverwriteForce.None`. The payload construction is extracted into an `internal static BuildPersistStoragePayload` helper so the behavior is unit-testable.

## Tests

Added `BuildPersistStoragePayload_includes_a_force_the_server_accepts` to `OnlineNodeTests`: it builds the payload and asserts `force` is present and parses as `OverwriteForce.None` using the server's exact `Enum.Parse<OverwriteForce>` expression, plus that `state` and the `storage` entry are carried through. Removing the `force` line makes the test fail (verified). Release build is clean and `dotnet format --verify-no-changes` reports no changes.

## Note

No automated test exercised this RPC round-trip previously, which is why the regression went unnoticed.