### PR TITLE
Resolve the signing password in the policy commands

### DIFF
--- a/src/neoxp/Commands/PolicyCommand.Block.cs
+++ b/src/neoxp/Commands/PolicyCommand.Block.cs
@@ -54,7 +54,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    await txExec.BlockAsync(ScriptHash, Account, Password).ConfigureAwait(false);
+                    await txExec.BlockAsync(ScriptHash, Account, password).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)

--- a/src/neoxp/Commands/PolicyCommand.Set.cs
+++ b/src/neoxp/Commands/PolicyCommand.Set.cs
@@ -57,9 +57,10 @@ namespace NeoExpress.Commands
                 try
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+                    var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
 
-                    await txExec.SetPolicyAsync(Policy, Value, Account, Password).ConfigureAwait(false);
+                    await txExec.SetPolicyAsync(Policy, Value, Account, password).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)

--- a/src/neoxp/Commands/PolicyCommand.Sync.cs
+++ b/src/neoxp/Commands/PolicyCommand.Sync.cs
@@ -52,6 +52,7 @@ namespace NeoExpress.Commands
                 try
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
+                    var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
 
                     var values = await txExec.TryGetRemoteNetworkPolicyAsync(Source).ConfigureAwait(false);
@@ -62,7 +63,7 @@ namespace NeoExpress.Commands
 
                     if (values.TryPickT0(out var policyValues, out var _))
                     {
-                        await txExec.SetPolicyAsync(policyValues, Account, Password).ConfigureAwait(false);
+                        await txExec.SetPolicyAsync(policyValues, Account, password).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/neoxp/Commands/PolicyCommand.Unblock.cs
+++ b/src/neoxp/Commands/PolicyCommand.Unblock.cs
@@ -54,7 +54,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    await txExec.UnblockAsync(ScriptHash, Account, Password).ConfigureAwait(false);
+                    await txExec.UnblockAsync(ScriptHash, Account, password).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Problem

The four `policy` transaction commands mishandle the fee-paying account's password when it is an external NEP-2/NEP-6 wallet (referenced by address or encrypted key) and `--password` is omitted:

- **`policy block` / `policy unblock`** compute the resolved password but then pass the **raw** option:
  ```csharp
  var password = chainManager.Chain.ResolvePassword(Account, Password); // computed
  await txExec.BlockAsync(ScriptHash, Account, Password);                // ...but Password is passed
  ```
  The `password` local was computed and discarded ([PolicyCommand.Block.cs:55-57](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/PolicyCommand.Block.cs#L55), [PolicyCommand.Unblock.cs:55-57](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/PolicyCommand.Unblock.cs#L55)).
- **`policy set` / `policy sync`** never call `ResolvePassword` at all, passing the raw option straight to `SetPolicyAsync` ([PolicyCommand.Set.cs:62](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/PolicyCommand.Set.cs#L62), [PolicyCommand.Sync.cs:65](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/PolicyCommand.Sync.cs#L65)).

`ResolvePassword` ([ExpressChainExtensions.cs:68](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Extensions/ExpressChainExtensions.cs#L68)) interactively prompts for the password exactly in the external-wallet case. Because the prompt result is discarded (or never obtained), the empty `--password` flows into `TryGetSigningAccount`, whose NEP-2/NEP-6 decrypt branches are gated on a non-empty password. The account therefore never unlocks and the command exits 1 with the misleading **`<account> account not found.`** — even though the account exists.

## Fix

Resolve the password and pass the resolved value in all four commands, matching the established pattern in `transfer`, `contract deploy`, `vote`, and the other transaction commands (13 callers already do this). In-chain express/consensus wallet accounts and reserved names are unaffected (they need no password).

## Note

This corrects the command-execution path, which has no unit-test harness in the repo (the commands wire up DI-constructed factories). The change is verified by inspection against the sibling commands' established pattern; the discarded `password` local in block/unblock was the direct evidence. Release build is clean and `dotnet format --verify-no-changes` reports no changes.