### PR TITLE
Support --results and --gas for batch contract invoke and run

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -94,7 +94,6 @@ namespace NeoExpress.Commands
                     internal string InvocationFile { get; init; } = string.Empty;
 
                     [Argument(1, Description = "Account to pay contract invocation GAS fee")]
-                    [Required]
                     internal string Account { get; init; } = string.Empty;
 
                     [Option(Description = "password to use for NEP-2/NEP-6 account")]
@@ -103,6 +102,12 @@ namespace NeoExpress.Commands
                     [Option(Description = "Witness Scope to use for transaction signer (Default: CalledByEntry)")]
                     [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
                     internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
+
+                    [Option(Description = "Invoke contract for results (does not cost GAS)")]
+                    internal bool Results { get; init; } = false;
+
+                    [Option("--gas|-g", CommandOptionType.SingleValue, Description = "Additional GAS to apply to the contract invocation")]
+                    internal decimal AdditionalGas { get; init; } = 0;
                 }
 
                 [Command("run")]
@@ -120,7 +125,6 @@ namespace NeoExpress.Commands
                     internal string[] Arguments { get; init; } = Array.Empty<string>();
 
                     [Option(Description = "Account to pay contract invocation GAS fee")]
-                    [Required]
                     internal string Account { get; init; } = string.Empty;
 
                     [Option(Description = "password to use for NEP-2/NEP-6 account")]
@@ -129,6 +133,12 @@ namespace NeoExpress.Commands
                     [Option(Description = "Witness Scope to use for transaction signer (Default: CalledByEntry)")]
                     [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
                     internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
+
+                    [Option(Description = "Invoke contract for results (does not cost GAS)")]
+                    internal bool Results { get; init; } = false;
+
+                    [Option("--gas|-g", CommandOptionType.SingleValue, Description = "Additional GAS to apply to the contract invocation")]
+                    internal decimal AdditionalGas { get; init; } = 0;
                 }
 
                 [Command("update")]

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -158,11 +158,24 @@ namespace NeoExpress.Commands
                         {
                             var script = await txExec.LoadInvocationScriptAsync(
                                 root.Resolve(cmd.Model.InvocationFile)).ConfigureAwait(false);
-                            await txExec.ContractInvokeAsync(
-                                script,
-                                cmd.Model.Account,
-                                cmd.Model.Password,
-                                cmd.Model.WitnessScope).ConfigureAwait(false);
+                            if (cmd.Model.Results)
+                            {
+                                await txExec.InvokeForResultsAsync(
+                                    script,
+                                    cmd.Model.Account,
+                                    cmd.Model.WitnessScope).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                if (string.IsNullOrEmpty(cmd.Model.Account))
+                                    throw new Exception("Either Account or --results must be specified");
+                                await txExec.ContractInvokeAsync(
+                                    script,
+                                    cmd.Model.Account,
+                                    cmd.Model.Password,
+                                    cmd.Model.WitnessScope,
+                                    cmd.Model.AdditionalGas).ConfigureAwait(false);
+                            }
                             break;
                         }
                     case CommandLineApplication<BatchFileCommands.Contract.Run> cmd:
@@ -171,11 +184,24 @@ namespace NeoExpress.Commands
                                 cmd.Model.Contract,
                                 cmd.Model.Method,
                                 cmd.Model.Arguments).ConfigureAwait(false);
-                            await txExec.ContractInvokeAsync(
-                                script,
-                                cmd.Model.Account,
-                                cmd.Model.Password,
-                                cmd.Model.WitnessScope).ConfigureAwait(false);
+                            if (cmd.Model.Results)
+                            {
+                                await txExec.InvokeForResultsAsync(
+                                    script,
+                                    cmd.Model.Account,
+                                    cmd.Model.WitnessScope).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                if (string.IsNullOrEmpty(cmd.Model.Account))
+                                    throw new Exception("Either Account or --results must be specified");
+                                await txExec.ContractInvokeAsync(
+                                    script,
+                                    cmd.Model.Account,
+                                    cmd.Model.Password,
+                                    cmd.Model.WitnessScope,
+                                    cmd.Model.AdditionalGas).ConfigureAwait(false);
+                            }
                             break;
                         }
                     case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -81,4 +81,33 @@ public class BatchCommandParserTests
         BatchCommand.SplitCommandLine("a\"b\"c\"d\"").Should()
             .Equal("abcd");
     }
+
+    [Fact]
+    public void Contract_invoke_binds_results_and_does_not_require_account()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("contract", "invoke", "invoke.json", "--results");
+
+        var invoke = result.SelectedCommand.Should()
+            .BeOfType<CommandLineApplication<BatchCommand.BatchFileCommands.Contract.Invoke>>().Subject;
+        invoke.Model.Results.Should().BeTrue();
+        result.SelectedCommand.GetValidationResult()
+            .Should().Be(System.ComponentModel.DataAnnotations.ValidationResult.Success);
+    }
+
+    [Fact]
+    public void Contract_run_binds_additional_gas()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("contract", "run", "myContract", "myMethod", "--account", "alice", "--gas", "5");
+
+        var run = result.SelectedCommand.Should()
+            .BeOfType<CommandLineApplication<BatchCommand.BatchFileCommands.Contract.Run>>().Subject;
+        run.Model.AdditionalGas.Should().Be(5m);
+        run.Model.Account.Should().Be("alice");
+    }
 }


### PR DESCRIPTION
## Problem

The standalone `contract invoke` and `contract run` commands accept:
- `--results` — a read-only invocation that costs no GAS (with the account optional), and
- `--gas`/`-g` — additional GAS to apply to the invocation

([ContractCommand.Invoke.cs:43-47](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Invoke.cs#L43), [ContractCommand.Run.cs:48-52](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/ContractCommand.Run.cs#L48)).

Their **batch** forms exposed neither ([BatchCommand.BatchFileCommands.cs:89-132](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs#L89)): the batch models forced `[Required]` accounts and defined no `Results`/`AdditionalGas`, and the dispatch always called `ContractInvokeAsync` without an additional-gas argument and never `InvokeForResultsAsync` ([BatchCommand.cs:157-180](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L157)). So a batch file could neither perform a read-only invocation nor attach extra GAS — contradicting the documented promise that batch commands support the same arguments as their standalone form.

## Fix

Add the `Results` and `AdditionalGas` options to both batch models, make the account optional, and branch the dispatch the same way the standalone commands do — `InvokeForResultsAsync` when `--results` is set, otherwise `ContractInvokeAsync` with the additional GAS — including the "Account or --results" check.

## Tests

Added to `BatchCommandParserTests`:
- `Contract_invoke_binds_results_and_does_not_require_account` — `contract invoke invoke.json --results` binds `Results` and validates with no account.
- `Contract_run_binds_additional_gas` — `contract run … --gas 5` binds `AdditionalGas = 5`.

Release build is clean, `dotnet format --verify-no-changes` reports no changes, and the full `BatchCommandParserTests` suite passes.