### PR TITLE
Guard against a null script container when logging offline executions

### DIFF
--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -104,8 +104,14 @@ namespace NeoExpress.Node
 
             var contract = NativeContract.ContractManagement.GetContract(neoSystem.StoreView, args.ScriptHash);
             var name = contract is null ? args.ScriptHash.ToString() : contract.Manifest.Name;
-            Console.WriteLine($"\x1b[35m{name}\x1b[0m Log: \x1b[{colorCode}m\"{args.Message}\"\x1b[0m [{args.ScriptContainer.GetType().Name}]");
+            Console.WriteLine($"\x1b[35m{name}\x1b[0m Log: \x1b[{colorCode}m\"{args.Message}\"\x1b[0m{FormatScriptContainer(args.ScriptContainer)}");
         }
+
+        // args.ScriptContainer is null for executions without a transaction container
+        // (e.g. verification triggers), so guard it the way ExpressLogPlugin does
+        // rather than dereferencing it for the type name.
+        internal static string FormatScriptContainer(IVerifiable? container)
+            => container is null ? string.Empty : $" [{container.GetType().Name}]";
 
         Task<T> MakeAsync<T>(Func<T> func)
         {

--- a/test/test.workflowvalidation/OfflineNodeTests.cs
+++ b/test/test.workflowvalidation/OfflineNodeTests.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OfflineNodeTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.Network.P2P.Payloads;
+using NeoExpress.Node;
+using System;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class OfflineNodeTests
+{
+    [Fact]
+    public void FormatScriptContainer_returns_empty_for_a_null_container()
+    {
+        // A log emitted without a transaction container (e.g. a verification
+        // trigger) must not dereference the null container.
+        OfflineNode.FormatScriptContainer(null).Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void FormatScriptContainer_wraps_the_type_name_when_present()
+    {
+        var tx = new Transaction
+        {
+            Signers = Array.Empty<Signer>(),
+            Attributes = Array.Empty<TransactionAttribute>(),
+            Witnesses = Array.Empty<Witness>(),
+        };
+        OfflineNode.FormatScriptContainer(tx).Should().Be(" [Transaction]");
+    }
+}


### PR DESCRIPTION
## Problem

`OfflineNode.OnLog` formats the log line with `args.ScriptContainer.GetType().Name` and **no null check** ([OfflineNode.cs:107](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OfflineNode.cs#L107)):

```csharp
var tx = engine.ScriptContainer as Transaction;   // line 102: container treated as nullable
...
Console.WriteLine($"...\x1b[0m [{args.ScriptContainer.GetType().Name}]");  // line 107: dereferenced
```

Line 102 already treats the container as possibly-null (`as Transaction`). A log emitted during an execution that has **no transaction container** (for example a verification trigger) makes `args.ScriptContainer` null, so line 107 throws a `NullReferenceException` from inside the synchronous `ApplicationEngine.Log` handler.

The sibling handler `ExpressLogPlugin.OnAppEngineLog` already guards exactly this ([ExpressLogPlugin.cs:90-92](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/Modules/ExpressLogPlugin.cs#L90)):

```csharp
var container = args.ScriptContainer is null
    ? string.Empty
    : $" [{args.ScriptContainer.GetType().Name}]";
```

## Fix

Format the container suffix through a `FormatScriptContainer` helper that returns an empty string when the container is null, matching the plugin's behavior. Output is unchanged when the container is present.

## Tests

Added `OfflineNodeTests`:
- `FormatScriptContainer_returns_empty_for_a_null_container` — the null case returns `string.Empty` instead of throwing (removing the guard makes this test fail, verified).
- `FormatScriptContainer_wraps_the_type_name_when_present` — a present container still yields ` [Transaction]`.

Release build is clean and `dotnet format --verify-no-changes` reports no changes.