### PR TITLE
Accept a script-hash account in show balance and show balances

### DIFF
--- a/src/neoxp/Commands/ShowCommand.Balance.cs
+++ b/src/neoxp/Commands/ShowCommand.Balance.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using McMaster.Extensions.CommandLineUtils;
+using Neo;
 using System.ComponentModel.DataAnnotations;
 
 namespace NeoExpress.Commands
@@ -29,7 +30,7 @@ namespace NeoExpress.Commands
             [Required]
             internal string Asset { get; init; } = string.Empty;
 
-            [Argument(1, Description = "Account to show asset balance for")]
+            [Argument(1, Description = "Account to show asset balance for (Format: Script Hash, Address, Wallet name)")]
             [Required]
             internal string Account { get; init; } = string.Empty;
 
@@ -43,10 +44,13 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var expressNode = chainManager.GetExpressNode();
 
-                    var getHashResult = await expressNode.TryGetAccountHashAsync(chainManager.Chain, Account).ConfigureAwait(false);
-                    if (getHashResult.TryPickT1(out _, out var accountHash))
+                    if (!UInt160.TryParse(Account, out var accountHash))
                     {
-                        throw new Exception($"{Account} account not found.");
+                        var getHashResult = await expressNode.TryGetAccountHashAsync(chainManager.Chain, Account).ConfigureAwait(false);
+                        if (getHashResult.TryPickT1(out _, out accountHash))
+                        {
+                            throw new Exception($"{Account} account not found.");
+                        }
                     }
 
                     var (balance, contract) = await expressNode.GetBalanceAsync(accountHash, Asset).ConfigureAwait(false);

--- a/src/neoxp/Commands/ShowCommand.Balances.cs
+++ b/src/neoxp/Commands/ShowCommand.Balances.cs
@@ -26,7 +26,7 @@ namespace NeoExpress.Commands
                 this.chainManagerFactory = chainManagerFactory;
             }
 
-            [Argument(0, Description = "Account to show asset balances for")]
+            [Argument(0, Description = "Account to show asset balances for (Format: Script Hash, Address, Wallet name)")]
             [Required]
             internal string Account { get; init; } = string.Empty;
 
@@ -40,10 +40,13 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var expressNode = chainManager.GetExpressNode();
 
-                    var getHashResult = await expressNode.TryGetAccountHashAsync(chainManager.Chain, Account).ConfigureAwait(false);
-                    if (getHashResult.TryPickT1(out _, out var accountHash))
+                    if (!UInt160.TryParse(Account, out var accountHash))
                     {
-                        throw new Exception($"{Account} account not found.");
+                        var getHashResult = await expressNode.TryGetAccountHashAsync(chainManager.Chain, Account).ConfigureAwait(false);
+                        if (getHashResult.TryPickT1(out _, out accountHash))
+                        {
+                            throw new Exception($"{Account} account not found.");
+                        }
                     }
 
                     var balances = await expressNode.ListBalancesAsync(accountHash).ConfigureAwait(false);


### PR DESCRIPTION
## Problem

`show balance` and `show balances` resolve the account argument only through `expressNode.TryGetAccountHashAsync` ([ShowCommand.Balance.cs:46](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ShowCommand.Balance.cs#L46), [ShowCommand.Balances.cs:43](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ShowCommand.Balances.cs#L43)), which handles wallet names, Neo addresses and WIF but **not** a `0x`-prefixed `UInt160` script hash. So passing a script hash fails with `<hash> account not found.` even though `show nft` accepts one — `show nft` adds an explicit `UInt160.TryParse` tier first ([ShowCommand.NFT.cs:48](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ShowCommand.NFT.cs#L48)).

Script hashes are a first-class identifier on Neo (returned by `contract hash`, block explorers, etc.), so the inconsistency is surprising — and the argument help ("Account to show asset balance(s) for") gave no hint a script hash was unsupported.

## Fix

Add the same leading `UInt160.TryParse` tier `show nft` uses (the existing `TryGetAccountHashAsync` continues to cover names/addresses/WIF), and update the argument descriptions to list the supported formats. Release build is clean and `dotnet format --verify-no-changes` reports no changes.

## Note

The show commands' execution path has no unit-test harness in the repo; the change mirrors the existing, working `show nft` resolution tier and is verified by Release build and inspection.