### PR TITLE
Compare boxed integral values in StackItem assertions

### DIFF
--- a/src/assertions/StackItemAssertions.cs
+++ b/src/assertions/StackItemAssertions.cs
@@ -41,6 +41,19 @@ namespace Neo.Assertions
                 {
                     string expectedString => BeEquivalentTo(expectedString, because, becauseArgs),
                     BigInteger expectedInt => BeEquivalentTo(expectedInt, because, becauseArgs),
+                    // Integral event/stack values arrive here boxed (e.g. an event interface
+                    // declaring an int/long parameter), which defeats the implicit conversion
+                    // to BigInteger; convert each integral type explicitly so they compare by
+                    // numeric value instead of failing as an unknown type.
+                    sbyte expectedSByte => BeEquivalentTo((BigInteger)expectedSByte, because, becauseArgs),
+                    byte expectedByte => BeEquivalentTo((BigInteger)expectedByte, because, becauseArgs),
+                    short expectedShort => BeEquivalentTo((BigInteger)expectedShort, because, becauseArgs),
+                    ushort expectedUShort => BeEquivalentTo((BigInteger)expectedUShort, because, becauseArgs),
+                    int expectedInt32 => BeEquivalentTo((BigInteger)expectedInt32, because, becauseArgs),
+                    uint expectedUInt32 => BeEquivalentTo((BigInteger)expectedUInt32, because, becauseArgs),
+                    long expectedInt64 => BeEquivalentTo((BigInteger)expectedInt64, because, becauseArgs),
+                    ulong expectedUInt64 => BeEquivalentTo((BigInteger)expectedUInt64, because, becauseArgs),
+                    char expectedChar => BeEquivalentTo((BigInteger)expectedChar, because, becauseArgs),
                     bool expectedBool => BeEquivalentTo(expectedBool, because, becauseArgs),
                     UInt160 expectedHash => BeEquivalentTo(expectedHash, because, becauseArgs),
                     UInt256 expectedHash => BeEquivalentTo(expectedHash, because, becauseArgs),

--- a/test/test-assertions/StackItemAssertionsTests.cs
+++ b/test/test-assertions/StackItemAssertionsTests.cs
@@ -52,6 +52,34 @@ public class StackItemAssertionsTests
         act.Should().NotThrow();
     }
 
+    [Theory]
+    [InlineData((int)42)]
+    [InlineData((long)42)]
+    [InlineData((short)42)]
+    [InlineData((byte)42)]
+    [InlineData((uint)42)]
+    [InlineData((ulong)42)]
+    public void BeEquivalentTo_object_matches_a_boxed_integral_value(object expected)
+    {
+        // A numeric event argument (e.g. an interface declaring an int/long parameter)
+        // arrives boxed; it must still compare equal to the integer stack item.
+        StackItem item = (Integer)42;
+
+        var act = () => item.Should().BeEquivalentTo(expected);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeEquivalentTo_object_fails_when_a_boxed_integral_value_differs()
+    {
+        StackItem item = (Integer)42;
+
+        var act = () => item.Should().BeEquivalentTo((object)43);
+
+        act.Should().Throw<Exception>();
+    }
+
     [Fact]
     public void BeEquivalentTo_bool_matches_boolean_value()
     {


### PR DESCRIPTION
## Problem

`StackItemAssertions.BeEquivalentTo(object?)` ([StackItemAssertions.cs:40-50](https://github.com/neo-project/neo-express/blob/master/src/assertions/StackItemAssertions.cs#L40)) switches on `BigInteger` for numbers but has no case for the boxed integral types, so they fall through to `UnsupportedType` → `"Unknown StackItem type …"`.

This surfaces through `NotifyEventArgsAssertions.BeEquivalentTo<T>`, which **boxes** each expected event argument (`Expression.Lambda(arg).Compile().DynamicInvoke()`) before `Subject.State[i].Should().BeEquivalentTo(obj)`. Boxing defeats the implicit `int`→`BigInteger` conversion that works for literals. So a notification whose event interface declares a parameter as `int`/`long`/`short`/`byte`/`uint`/… — the idiomatic choice for counts, ids and indices — asserted via `notification.Should().BeEquivalentTo<IEvents>(e => e.MyEvent(42))` **fails with `Unknown StackItem type System.Int32` even when the value matches**, forcing authors to redeclare every numeric event parameter as `System.Numerics.BigInteger`.

This is in the published `Neo.Assertions` NuGet package used by external contract test authors.

## Fix

Add explicit switch cases for the integral types (`sbyte`/`byte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`) and `char` that convert to `BigInteger` before comparing — preserving each type's sign via the `BigInteger` implicit operators.

## Tests

Added a theory to `StackItemAssertionsTests` covering int/long/short/byte/uint/ulong matching an `Integer` stack item, plus a negative case. Removing the new cases makes all six fail with the unknown-type error (verified). Release build is clean and `dotnet format --verify-no-changes` reports no changes.