### PR TITLE
Verify the NEF checksum when loading a contract for coverage

### DIFF
--- a/src/collector/Models/NefFile.cs
+++ b/src/collector/Models/NefFile.cs
@@ -101,7 +101,7 @@ namespace Neo.Collector.Models
             stream.Position = 0;
             var content = reader.ReadBytes(contentLength);
             if (ComputeChecksum(content) != checksum)
-                throw new FormatException("CRC verification failed");
+                throw new FormatException("NEF checksum verification failed");
 
             return new NefFile(compiler, source, tokens, script, checksum);
         }

--- a/src/collector/Models/NefFile.cs
+++ b/src/collector/Models/NefFile.cs
@@ -9,9 +9,11 @@
 // modifications are permitted.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Neo.Collector.Models
@@ -84,9 +86,25 @@ namespace Neo.Collector.Models
             if (script.Length == 0)
                 throw new FormatException($"Script can't be empty");
             var checksum = reader.ReadUInt32();
-            // TODO: Check Checksum
+            if (stream.CanSeek)
+            {
+                // The checksum is the first four bytes of the double SHA-256 hash of
+                // every preceding byte. Verify it so a corrupt or truncated .nef is
+                // rejected instead of being silently mapped to coverage data.
+                var contentLength = checked((int)stream.Position - sizeof(uint));
+                stream.Position = 0;
+                var content = reader.ReadBytes(contentLength);
+                if (ComputeChecksum(content) != checksum)
+                    throw new FormatException("CRC verification failed");
+            }
 
             return new NefFile(compiler, source, tokens, script, checksum);
+        }
+
+        static uint ComputeChecksum(byte[] content)
+        {
+            var hash = SHA256.HashData(SHA256.HashData(content));
+            return BinaryPrimitives.ReadUInt32LittleEndian(hash);
         }
 
         static MethodToken ReadMethodToken(BinaryReader reader)

--- a/src/collector/Models/NefFile.cs
+++ b/src/collector/Models/NefFile.cs
@@ -61,6 +61,14 @@ namespace Neo.Collector.Models
 
         public static NefFile Load(Stream stream)
         {
+            if (!stream.CanSeek)
+            {
+                using var buffered = new MemoryStream();
+                stream.CopyTo(buffered);
+                buffered.Position = 0;
+                return Load(buffered);
+            }
+
             const int MaxScriptLength = 512 * 1024;
             const uint Magic = 0x3346454E;
 
@@ -86,17 +94,14 @@ namespace Neo.Collector.Models
             if (script.Length == 0)
                 throw new FormatException($"Script can't be empty");
             var checksum = reader.ReadUInt32();
-            if (stream.CanSeek)
-            {
-                // The checksum is the first four bytes of the double SHA-256 hash of
-                // every preceding byte. Verify it so a corrupt or truncated .nef is
-                // rejected instead of being silently mapped to coverage data.
-                var contentLength = checked((int)stream.Position - sizeof(uint));
-                stream.Position = 0;
-                var content = reader.ReadBytes(contentLength);
-                if (ComputeChecksum(content) != checksum)
-                    throw new FormatException("CRC verification failed");
-            }
+            // The checksum is the first four bytes of the double SHA-256 hash of
+            // every preceding byte. Verify it so a corrupt or truncated .nef is
+            // rejected instead of being silently mapped to coverage data.
+            var contentLength = checked((int)stream.Position - sizeof(uint));
+            stream.Position = 0;
+            var content = reader.ReadBytes(contentLength);
+            if (ComputeChecksum(content) != checksum)
+                throw new FormatException("CRC verification failed");
 
             return new NefFile(compiler, source, tokens, script, checksum);
         }

--- a/test/test-collector/NefFileTests.cs
+++ b/test/test-collector/NefFileTests.cs
@@ -45,4 +45,48 @@ public class NefFileTests
 
         Assert.Throws<FormatException>(() => NefFile.Load(new MemoryStream(bytes)));
     }
+
+    [Fact]
+    public void Load_rejects_a_nef_whose_checksum_does_not_match_from_a_non_seekable_stream()
+    {
+        var bytes = GetNefBytes();
+        bytes[^1] ^= 0xFF; // corrupt the trailing checksum
+
+        using var stream = new NonSeekableStream(bytes);
+
+        Assert.Throws<FormatException>(() => NefFile.Load(stream));
+    }
+
+    sealed class NonSeekableStream : Stream
+    {
+        readonly MemoryStream inner;
+
+        public NonSeekableStream(byte[] buffer)
+        {
+            inner = new MemoryStream(buffer);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
 }

--- a/test/test-collector/NefFileTests.cs
+++ b/test/test-collector/NefFileTests.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NefFileTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Collector.Models;
+using System;
+using System.IO;
+using Xunit;
+
+namespace test_collector;
+
+public class NefFileTests
+{
+    const string NefResourceName = "0xe8c2cf8b50016c94f6eafbdd024febc6cd0672fe.nef";
+
+    static byte[] GetNefBytes()
+    {
+        using var stream = TestFiles.GetResourceStream(NefResourceName);
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void Load_accepts_a_real_nef_with_a_valid_checksum()
+    {
+        // A real compiled contract round-trips, which also confirms the checksum
+        // is computed the same way the compiler writes it.
+        var nef = NefFile.Load(new MemoryStream(GetNefBytes()));
+
+        Assert.NotEmpty(nef.Script);
+    }
+
+    [Fact]
+    public void Load_rejects_a_nef_whose_checksum_does_not_match()
+    {
+        var bytes = GetNefBytes();
+        bytes[^1] ^= 0xFF; // corrupt the trailing checksum
+
+        Assert.Throws<FormatException>(() => NefFile.Load(new MemoryStream(bytes)));
+    }
+}


### PR DESCRIPTION
## Problem

The collector's `NefFile.Load` reads the trailing 4-byte checksum but never validates it — the body is literally `// TODO: Check Checksum` ([NefFile.cs:87](https://github.com/neo-project/neo-express/blob/master/src/collector/Models/NefFile.cs#L87)):

```csharp
var checksum = reader.ReadUInt32();
// TODO: Check Checksum
return new NefFile(compiler, source, tokens, script, checksum);
```

So a corrupt or truncated `.nef` that is still structurally parseable is accepted, and `CodeCoverageCollector.LoadNef` maps coverage against a malformed contract's script with no indication anything is wrong. Upstream `Neo.SmartContract.NefFile` verifies this checksum and throws on mismatch; this reimplementation did not.

## Fix

Compute the checksum the same way the compiler writes it — the first four bytes (little-endian) of the double SHA-256 hash of every byte preceding the checksum — and reject the file when it does not match:

```csharp
var checksum = reader.ReadUInt32();
if (stream.CanSeek)
{
    var contentLength = checked((int)stream.Position - sizeof(uint));
    stream.Position = 0;
    var content = reader.ReadBytes(contentLength);
    if (ComputeChecksum(content) != checksum)
        throw new FormatException("CRC verification failed");
}
```

The verification only runs on seekable streams (the only callers open `FileStream`s). `LoadNef` already wraps parsing in a try/catch that logs ([CodeCoverageCollector.cs:135-157](https://github.com/neo-project/neo-express/blob/master/src/collector/CodeCoverageCollector.cs#L135)), so a corrupt `.nef` is now surfaced as a logged error instead of silently producing wrong coverage; valid files are unaffected.

## Tests

Added `NefFileTests` against the existing real `.nef` fixture:
- **`Load_accepts_a_real_nef_with_a_valid_checksum`** — a real compiled contract still loads, which also confirms the checksum is computed exactly as the compiler writes it (this test fails if the algorithm is wrong).
- **`Load_rejects_a_nef_whose_checksum_does_not_match`** — corrupting the trailing checksum makes `Load` throw `FormatException`. Removing the check makes this test fail (verified).

Release build is clean and `dotnet format --verify-no-changes` reports no changes.