### PR TITLE
Quote nccs argument paths so spaces do not break the contract build

### DIFF
--- a/src/build-tasks/NeoCsc.cs
+++ b/src/build-tasks/NeoCsc.cs
@@ -52,34 +52,43 @@ namespace Neo.BuildTasks
         }
 
         protected override string GetArguments()
+            => BuildArguments(Sources.Select(s => s.ItemSpec), Output?.ItemSpec, BaseFileName,
+                Debug, Assembly, Optimize, Inline, AddressVersion);
+
+        internal static string BuildArguments(IEnumerable<string> sources, string? output, string baseFileName,
+            bool debug, bool assembly, bool optimize, bool inline, byte addressVersion)
         {
             var builder = new StringBuilder();
-            foreach (var file in Sources)
+            // Quote every path-derived value so a source path, output directory or base
+            // name containing a space is passed to nccs as a single argument rather than
+            // split into multiple tokens. Sources is always the full project path, so a
+            // project located under e.g. "C:\Users\John Doe\..." would otherwise break.
+            foreach (var file in sources)
             {
-                builder.AppendFormat(" {0}", file.ItemSpec);
+                builder.AppendFormat(" \"{0}\"", file);
             }
 
-            if (!(Output is null))
+            if (output is not null)
             {
-                builder.AppendFormat(" --output {0}", Output.ItemSpec);
+                builder.AppendFormat(" --output \"{0}\"", output);
             }
 
-            if (!string.IsNullOrEmpty(BaseFileName))
+            if (!string.IsNullOrEmpty(baseFileName))
             {
-                builder.AppendFormat(" --base-name {0}", BaseFileName);
+                builder.AppendFormat(" --base-name \"{0}\"", baseFileName);
             }
 
-            if (Debug)
+            if (debug)
                 builder.Append(" --debug");
-            if (Assembly)
+            if (assembly)
                 builder.Append(" --assembly");
-            if (!Optimize)
+            if (!optimize)
                 builder.Append(" --no-optimize");
-            if (!Inline)
+            if (!inline)
                 builder.Append(" --no-inline");
-            if (AddressVersion != DEFAULT_ADDRESS_VERSION)
+            if (addressVersion != DEFAULT_ADDRESS_VERSION)
             {
-                builder.AppendFormat(" --address-version {0}", AddressVersion);
+                builder.AppendFormat(" --address-version {0}", addressVersion);
             }
 
             return builder.ToString();

--- a/test/test-build-tasks/NeoCscTests.cs
+++ b/test/test-build-tasks/NeoCscTests.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NeoCscTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BuildTasks;
+using Xunit;
+
+namespace build_tasks;
+
+public class NeoCscTests
+{
+    [Fact]
+    public void BuildArguments_quotes_path_derived_values()
+    {
+        // A project path, output directory or base name containing a space must be
+        // passed to nccs as a single quoted argument, not split into tokens.
+        var args = NeoCsc.BuildArguments(
+            new[] { @"C:\Users\John Doe\contract.csproj" },
+            @"C:\Users\John Doe\bin\sc",
+            "base name",
+            debug: false, assembly: false, optimize: true, inline: true, addressVersion: 53);
+
+        Assert.Contains("\"C:\\Users\\John Doe\\contract.csproj\"", args);
+        Assert.Contains("--output \"C:\\Users\\John Doe\\bin\\sc\"", args);
+        Assert.Contains("--base-name \"base name\"", args);
+    }
+}


### PR DESCRIPTION
## Problem

`NeoCsc.GetArguments` ([NeoCsc.cs:54-69](https://github.com/neo-project/neo-express/blob/master/src/build-tasks/NeoCsc.cs#L54)) builds the `nccs` command line with the source files, `--output` and `--base-name` values **unquoted**:

```csharp
builder.AppendFormat(" {0}", file.ItemSpec);      // source
builder.AppendFormat(" --output {0}", Output.ItemSpec);
builder.AppendFormat(" --base-name {0}", BaseFileName);
```

The MSBuild targets always pass the full project path (`$(MSBuildProjectFullPath)`) as a source, and `ProcessRunner` passes the joined string to `ProcessStartInfo` (`UseShellExecute=false`), where the callee argv-parses on whitespace. So a project located under a path containing a space (e.g. `C:\Users\John Doe\proj`, common on Windows), or a `NeoContractOutput` / `NeoContractName` containing a space, produces an argument that `nccs` splits into multiple tokens — **failing the build or writing output to the wrong location**. The sibling `NeoExpressBatch` task already quotes its path arguments.

## Fix

Quote the three path-derived values, and extract the argument construction into an `internal static BuildArguments` helper so it is unit-testable.

## Tests

Added `NeoCscTests.BuildArguments_quotes_path_derived_values` asserting a source path, `--output` and `--base-name` with spaces are each quoted. Reverting the quoting makes it fail (verified). Release build (net10.0 + netstandard2.0) is clean and `dotnet format --verify-no-changes` reports no changes.
