### PR TITLE
Parse numeric CLI arguments with the invariant culture

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -100,6 +100,7 @@ namespace NeoExpress.Commands
             for (var i = 0; i < commands.Length; i++)
             {
                 var batchApp = new CommandLineApplication<BatchFileCommands>();
+                batchApp.UseInvariantValueParsing();
                 batchApp.Conventions.UseDefaultConventions();
 
                 var args = SplitCommandLine(commands.Span[i]).ToArray();

--- a/src/neoxp/Extensions/CommandLineApplicationExtensions.cs
+++ b/src/neoxp/Extensions/CommandLineApplicationExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CommandLineApplicationExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using McMaster.Extensions.CommandLineUtils;
+using System.Globalization;
+
+namespace NeoExpress
+{
+    static class CommandLineApplicationExtensions
+    {
+        // Parse numeric arguments (e.g. decimal GAS amounts and policy values) with the
+        // invariant culture so that '.' is always the decimal separator regardless of the
+        // host machine's locale. Without this, McMaster parses with the current culture, so
+        // on a ',' decimal-separator locale (e.g. de-DE) "1.5" is rejected outright and a
+        // value typed as "1,5" is silently read differently than on an en-US machine.
+        public static void UseInvariantValueParsing(this CommandLineApplication app)
+        {
+            app.ValueParsers.ParseCulture = CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/src/neoxp/Program.cs
+++ b/src/neoxp/Program.cs
@@ -50,6 +50,7 @@ namespace NeoExpress
                 .BuildServiceProvider();
 
             var app = new CommandLineApplication<Program>();
+            app.UseInvariantValueParsing();
             app.Option<bool>("--stack-trace", "", CommandOptionType.NoValue, o => o.ShowInHelpText = false, inherited: true);
             app.Conventions
                 .UseDefaultConventions()

--- a/test/test.workflowvalidation/CommandLineApplicationExtensionsTests.cs
+++ b/test/test.workflowvalidation/CommandLineApplicationExtensionsTests.cs
@@ -1,0 +1,51 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CommandLineApplicationExtensionsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
+using NeoExpress;
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class CommandLineApplicationExtensionsTests
+{
+    class DecimalModel
+    {
+        [Option("--value")]
+        public decimal Value { get; init; }
+    }
+
+    [Fact]
+    public void UseInvariantValueParsing_parses_a_period_decimal_under_a_comma_locale()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            // de-DE uses ',' as the decimal separator. Without invariant parsing,
+            // McMaster would reject "1.5" or read it as a different value.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var app = new CommandLineApplication<DecimalModel>();
+            app.UseInvariantValueParsing();
+            app.Conventions.UseDefaultConventions();
+
+            app.Parse("--value", "1.5");
+
+            app.Model.Value.Should().Be(1.5m);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`decimal` options and arguments are parsed by McMaster using the host machine's **current culture**:
- `policy set <policy> <value>` ([PolicyCommand.Set.cs:37](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/PolicyCommand.Set.cs#L37)) and its batch form,
- `--additional-gas` on `execute`, `contract invoke`, and `contract run` ([ExecuteCommand.cs:55](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ExecuteCommand.cs#L55), [ContractCommand.Invoke.cs:47](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Invoke.cs#L47), [ContractCommand.Run.cs:53](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Run.cs#L53)).

On a locale whose decimal separator is `,` (e.g. de-DE, fr-FR):
- `neoxp policy set GasPerBlock 1.5 genesis` is rejected outright with **"1.5 is not a valid value for Decimal"**;
- a value typed as `1,5` is silently read as a *different* value than on an en-US machine.

Fractional GAS-denominated values are intentional — `SetPolicyAsync` computes the decimal scale and supports up to 8 decimal places. The transfer command already avoids this by parsing its quantity with `InvariantCulture` ([`ParseQuantity`](https://github.com/neo-project/neo-express/blob/master/src/neoxp/TransactionExecutor.cs#L524), with a comment documenting exactly this bug class), but the policy/gas decimals were not given the same treatment.

## Fix

Set `ValueParsers.ParseCulture` to `CultureInfo.InvariantCulture` for **both** the main application ([Program.cs](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Program.cs#L52)) and the batch sub-application ([BatchCommand.cs](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L102)), via a shared `UseInvariantValueParsing` helper. Numeric CLI arguments now always use `.` as the decimal separator regardless of locale — the correct, predictable behavior for a CLI, and a generalization of the existing `ParseQuantity` handling.

## Tests

Added `CommandLineApplicationExtensionsTests.UseInvariantValueParsing_parses_a_period_decimal_under_a_comma_locale`: under `de-DE`, a `decimal` option parses `1.5` to `1.5m`. Removing the helper call makes the test fail under de-DE (verified), confirming both the bug and the fix. Release build is clean and `dotnet format --verify-no-changes` reports no changes.