### PR TITLE
Validate required arguments in batch file commands

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -12,6 +12,7 @@ using McMaster.Extensions.CommandLineUtils;
 using Neo;
 using Neo.BlockchainToolkit;
 using Neo.Wallets;
+using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
 using static Neo.BlockchainToolkit.Constants;
 
@@ -109,6 +110,15 @@ namespace NeoExpress.Commands
                     continue;
 
                 var pr = batchApp.Parse(args);
+
+                // Parse() does not run DataAnnotations validation (only ExecuteAsync does),
+                // so enforce the [Required]/[AllowedValues] attributes on the batch models
+                // here. Otherwise a line missing a required argument is dispatched with the
+                // field defaulted to "" and fails later with a confusing downstream error.
+                var validationResult = pr.SelectedCommand.GetValidationResult();
+                if (validationResult != ValidationResult.Success)
+                    throw new Exception(validationResult?.ErrorMessage ?? $"Invalid batch command: {commands.Span[i]}");
+
                 switch (pr.SelectedCommand)
                 {
                     case CommandLineApplication<BatchFileCommands.Checkpoint.Create> cmd:

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -11,12 +11,36 @@
 using FluentAssertions;
 using McMaster.Extensions.CommandLineUtils;
 using NeoExpress.Commands;
+using System.ComponentModel.DataAnnotations;
 using Xunit;
 
 namespace test.workflowvalidation;
 
 public class BatchCommandParserTests
 {
+    [Fact]
+    public void Validation_detects_a_batch_line_missing_a_required_argument()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        // transfer requires a receiver; this line omits it.
+        var result = app.Parse("transfer", "10", "gas", "alice");
+
+        result.SelectedCommand.GetValidationResult().Should().NotBe(ValidationResult.Success);
+    }
+
+    [Fact]
+    public void Validation_passes_for_a_complete_batch_line()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("transfer", "10", "gas", "alice", "bob");
+
+        result.SelectedCommand.GetValidationResult().Should().Be(ValidationResult.Success);
+    }
+
     [Fact]
     public void Contract_update_is_a_recognized_batch_subcommand()
     {


### PR DESCRIPTION
## Problem

`BatchCommand.ExecuteAsync` dispatches each parsed line by switching on `pr.SelectedCommand` ([BatchCommand.cs:111-112](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L111)), but McMaster's `Parse()` only parses — it does **not** run DataAnnotations validation (only `ExecuteAsync` does, via the validation convention). So every `[Required]`/`[AllowedValues]` attribute on the batch models is dead in the batch path.

A batch line missing a required argument — e.g. `transfer 10 gas alice` with no receiver — is therefore parsed with the field defaulted to `""` and dispatched straight into execution, which fails later with a confusing downstream error (` account not found.` for a blank receiver) instead of the clear **"The Receiver field is required"** that the standalone `neoxp transfer` reports.

## Fix

Run `GetValidationResult()` on the selected command after parsing and throw the validation error before dispatching, so the batch path enforces the same `[Required]`/`[AllowedValues]` rules as the standalone commands.

## Tests

Added to `BatchCommandParserTests`:
- `Validation_detects_a_batch_line_missing_a_required_argument` — `transfer 10 gas alice` (no receiver) fails validation.
- `Validation_passes_for_a_complete_batch_line` — `transfer 10 gas alice bob` validates.

Release build is clean, `dotnet format --verify-no-changes` reports no changes, and the full `BatchCommandParserTests` suite passes.