### PR TITLE
Report the valid node-index range in the run command

### DIFF
--- a/src/neoxp/Commands/RunCommand.cs
+++ b/src/neoxp/Commands/RunCommand.cs
@@ -43,7 +43,7 @@ namespace NeoExpress.Commands
             var chain = chainManager.Chain;
 
             if (NodeIndex < 0 || NodeIndex >= chain.ConsensusNodes.Count)
-                throw new Exception("Invalid node index");
+                throw new ArgumentException($"node-index must be in [0, {chain.ConsensusNodes.Count - 1}]", nameof(NodeIndex));
 
             var node = chain.ConsensusNodes[NodeIndex];
             var storageProvider = chainManager.GetNodeStorageProvider(node, Discard);


### PR DESCRIPTION
## Problem

`RunCommand` rejects an out-of-range `--node-index` with a bare message that gives no hint of the valid range ([RunCommand.cs:45-46](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/RunCommand.cs#L45)):

```csharp
if (NodeIndex < 0 || NodeIndex >= chain.ConsensusNodes.Count)
    throw new Exception("Invalid node index");
```

The sibling node-targeting commands are more helpful — `stop` and `reset` both throw `node-index must be in [0, N-1]` ([StopCommand.cs:73](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/StopCommand.cs#L73), [ResetCommand.cs:65](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ResetCommand.cs#L65)). A user passing `--node-index 9` to `run` on a 4-node chain just sees "Invalid node index" and must guess.

## Fix

Align `run` with `stop`/`reset`: report the valid range `[0, {count-1}]`. Behavior (rejection, non-zero exit) is unchanged; this only improves the message. Release build is clean and `dotnet format --verify-no-changes` reports no changes.