### PR TITLE
Remove an unused JObject allocation in ExpressListTokenContracts

### DIFF
--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -144,7 +144,6 @@ namespace NeoExpress.Node
             using var snapshot = neoSystem.GetSnapshotCache();
             foreach (var contract in snapshot.EnumerateTokenContracts(neoSystem.Settings))
             {
-                var jsonContract = new JObject();
                 jsonContracts.Add(contract.ToJson());
             }
             return jsonContracts;


### PR DESCRIPTION
## Problem

The `expresslisttokencontracts` handler allocates a `JObject` in the loop body and then adds `contract.ToJson()` to the array instead, so the local is never used ([ExpressRpcServerPlugin.cs:147-148](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs#L147)):

```csharp
foreach (var contract in snapshot.EnumerateTokenContracts(neoSystem.Settings))
{
    var jsonContract = new JObject();   // never used
    jsonContracts.Add(contract.ToJson());
}
```

## Fix

Drop the dead allocation. The response is unchanged — `contract.ToJson()` is still what gets added — this just removes a throwaway object allocated once per token contract.

Release build is clean and `dotnet format --verify-no-changes` reports no changes.