### PR TITLE
Clean up the extracted checkpoint directory when opening it fails

### DIFF
--- a/src/bctklib/persistence/CheckpointStore.cs
+++ b/src/bctklib/persistence/CheckpointStore.cs
@@ -31,15 +31,32 @@ namespace Neo.BlockchainToolkit.Persistence
         public CheckpointStore(string checkpointPath, uint? network = null, byte? addressVersion = null, UInt160? scriptHash = null, string? columnFamilyName = null)
         {
             checkpointTempPath = RocksDbUtility.GetTempPath();
-            var metadata = RocksDbUtility.RestoreCheckpoint(checkpointPath, checkpointTempPath, network, addressVersion, scriptHash);
-
-            Settings = ProtocolSettings.Default with
+            try
             {
-                Network = metadata.network,
-                AddressVersion = metadata.addressVersion,
-            };
-            var db = RocksDbUtility.OpenReadOnlyDb(checkpointTempPath);
-            store = new RocksDbStore(db, columnFamilyName, readOnly: true);
+                var metadata = RocksDbUtility.RestoreCheckpoint(checkpointPath, checkpointTempPath, network, addressVersion, scriptHash);
+
+                Settings = ProtocolSettings.Default with
+                {
+                    Network = metadata.network,
+                    AddressVersion = metadata.addressVersion,
+                };
+                var db = RocksDbUtility.OpenReadOnlyDb(checkpointTempPath);
+                store = new RocksDbStore(db, columnFamilyName, readOnly: true);
+            }
+            catch
+            {
+                // The checkpoint archive is extracted into checkpointTempPath before the
+                // database is opened. If opening fails (corrupt/locked/incompatible db),
+                // the constructor never completes, so Dispose is never called; delete the
+                // extracted directory here to avoid leaking it under the temp path.
+                if (Directory.Exists(checkpointTempPath))
+                {
+                    try
+                    { Directory.Delete(checkpointTempPath, true); }
+                    catch { }
+                }
+                throw;
+            }
         }
 
         public void Dispose()

--- a/src/bctklib/persistence/CheckpointStore.cs
+++ b/src/bctklib/persistence/CheckpointStore.cs
@@ -51,8 +51,13 @@ namespace Neo.BlockchainToolkit.Persistence
                 // extracted directory here to avoid leaking it under the temp path.
                 if (Directory.Exists(checkpointTempPath))
                 {
-                    try { Directory.Delete(checkpointTempPath, true); }
-                    catch { }
+                    try
+                    {
+                        Directory.Delete(checkpointTempPath, true);
+                    }
+                    catch
+                    {
+                    }
                 }
                 throw;
             }

--- a/src/bctklib/persistence/CheckpointStore.cs
+++ b/src/bctklib/persistence/CheckpointStore.cs
@@ -51,8 +51,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 // extracted directory here to avoid leaking it under the temp path.
                 if (Directory.Exists(checkpointTempPath))
                 {
-                    try
-                    { Directory.Delete(checkpointTempPath, true); }
+                    try { Directory.Delete(checkpointTempPath, true); }
                     catch { }
                 }
                 throw;


### PR DESCRIPTION
## Problem

`CheckpointStore`'s constructor ([CheckpointStore.cs:31-43](https://github.com/neo-project/neo-express/blob/master/src/bctklib/persistence/CheckpointStore.cs#L31)) extracts the checkpoint archive into a temp directory (`RestoreCheckpoint` → `ExtractToDirectory`) and then opens it as a read-only RocksDB:

```csharp
checkpointTempPath = RocksDbUtility.GetTempPath();
var metadata = RocksDbUtility.RestoreCheckpoint(checkpointPath, checkpointTempPath, ...); // extracts
...
var db = RocksDbUtility.OpenReadOnlyDb(checkpointTempPath);   // can throw
store = new RocksDbStore(db, columnFamilyName, readOnly: true);
```

If `OpenReadOnlyDb` (or the `RocksDbStore` ctor) throws — a corrupt, locked, or incompatible database — the constructor exits via exception. Because the object was never fully constructed, the caller's `using`/`Dispose` never runs, and `Dispose`'s `Directory.Delete(checkpointTempPath, true)` is never invoked. The extracted directory (potentially hundreds of MB of RocksDB data) is **orphaned under the temp path**, and repeated failed restores accumulate disk usage that is never reclaimed.

(The network/version/script-hash validation in `RestoreCheckpoint` happens *before* extraction, so that path does not leak — only a post-extraction open failure does.)

## Fix

Wrap the constructor body in a `try`/`catch` that deletes the extracted directory on failure and rethrows.

## Note

The failure path requires injecting an extract-succeeds-but-open-fails scenario (a structurally valid archive that is not a valid RocksDB), which is impractical to construct as a stable unit test, so this is verified by Release build and the existing `Checkpoint` tests still passing. The change is a standard cleanup-on-exception pattern and does not alter the success path.
