### PR TITLE
Clarify the transfernft tokenId hex format in help text

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -301,7 +301,7 @@ namespace NeoExpress.Commands
                 [Required]
                 internal string Contract { get; init; } = string.Empty;
 
-                [Argument(1, Description = "TokenId of NFT (Format: HEX, BASE64)")]
+                [Argument(1, Description = "TokenId of NFT (Format: BASE64, or 0x-prefixed HEX)")]
                 [Required]
                 internal string TokenId { get; init; } = string.Empty;
 

--- a/src/neoxp/Commands/TransferNFTCommand.cs
+++ b/src/neoxp/Commands/TransferNFTCommand.cs
@@ -29,7 +29,7 @@ namespace NeoExpress.Commands
         [Required]
         internal string Contract { get; init; } = string.Empty;
 
-        [Argument(1, Description = "TokenId of NFT (Format: HEX, BASE64)")]
+        [Argument(1, Description = "TokenId of NFT (Format: BASE64, or 0x-prefixed HEX)")]
         [Required]
         internal string TokenId { get; init; } = string.Empty;
 


### PR DESCRIPTION
## Problem

Both `transfernft` argument descriptions read **"TokenId of NFT (Format: HEX, BASE64)"** ([TransferNFTCommand.cs:32](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/TransferNFTCommand.cs#L32), [BatchCommand.BatchFileCommands.cs:304](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs#L304)). But `TokenIdParser.Parse` only treats input as hex when it begins with a `0x` prefix ([TokenIdParser.cs:22](https://github.com/neo-project/neo-express/blob/master/src/neoxp/TokenIdParser.cs#L22)); otherwise it tries base64, then falls back to UTF-8 — never bare hex.

So a user who types a plain hex token id that is also valid base64 (e.g. `0a0b0c`) gets it silently decoded as base64 into *different* bytes, sending the wrong/nonexistent NFT with no error.

## Fix

State that hex requires a `0x` prefix: **"Format: BASE64, or 0x-prefixed HEX"**. This matches the form `show nft` already prints (`TokenId(Hex): 0x...`), which round-trips correctly. Help-text only; no behavior change. Release build is clean and `dotnet format --verify-no-changes` reports no changes.