### PR TITLE
Filter show balances to NEP-17 contracts on a running node

### DIFF
--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -172,7 +172,12 @@ namespace NeoExpress.Node
                 .ConfigureAwait(false);
             var balanceMap = rpcBalances.Balances.ToDictionary(b => b.AssetHash, b => b.Amount);
             var contracts = await ListTokenContractsAsync().ConfigureAwait(false);
-            return contracts.Select(c => (c, balanceMap.TryGetValue(c.ScriptHash, out var value) ? value : 0)).ToList();
+            // ListTokenContractsAsync returns both NEP-11 and NEP-17 contracts; filter to
+            // NEP-17 to match the offline node (OfflineNode.ListBalances) so this NEP-17
+            // balance view does not list NEP-11 contracts as spurious zero-balance rows.
+            return contracts
+                .Where(c => c.Standard == TokenStandard.Nep17)
+                .Select(c => (c, balanceMap.TryGetValue(c.ScriptHash, out var value) ? value : 0)).ToList();
         }
 
         public async Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync()


### PR DESCRIPTION
## Problem

`neoxp show balances <account>` produces different output depending on whether the node is running.

`OnlineNode.ListBalancesAsync` ([OnlineNode.cs:174-175](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L174)) projects balances over `ListTokenContractsAsync()`, which returns **both** NEP-11 and NEP-17 token contracts, and emits a zero-balance row for every contract not present in the NEP-17 balance map:

```csharp
var contracts = await ListTokenContractsAsync().ConfigureAwait(false);
return contracts.Select(c => (c, balanceMap.TryGetValue(c.ScriptHash, out var value) ? value : 0)).ToList();
```

The offline path filters to NEP-17 ([OfflineNode.cs:321-323](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OfflineNode.cs#L321)):

```csharp
.Where(c => c.standard == TokenStandard.Nep17)
```

So against a running node, the command — documented as "Show all NEP-17 asset balances" — lists every deployed NEP-11 contract as a spurious zero-balance row, while against an offline data file it does not. Secondarily, because the online path always returns one row per deployed token contract, the "No balances for {account}" message never prints online once any token contract is deployed.

## Fix

Filter the online projection to `TokenStandard.Nep17`, matching the offline node.

## Note

This is on the online RPC path, which has no unit-test harness in the repo (it requires a live node). The one-line filter mirrors the existing, tested offline behavior. Release build is clean and `dotnet format --verify-no-changes` reports no changes.