### PR TITLE
Emit LCOV coverage alongside Cobertura

### DIFF
--- a/src/collector/CodeCoverageDataCollector.cs
+++ b/src/collector/CodeCoverageDataCollector.cs
@@ -115,6 +115,7 @@ namespace Neo.Collector
             if (coverage is not null)
             {
                 new CoberturaFormat().WriteReport(coverage, WriteAttachment);
+                new LcovFormat().WriteReport(coverage, WriteAttachment);
                 new RawCoverageFormat().WriteReport(coverage, WriteAttachment);
             }
 

--- a/src/collector/Formats/LcovFormat.cs
+++ b/src/collector/Formats/LcovFormat.cs
@@ -25,12 +25,11 @@ namespace Neo.Collector.Formats
         {
             writeAttachement("neo-coverage.lcov.info", stream =>
             {
-                var writer = new StreamWriter(stream);
+                using var writer = new StreamWriter(stream, leaveOpen: true);
                 foreach (var contract in coverage)
                 {
                     WriteContract(writer, contract);
                 }
-                writer.Flush();
             });
         }
 
@@ -50,7 +49,9 @@ namespace Neo.Collector.Formats
                 writer.WriteLine($"SF:{group.Key}");
 
                 var methods = group.Where(m => m.SequencePoints.Count > 0).ToList();
-                var fnHit = 0;
+                var functionsHit = 0;
+                // LCOV tracefiles use fixed labels: FN=function, FNDA=function data,
+                // FNF=functions found, and FNH=functions hit.
                 foreach (var method in methods)
                 {
                     writer.WriteLine($"FN:{method.SequencePoints[0].Start.Line},{method.Name}");
@@ -59,11 +60,11 @@ namespace Neo.Collector.Formats
                 {
                     var hits = HitsAt(method.SequencePoints[0].Address);
                     if (hits > 0)
-                        fnHit++;
+                        functionsHit++;
                     writer.WriteLine($"FNDA:{hits},{method.Name}");
                 }
                 writer.WriteLine($"FNF:{methods.Count}");
-                writer.WriteLine($"FNH:{fnHit}");
+                writer.WriteLine($"FNH:{functionsHit}");
 
                 // Aggregate per source line; a line can map to several sequence points,
                 // so record the highest hit count observed for that line.

--- a/src/collector/Formats/LcovFormat.cs
+++ b/src/collector/Formats/LcovFormat.cs
@@ -1,0 +1,106 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// LcovFormat.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Collector.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Collector.Formats
+{
+    // Emits line and function coverage in the LCOV tracefile format consumed by
+    // genhtml, Coveralls, Codecov and many editor coverage gutters. Branch coverage
+    // is intentionally omitted here; it is available in the Cobertura report.
+    class LcovFormat : ICoverageFormat
+    {
+        public void WriteReport(IReadOnlyList<ContractCoverage> coverage, Action<string, Action<Stream>> writeAttachement)
+        {
+            writeAttachement("neo-coverage.lcov.info", stream =>
+            {
+                var writer = new StreamWriter(stream);
+                foreach (var contract in coverage)
+                {
+                    WriteContract(writer, contract);
+                }
+                writer.Flush();
+            });
+        }
+
+        internal static void WriteContract(TextWriter writer, ContractCoverage contract)
+        {
+            var debugInfo = contract.DebugInfo;
+            uint HitsAt(int address) => contract.HitMap.TryGetValue(address, out var count) ? count : 0u;
+
+            var byDocument = debugInfo.Methods
+                .Select(method => (method, document: SingleDocument(debugInfo, method)))
+                .Where(x => x.document is not null)
+                .GroupBy(x => x.document!, x => x.method);
+
+            foreach (var group in byDocument)
+            {
+                writer.WriteLine("TN:");
+                writer.WriteLine($"SF:{group.Key}");
+
+                var methods = group.Where(m => m.SequencePoints.Count > 0).ToList();
+                var fnHit = 0;
+                foreach (var method in methods)
+                {
+                    writer.WriteLine($"FN:{method.SequencePoints[0].Start.Line},{method.Name}");
+                }
+                foreach (var method in methods)
+                {
+                    var hits = HitsAt(method.SequencePoints[0].Address);
+                    if (hits > 0)
+                        fnHit++;
+                    writer.WriteLine($"FNDA:{hits},{method.Name}");
+                }
+                writer.WriteLine($"FNF:{methods.Count}");
+                writer.WriteLine($"FNH:{fnHit}");
+
+                // Aggregate per source line; a line can map to several sequence points,
+                // so record the highest hit count observed for that line.
+                var lineHits = new SortedDictionary<int, uint>();
+                foreach (var method in group)
+                {
+                    foreach (var sp in method.SequencePoints)
+                    {
+                        var hits = HitsAt(sp.Address);
+                        if (!lineHits.TryGetValue(sp.Start.Line, out var existing) || hits > existing)
+                            lineHits[sp.Start.Line] = hits;
+                    }
+                }
+
+                var linesHit = 0;
+                foreach (var line in lineHits)
+                {
+                    writer.WriteLine($"DA:{line.Key},{line.Value}");
+                    if (line.Value > 0)
+                        linesHit++;
+                }
+                writer.WriteLine($"LF:{lineHits.Count}");
+                writer.WriteLine($"LH:{linesHit}");
+                writer.WriteLine("end_of_record");
+            }
+        }
+
+        static string? SingleDocument(NeoDebugInfo debugInfo, NeoDebugInfo.Method method)
+        {
+            var documents = method.SequencePoints.Select(sp => sp.Document).Distinct().ToList();
+            if (documents.Count == 1)
+            {
+                var index = documents[0];
+                if (index >= 0 && index < debugInfo.Documents.Count)
+                    return debugInfo.Documents[index];
+            }
+            return null;
+        }
+    }
+}

--- a/test/test-collector/LcovFormatTests.cs
+++ b/test/test-collector/LcovFormatTests.cs
@@ -1,0 +1,94 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// LcovFormatTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Moq;
+using Neo.Collector;
+using Neo.Collector.Formats;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace test_collector;
+
+public class LcovFormatTests
+{
+    static string WriteLcov()
+    {
+        var logger = new Mock<ILogger>();
+        var collector = new CodeCoverageCollector(logger.Object);
+        collector.TrackTestContract("contract", "registrar.nefdbgnfo");
+        collector.LoadTestOutput("run1");
+        var coverage = collector.CollectCoverage().ToList();
+
+        var lcov = "";
+        new LcovFormat().WriteReport(coverage, (filename, write) =>
+        {
+            Assert.EndsWith(".lcov.info", filename);
+            using var ms = new MemoryStream();
+            write(ms);
+            lcov = Encoding.UTF8.GetString(ms.ToArray());
+        });
+        return lcov;
+    }
+
+    [Fact]
+    public void Produces_a_well_formed_lcov_record()
+    {
+        var lcov = WriteLcov();
+
+        Assert.Contains("SF:", lcov);
+        Assert.Contains("DA:", lcov);
+        Assert.Contains("end_of_record", lcov);
+
+        // every record is terminated
+        var sf = lcov.Split('\n').Count(l => l.StartsWith("SF:"));
+        var eor = lcov.Split('\n').Count(l => l.Trim() == "end_of_record");
+        Assert.Equal(sf, eor);
+    }
+
+    [Fact]
+    public void Lines_hit_never_exceeds_lines_found()
+    {
+        var lcov = WriteLcov();
+
+        foreach (var line in lcov.Split('\n'))
+        {
+            if (line.StartsWith("LF:"))
+            {
+                var lf = int.Parse(line.Substring(3).Trim());
+                Assert.True(lf >= 0);
+            }
+            if (line.StartsWith("LH:"))
+            {
+                var lh = int.Parse(line.Substring(3).Trim());
+                Assert.True(lh >= 0);
+            }
+        }
+
+        // pair up LF/LH per record and assert LH <= LF
+        var records = lcov.Split(new[] { "end_of_record" }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var record in records)
+        {
+            if (!record.Contains("LF:"))
+                continue;
+            var lf = ReadCounter(record, "LF:");
+            var lh = ReadCounter(record, "LH:");
+            Assert.True(lh <= lf, $"LH ({lh}) must not exceed LF ({lf})");
+        }
+    }
+
+    static int ReadCounter(string record, string prefix)
+    {
+        var line = record.Split('\n').Single(l => l.StartsWith(prefix));
+        return int.Parse(line.Substring(prefix.Length).Trim());
+    }
+}


### PR DESCRIPTION
## Motivation

The coverage collector ([CodeCoverageDataCollector.cs:117-118](https://github.com/neo-project/neo-express/blob/master/src/collector/CodeCoverageDataCollector.cs#L117)) emits Cobertura XML and a raw text dump. **LCOV** is the other widely-consumed coverage format — genhtml, Coveralls, Codecov, and many editor coverage gutters read it natively. Emitting it directly removes the need for a Cobertura→LCOV conversion step in CI.

## Change

Add `LcovFormat : ICoverageFormat` and wire it into the collector next to the existing formats, producing `neo-coverage.lcov.info`.

The LCOV writer reuses the **same** per-address `HitMap` and sequence-point data the Cobertura writer uses, so the numbers are consistent between the two reports. It groups methods by source document and emits:
- function coverage — `FN`/`FNDA`/`FNF`/`FNH`
- line coverage — `DA` (per source line, highest hit count when several sequence points map to one line), `LF`/`LH`
- `end_of_record` per source file

Branch coverage is intentionally left to the Cobertura report; this first version covers the universally-consumed line and function records.

## Tests

`LcovFormatTests` runs the format against the existing `registrar` coverage fixture (`run1`) and asserts the output is well-formed (`SF:`/`DA:`/`end_of_record`, one `end_of_record` per `SF:`) and that lines-hit never exceeds lines-found per record. Release build is clean, `dotnet format --verify-no-changes` reports no changes, and the full `test-collector` suite passes.