### PR TITLE
Report which batch file line failed

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -110,230 +110,237 @@ namespace NeoExpress.Commands
                     || args[0].StartsWith("//"))
                     continue;
 
-                var pr = batchApp.Parse(args);
-
-                // Parse() does not run DataAnnotations validation (only ExecuteAsync does),
-                // so enforce the [Required]/[AllowedValues] attributes on the batch models
-                // here. Otherwise a line missing a required argument is dispatched with the
-                // field defaulted to "" and fails later with a confusing downstream error.
-                var validationResult = pr.SelectedCommand.GetValidationResult();
-                if (validationResult != ValidationResult.Success)
-                    throw new Exception(validationResult?.ErrorMessage ?? $"Invalid batch command: {commands.Span[i]}");
-
-                switch (pr.SelectedCommand)
+                try
                 {
-                    case CommandLineApplication<BatchFileCommands.Checkpoint.Create> cmd:
-                        {
-                            _ = await chainManager.CreateCheckpointAsync(
-                                txExec.ExpressNode,
-                                cmd.Model.Name,
-                                cmd.Model.Force,
-                                writer).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Contract.Deploy> cmd:
-                        {
-                            await txExec.ContractDeployAsync(
-                                root.Resolve(cmd.Model.Contract),
-                                cmd.Model.Account,
-                                cmd.Model.Password,
-                                cmd.Model.WitnessScope,
-                                cmd.Model.Data,
-                                cmd.Model.Force).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Contract.Download> cmd:
-                        {
-                            if (cmd.Model.Height == 0)
-                            {
-                                throw new ArgumentException("Height cannot be 0. Please specify a height > 0");
-                            }
+                    var pr = batchApp.Parse(args);
 
-                            if (chainManager.Chain.ConsensusNodes.Count != 1)
-                            {
-                                throw new ArgumentException("Contract download is only supported for single-node consensus");
-                            }
+                    // Parse() does not run DataAnnotations validation (only ExecuteAsync does),
+                    // so enforce the [Required]/[AllowedValues] attributes on the batch models
+                    // here. Otherwise a line missing a required argument is dispatched with the
+                    // field defaulted to "" and fails later with a confusing downstream error.
+                    var validationResult = pr.SelectedCommand.GetValidationResult();
+                    if (validationResult != ValidationResult.Success)
+                        throw new Exception(validationResult?.ErrorMessage ?? $"Invalid batch command: {commands.Span[i]}");
 
-                            var force = ContractCommand.Download.ParseOverwriteForceOption(cmd);
-
-                            await ContractCommand.Download.ExecuteAsync(
-                                txExec.ExpressNode,
-                                cmd.Model.Contract,
-                                cmd.Model.RpcUri,
-                                cmd.Model.Height,
-                                force,
-                                writer).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Contract.Invoke> cmd:
-                        {
-                            var script = await txExec.LoadInvocationScriptAsync(
-                                root.Resolve(cmd.Model.InvocationFile)).ConfigureAwait(false);
-                            if (cmd.Model.Results)
+                    switch (pr.SelectedCommand)
+                    {
+                        case CommandLineApplication<BatchFileCommands.Checkpoint.Create> cmd:
                             {
-                                await txExec.InvokeForResultsAsync(
-                                    script,
-                                    cmd.Model.Account,
-                                    cmd.Model.WitnessScope).ConfigureAwait(false);
+                                _ = await chainManager.CreateCheckpointAsync(
+                                    txExec.ExpressNode,
+                                    cmd.Model.Name,
+                                    cmd.Model.Force,
+                                    writer).ConfigureAwait(false);
+                                break;
                             }
-                            else
+                        case CommandLineApplication<BatchFileCommands.Contract.Deploy> cmd:
                             {
-                                if (string.IsNullOrEmpty(cmd.Model.Account))
-                                    throw new Exception("Either Account or --results must be specified");
-                                await txExec.ContractInvokeAsync(
-                                    script,
+                                await txExec.ContractDeployAsync(
+                                    root.Resolve(cmd.Model.Contract),
                                     cmd.Model.Account,
                                     cmd.Model.Password,
                                     cmd.Model.WitnessScope,
-                                    cmd.Model.AdditionalGas).ConfigureAwait(false);
+                                    cmd.Model.Data,
+                                    cmd.Model.Force).ConfigureAwait(false);
+                                break;
                             }
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Contract.Run> cmd:
-                        {
-                            var script = await txExec.BuildInvocationScriptAsync(
-                                cmd.Model.Contract,
-                                cmd.Model.Method,
-                                cmd.Model.Arguments).ConfigureAwait(false);
-                            if (cmd.Model.Results)
+                        case CommandLineApplication<BatchFileCommands.Contract.Download> cmd:
                             {
-                                await txExec.InvokeForResultsAsync(
-                                    script,
-                                    cmd.Model.Account,
-                                    cmd.Model.WitnessScope).ConfigureAwait(false);
+                                if (cmd.Model.Height == 0)
+                                {
+                                    throw new ArgumentException("Height cannot be 0. Please specify a height > 0");
+                                }
+
+                                if (chainManager.Chain.ConsensusNodes.Count != 1)
+                                {
+                                    throw new ArgumentException("Contract download is only supported for single-node consensus");
+                                }
+
+                                var force = ContractCommand.Download.ParseOverwriteForceOption(cmd);
+
+                                await ContractCommand.Download.ExecuteAsync(
+                                    txExec.ExpressNode,
+                                    cmd.Model.Contract,
+                                    cmd.Model.RpcUri,
+                                    cmd.Model.Height,
+                                    force,
+                                    writer).ConfigureAwait(false);
+                                break;
                             }
-                            else
+                        case CommandLineApplication<BatchFileCommands.Contract.Invoke> cmd:
                             {
-                                if (string.IsNullOrEmpty(cmd.Model.Account))
-                                    throw new Exception("Either Account or --results must be specified");
-                                await txExec.ContractInvokeAsync(
-                                    script,
+                                var script = await txExec.LoadInvocationScriptAsync(
+                                    root.Resolve(cmd.Model.InvocationFile)).ConfigureAwait(false);
+                                if (cmd.Model.Results)
+                                {
+                                    await txExec.InvokeForResultsAsync(
+                                        script,
+                                        cmd.Model.Account,
+                                        cmd.Model.WitnessScope).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    if (string.IsNullOrEmpty(cmd.Model.Account))
+                                        throw new Exception("Either Account or --results must be specified");
+                                    await txExec.ContractInvokeAsync(
+                                        script,
+                                        cmd.Model.Account,
+                                        cmd.Model.Password,
+                                        cmd.Model.WitnessScope,
+                                        cmd.Model.AdditionalGas).ConfigureAwait(false);
+                                }
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Contract.Run> cmd:
+                            {
+                                var script = await txExec.BuildInvocationScriptAsync(
+                                    cmd.Model.Contract,
+                                    cmd.Model.Method,
+                                    cmd.Model.Arguments).ConfigureAwait(false);
+                                if (cmd.Model.Results)
+                                {
+                                    await txExec.InvokeForResultsAsync(
+                                        script,
+                                        cmd.Model.Account,
+                                        cmd.Model.WitnessScope).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    if (string.IsNullOrEmpty(cmd.Model.Account))
+                                        throw new Exception("Either Account or --results must be specified");
+                                    await txExec.ContractInvokeAsync(
+                                        script,
+                                        cmd.Model.Account,
+                                        cmd.Model.Password,
+                                        cmd.Model.WitnessScope,
+                                        cmd.Model.AdditionalGas).ConfigureAwait(false);
+                                }
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:
+                            {
+                                var data = txExec.ContractParameterParser(cmd.Model.Data);
+                                await txExec.ContractUpdateAsync(
+                                    cmd.Model.Contract,
+                                    root.Resolve(cmd.Model.NefFile),
                                     cmd.Model.Account,
                                     cmd.Model.Password,
                                     cmd.Model.WitnessScope,
-                                    cmd.Model.AdditionalGas).ConfigureAwait(false);
+                                    data).ConfigureAwait(false);
+                                break;
                             }
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:
-                        {
-                            var data = txExec.ContractParameterParser(cmd.Model.Data);
-                            await txExec.ContractUpdateAsync(
-                                cmd.Model.Contract,
-                                root.Resolve(cmd.Model.NefFile),
-                                cmd.Model.Account,
-                                cmd.Model.Password,
-                                cmd.Model.WitnessScope,
-                                data).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.FastForward> cmd:
-                        {
-                            FastForwardCommand.ValidateCount(cmd.Model.Count);
-                            var timestampDelta = FastForwardCommand.ParseTimestampDelta(cmd.Model.TimestampDelta);
-                            await txExec.ExpressNode.FastForwardAsync(
-                                cmd.Model.Count,
-                                timestampDelta).ConfigureAwait(false);
-                            await writer.WriteLineAsync($"{cmd.Model.Count} empty blocks minted").ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Oracle.Enable> cmd:
-                        {
-                            await txExec.OracleEnableAsync(
-                                cmd.Model.Account,
-                                cmd.Model.Password).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Oracle.Response> cmd:
-                        {
-                            await txExec.OracleResponseAsync(
-                                cmd.Model.Url,
-                                root.Resolve(cmd.Model.ResponsePath),
-                                cmd.Model.RequestId).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Policy.Block> cmd:
-                        {
-                            await txExec.BlockAsync(
-                                cmd.Model.ScriptHash,
-                                cmd.Model.Account,
-                                cmd.Model.Password).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Policy.Set> cmd:
-                        {
-                            await txExec.SetPolicyAsync(
-                                cmd.Model.Policy,
-                                cmd.Model.Value,
-                                cmd.Model.Account,
-                                cmd.Model.Password).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Policy.Sync> cmd:
-                        {
-                            if (string.IsNullOrEmpty(cmd.Model.Account))
-                                throw new ArgumentException("Policy sync requires --account field");
-
-                            var values = await txExec.TryGetRemoteNetworkPolicyAsync(cmd.Model.Source).ConfigureAwait(false);
-
-                            if (values.IsT1)
-                                values = await txExec.TryLoadPolicyFromFileSystemAsync(cmd.Model.Source)
-                                    .ConfigureAwait(false);
-
-                            if (values.TryPickT0(out var policyValues, out _))
+                        case CommandLineApplication<BatchFileCommands.FastForward> cmd:
                             {
-                                await txExec.SetPolicyAsync(policyValues, cmd.Model.Account, cmd.Model.Password);
+                                FastForwardCommand.ValidateCount(cmd.Model.Count);
+                                var timestampDelta = FastForwardCommand.ParseTimestampDelta(cmd.Model.TimestampDelta);
+                                await txExec.ExpressNode.FastForwardAsync(
+                                    cmd.Model.Count,
+                                    timestampDelta).ConfigureAwait(false);
+                                await writer.WriteLineAsync($"{cmd.Model.Count} empty blocks minted").ConfigureAwait(false);
+                                break;
                             }
-                            else
+                        case CommandLineApplication<BatchFileCommands.Oracle.Enable> cmd:
                             {
-                                throw new ArgumentException($"Could not load policy values from \"{cmd.Model.Source}\"");
+                                await txExec.OracleEnableAsync(
+                                    cmd.Model.Account,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
                             }
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Policy.Unblock> cmd:
-                        {
-                            await txExec.UnblockAsync(
-                                cmd.Model.ScriptHash,
-                                cmd.Model.Account,
-                                cmd.Model.Password).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Transfer> cmd:
-                        {
-                            await txExec.TransferAsync(
-                                cmd.Model.Quantity,
-                                cmd.Model.Asset,
-                                cmd.Model.Sender,
-                                cmd.Model.Password,
-                                cmd.Model.Receiver,
-                                cmd.Model.Data).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.TransferNFT> cmd:
-                        {
-                            await txExec.TransferNFTAsync(
-                                cmd.Model.Contract,
-                                cmd.Model.TokenId,
-                                cmd.Model.Sender,
-                                cmd.Model.Password,
-                                cmd.Model.Receiver,
-                                cmd.Model.Data).ConfigureAwait(false);
-                            break;
-                        }
-                    case CommandLineApplication<BatchFileCommands.Wallet.Create> cmd:
-                        {
-                            var wallet = chainManager.CreateWallet(
-                                cmd.Model.Name,
-                                cmd.Model.PrivateKey,
-                                cmd.Model.Force);
-                            chainManager.SaveChain(chainFilename!);
-                            await writer.WriteLineAsync($"Created Wallet {cmd.Model.Name}");
-                            for (int x = 0; x < wallet.Accounts.Count; x++)
-                                await writer.WriteLineAsync($"    Address: {wallet.Accounts[x].ScriptHash}");
-                            break;
-                        }
-                    default:
-                        throw new Exception($"Unknown batch command {pr.SelectedCommand.GetType()}");
+                        case CommandLineApplication<BatchFileCommands.Oracle.Response> cmd:
+                            {
+                                await txExec.OracleResponseAsync(
+                                    cmd.Model.Url,
+                                    root.Resolve(cmd.Model.ResponsePath),
+                                    cmd.Model.RequestId).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Policy.Block> cmd:
+                            {
+                                await txExec.BlockAsync(
+                                    cmd.Model.ScriptHash,
+                                    cmd.Model.Account,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Policy.Set> cmd:
+                            {
+                                await txExec.SetPolicyAsync(
+                                    cmd.Model.Policy,
+                                    cmd.Model.Value,
+                                    cmd.Model.Account,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Policy.Sync> cmd:
+                            {
+                                if (string.IsNullOrEmpty(cmd.Model.Account))
+                                    throw new ArgumentException("Policy sync requires --account field");
+
+                                var values = await txExec.TryGetRemoteNetworkPolicyAsync(cmd.Model.Source).ConfigureAwait(false);
+
+                                if (values.IsT1)
+                                    values = await txExec.TryLoadPolicyFromFileSystemAsync(cmd.Model.Source)
+                                        .ConfigureAwait(false);
+
+                                if (values.TryPickT0(out var policyValues, out _))
+                                {
+                                    await txExec.SetPolicyAsync(policyValues, cmd.Model.Account, cmd.Model.Password);
+                                }
+                                else
+                                {
+                                    throw new ArgumentException($"Could not load policy values from \"{cmd.Model.Source}\"");
+                                }
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Policy.Unblock> cmd:
+                            {
+                                await txExec.UnblockAsync(
+                                    cmd.Model.ScriptHash,
+                                    cmd.Model.Account,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Transfer> cmd:
+                            {
+                                await txExec.TransferAsync(
+                                    cmd.Model.Quantity,
+                                    cmd.Model.Asset,
+                                    cmd.Model.Sender,
+                                    cmd.Model.Password,
+                                    cmd.Model.Receiver,
+                                    cmd.Model.Data).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.TransferNFT> cmd:
+                            {
+                                await txExec.TransferNFTAsync(
+                                    cmd.Model.Contract,
+                                    cmd.Model.TokenId,
+                                    cmd.Model.Sender,
+                                    cmd.Model.Password,
+                                    cmd.Model.Receiver,
+                                    cmd.Model.Data).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Wallet.Create> cmd:
+                            {
+                                var wallet = chainManager.CreateWallet(
+                                    cmd.Model.Name,
+                                    cmd.Model.PrivateKey,
+                                    cmd.Model.Force);
+                                chainManager.SaveChain(chainFilename!);
+                                await writer.WriteLineAsync($"Created Wallet {cmd.Model.Name}");
+                                for (int x = 0; x < wallet.Accounts.Count; x++)
+                                    await writer.WriteLineAsync($"    Address: {wallet.Accounts[x].ScriptHash}");
+                                break;
+                            }
+                        default:
+                            throw new Exception($"Unknown batch command {pr.SelectedCommand.GetType()}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Error in batch file line {i + 1}: \"{commands.Span[i].Trim()}\" - {ex.Message}", ex);
                 }
             }
         }

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -100,18 +100,18 @@ namespace NeoExpress.Commands
 
             for (var i = 0; i < commands.Length; i++)
             {
-                var batchApp = new CommandLineApplication<BatchFileCommands>();
-                batchApp.UseInvariantValueParsing();
-                batchApp.Conventions.UseDefaultConventions();
-
-                var args = SplitCommandLine(commands.Span[i]).ToArray();
-                if (args.Length == 0
-                    || args[0].StartsWith('#')
-                    || args[0].StartsWith("//"))
-                    continue;
-
                 try
                 {
+                    var args = SplitCommandLine(commands.Span[i]).ToArray();
+                    if (args.Length == 0
+                        || args[0].StartsWith('#')
+                        || args[0].StartsWith("//"))
+                        continue;
+
+                    var batchApp = new CommandLineApplication<BatchFileCommands>();
+                    batchApp.UseInvariantValueParsing();
+                    batchApp.Conventions.UseDefaultConventions();
+
                     var pr = batchApp.Parse(args);
 
                     // Parse() does not run DataAnnotations validation (only ExecuteAsync does),
@@ -340,10 +340,13 @@ namespace NeoExpress.Commands
                 }
                 catch (Exception ex)
                 {
-                    throw new Exception($"Error in batch file line {i + 1}: \"{commands.Span[i].Trim()}\" - {ex.Message}", ex);
+                    throw CreateBatchLineException(i + 1, commands.Span[i], ex);
                 }
             }
         }
+
+        internal static Exception CreateBatchLineException(int lineNumber, ReadOnlySpan<char> commandLine, Exception innerException)
+            => new($"Error in batch file line {lineNumber}: \"{commandLine.Trim()}\" - {innerException.Message}", innerException);
 
         // SplitCommandLine method adapted from CommandLineStringSplitter class in https://github.com/dotnet/command-line-api
         internal static IEnumerable<string> SplitCommandLine(string commandLine)

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -76,6 +76,17 @@ public class BatchCommandParserTests
     }
 
     [Fact]
+    public void Batch_line_errors_include_the_line_number_and_text()
+    {
+        var original = new FormatException("Unbalanced quote in batch command line.");
+
+        var wrapped = BatchCommand.CreateBatchLineException(2, "wallet create \"alice", original);
+
+        wrapped.Message.Should().Be("Error in batch file line 2: \"wallet create \"alice\" - Unbalanced quote in batch command line.");
+        wrapped.InnerException.Should().BeSameAs(original);
+    }
+
+    [Fact]
     public void SplitCommandLine_preserves_balanced_quoted_tokens()
     {
         BatchCommand.SplitCommandLine("wallet create \"alice bob\"").Should()


### PR DESCRIPTION
## Problem

When a command inside a batch file throws (a bad argument, a transfer/deploy failure, a deploy name conflict, etc.), the exception propagates out of the per-line loop up to `OnExecuteAsync`, whose catch calls `app.WriteException(ex)` with **no indication of which line was executing** ([BatchCommand.cs:62-66](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Commands/BatchCommand.cs#L62)). The loop index `i` and the raw line text are never surfaced. For a batch file of dozens of lines, the user sees only the bare exception message and has to guess which command produced it — undercutting the batch feature's whole purpose. The default output gives zero location context (a C# stack trace requires `--stack-trace`).

## Fix

Wrap the per-line parse and dispatch in a `try`/`catch` that rethrows with the **1-based line number and the line text**:

```
Error in batch file line 7: "transfer 10 gas alice bob" - <original message>
```

The original exception is preserved as the inner exception, and `OnExecuteAsync` already prints inner exceptions (`showInnerExceptions: true`), so no detail is lost.

## Note on the diff

Most of the diff is the **indentation change** from wrapping the existing ~190-line `switch` in a `try` block — reviewing with whitespace changes hidden shows the real change is just the added `try {` / `catch { … }`. The switch body is otherwise untouched.

This is on the batch execution path, which has no unit-test harness in the repo (it requires a loaded chain), so it is verified by Release build, `dotnet format --verify-no-changes`, and the existing `BatchCommandParserTests` suite still passing.