### PR TITLE
Write the contract interface even when OutputFile has no directory

### DIFF
--- a/src/build-tasks/NeoContractInterface.cs
+++ b/src/build-tasks/NeoContractInterface.cs
@@ -29,10 +29,16 @@ namespace Neo.BuildTasks
                 {
                     var manifest = NeoManifest.Load(ManifestFile);
                     var source = ContractGenerator.GenerateContractInterface(manifest, ManifestFile, ContractNameOverride, RootNamespace);
-                    var pathFile = Path.GetDirectoryName(this.OutputFile);
-                    if (!string.IsNullOrEmpty(source) && !string.IsNullOrWhiteSpace(pathFile))
+                    if (!string.IsNullOrEmpty(source))
                     {
-                        Directory.CreateDirectory(pathFile);
+                        // Only create a directory when OutputFile has one. Path.GetDirectoryName
+                        // returns an empty string for a bare filename, which previously skipped the
+                        // write entirely and left the build expecting a file that was never produced.
+                        var pathFile = Path.GetDirectoryName(this.OutputFile);
+                        if (!string.IsNullOrWhiteSpace(pathFile))
+                        {
+                            Directory.CreateDirectory(pathFile);
+                        }
                         FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, source));
                     }
                 }


### PR DESCRIPTION
## Problem

`NeoContractInterface.Execute` gated the file write on the OutputFile having a directory component ([NeoContractInterface.cs:32-37](https://github.com/neo-project/neo-express/blob/master/src/build-tasks/NeoContractInterface.cs#L32)):

```csharp
var pathFile = Path.GetDirectoryName(this.OutputFile);
if (!string.IsNullOrEmpty(source) && !string.IsNullOrWhiteSpace(pathFile))
{
    Directory.CreateDirectory(pathFile);
    FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, source));
}
```

`Path.GetDirectoryName` returns an **empty string** for a bare filename (e.g. `Foo.contract-interface.cs`). So when `OutputFile` is a bare relative filename — which happens if a project overrides the `NeoContractGeneration` item's `OutputPath` metadata to a name with no directory part — the whole block, including `File.WriteAllText`, is skipped and the task returns success **without producing the file**. The build targets then add that file to `<Compile>`, so the build fails with a "source file not found" error for a file the task silently never wrote.

## Fix

Separate the directory-creation guard from the write: create the directory only when `OutputFile` has one, and always write the file when `source` is non-empty.

## Note

Reproducing the bare-filename case in a unit test requires manipulating the process working directory (a bare path is relative to it), which is unsafe to do in a parallel test run, so this is verified by Release build (net10.0 + netstandard2.0) and inspection — `Path.GetDirectoryName` of a bare filename returning `""` is documented behavior. `dotnet format --verify-no-changes` reports no changes.
