### PR TITLE
Handle duplicate contract names in worknet prefetch

### DIFF
--- a/src/worknet/Commands/PrefetchCommand.cs
+++ b/src/worknet/Commands/PrefetchCommand.cs
@@ -54,8 +54,15 @@ class PrefetchCommand
             var contracts = worknet.BranchInfo.Contracts;
             if (!UInt160.TryParse(Contract, out var contractHash))
             {
-                var info = contracts.SingleOrDefault(c => c.Name.Equals(Contract, StringComparison.OrdinalIgnoreCase));
-                contractHash = info?.Hash ?? UInt160.Zero;
+                // Manifest names are not unique on Neo N3, so more than one contract can
+                // share a name. SingleOrDefault would throw an opaque "Sequence contains
+                // more than one matching element"; tell the user to disambiguate instead.
+                var matches = contracts
+                    .Where(c => c.Name.Equals(Contract, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (matches.Count > 1)
+                    throw new Exception($"More than one contract is named \"{Contract}\". Specify the contract's script hash instead.");
+                contractHash = matches.Count == 1 ? matches[0].Hash : UInt160.Zero;
             }
 
             if (contractHash == UInt160.Zero)


### PR DESCRIPTION
## Problem

`worknet prefetch <name>` resolves the contract argument by name with `SingleOrDefault` ([PrefetchCommand.cs:57](https://github.com/neo-project/neo-express/blob/master/src/worknet/Commands/PrefetchCommand.cs#L57)):

```csharp
var info = contracts.SingleOrDefault(c => c.Name.Equals(Contract, StringComparison.OrdinalIgnoreCase));
```

If the branched network has two contracts sharing a case-insensitive manifest name, `SingleOrDefault` throws `System.InvalidOperationException: Sequence contains more than one matching element`, which the generic handler prints verbatim. Manifest names are **not** unique on Neo N3 (only the contract hash is), so against a mainnet/testnet fork this is a legitimate input, and the intended "Invalid Contract argument" guidance never fires.

## Fix

Detect the multiple-match case and throw an actionable message telling the user to pass the contract's script hash instead. A single match resolves as before; no match still yields the "Invalid Contract argument" path. (The later `SingleOrDefault(c => c.Hash == contractHash)` is left as-is since the hash is unique.)

## Note

`src/worknet` has no test project in the repo, so this is verified by Release build and inspection rather than a unit test. The change is a safe, local replacement of `SingleOrDefault` with multi-match-aware logic. `dotnet format --verify-no-changes` reports no changes.