### PR TITLE
Correct the checkpoint run multi-node error message

### DIFF
--- a/src/neoxp/Commands/CheckpointCommand.Run.cs
+++ b/src/neoxp/Commands/CheckpointCommand.Run.cs
@@ -45,7 +45,7 @@ namespace NeoExpress.Commands
                 var chain = chainManager.Chain;
                 if (chain.ConsensusNodes.Count != 1)
                 {
-                    throw new ArgumentException("Checkpoint create is only supported on single node express instances", nameof(chain));
+                    throw new ArgumentException("Checkpoint run is only supported on single node express instances", nameof(chain));
                 }
 
                 var storageProvider = chainManager.GetCheckpointStorageProvider(Name);


### PR DESCRIPTION
## Problem

`CheckpointCommand.Run` rejects multi-node chains with a message naming the wrong operation ([CheckpointCommand.Run.cs:48](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/CheckpointCommand.Run.cs#L48)):

```csharp
throw new ArgumentException("Checkpoint create is only supported on single node express instances", nameof(chain));
```

This is the `checkpoint run` command, not `create`. A user running `neoxp checkpoint run <name>` against a 4- or 7-node chain is told that *create* is unsupported, sending them to investigate the wrong command. The message is surfaced via `app.WriteException` with exit code 1.

(The identical string at [ExpressChainManager.cs:189](https://github.com/neo-project/neo-express/blob/master/src/neoxp/ExpressChainManager.cs#L189) is correct because it lives inside `CreateCheckpointAsync`; the restore guards already say "Checkpoint restore is only supported...".)

## Fix

Reference `run` instead of `create`, matching the operation actually invoked and the convention used by the sibling create/restore guards. Release build is clean and `dotnet format --verify-no-changes` reports no changes.