### PR TITLE
Match standalone contract download in the batch form

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -74,11 +74,9 @@ namespace NeoExpress.Commands
                     internal string Contract { get; init; } = string.Empty;
 
                     [Argument(1, Description = "URL of Neo JSON-RPC Node\nSpecify MainNet (default), TestNet or JSON-RPC URL")]
-                    [Required]
                     internal string RpcUri { get; } = string.Empty;
 
-                    [Option(Description = "Block height to get contract state for")]
-                    [Required]
+                    [Option(Description = "Block height to get contract state for\nZero gets the latest")]
                     internal uint Height { get; } = 0;
 
                     [Option(CommandOptionType.SingleOrNoValue,

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -144,11 +144,6 @@ namespace NeoExpress.Commands
                         }
                     case CommandLineApplication<BatchFileCommands.Contract.Download> cmd:
                         {
-                            if (cmd.Model.Height == 0)
-                            {
-                                throw new ArgumentException("Height cannot be 0. Please specify a height > 0");
-                            }
-
                             if (chainManager.Chain.ConsensusNodes.Count != 1)
                             {
                                 throw new ArgumentException("Contract download is only supported for single-node consensus");

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -134,4 +134,18 @@ public class BatchCommandParserTests
         run.Model.AdditionalGas.Should().Be(5m);
         run.Model.Account.Should().Be("alice");
     }
+
+    [Fact]
+    public void Contract_download_does_not_require_rpc_uri_or_height()
+    {
+        // The standalone contract download leaves the RPC URI optional and treats
+        // height 0 as "latest"; the batch form must match.
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("contract", "download", "0x0102030405060708090001020304050607080900");
+
+        result.SelectedCommand.GetValidationResult()
+            .Should().Be(System.ComponentModel.DataAnnotations.ValidationResult.Success);
+    }
 }


### PR DESCRIPTION
## Problem

The standalone `contract download` leaves the RPC URI **optional** and treats height **0 as "latest"** — `NodeUtility.DownloadContractStateAsync` resolves `0` to the current validated index ([ContractCommand.Download.cs:41-48](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Download.cs#L41)).

The batch form diverged ([BatchCommand.BatchFileCommands.cs:76-82](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs#L76), [BatchCommand.cs:136-139](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L136)):
- `RpcUri` and `Height` were marked `[Required]`;
- the dispatch threw `"Height cannot be 0. Please specify a height > 0"`.

So a batch line could not download a contract's **latest** state (`contract download <hash> <rpc> 0` was rejected) and always had to pass an explicit RPC URI — contradicting the documented promise that batch commands support the same arguments as their standalone form. The batch height help also omitted the "Zero gets the latest" note.

## Fix

Drop the `[Required]` attributes and the `Height == 0` guard so the batch form accepts the same inputs as the standalone command, and add the "Zero gets the latest" note to the height description.

## Tests

Added `Contract_download_does_not_require_rpc_uri_or_height` to `BatchCommandParserTests`: `contract download <hash>` (no RPC URI / height) now validates. Re-adding `[Required]` to `RpcUri` makes it fail (verified). Release build is clean, format reports no changes, and the full `BatchCommandParserTests` suite passes.