### PR TITLE
Load the containing block when selecting a transaction in the tracker

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/panelControllers/trackerPanelController.ts
+++ b/extentions/neo3-visual-tracker/src/extension/panelControllers/trackerPanelController.ts
@@ -114,9 +114,13 @@ export default class TrackerPanelController extends PanelControllerBase<
         const selectedTransaction = await this.getTransaction(
           request.selectTransaction
         );
-        const selectedBlock = await this.blockchainMonitor.getBlock(
-          (selectedTransaction as any).blockhash
-        );
+        // getTransaction returns { tx, log } | null, so the containing block hash
+        // lives on selectedTransaction.tx, not at the top level. Only fetch the
+        // block when a hash is present.
+        const blockHash = (selectedTransaction?.tx as any)?.blockhash;
+        const selectedBlock = blockHash
+          ? await this.blockchainMonitor.getBlock(blockHash)
+          : null;
         await this.updateViewState({
           selectedTransaction,
           selectedBlock,


### PR DESCRIPTION
## Problem

In `TrackerPanelController`, the `selectTransaction` handler ([trackerPanelController.ts:117-119](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/panelControllers/trackerPanelController.ts#L117)) fetched the containing block using the top-level `blockhash`:

```ts
const selectedBlock = await this.blockchainMonitor.getBlock(
  (selectedTransaction as any).blockhash
);
```

But `getTransaction` returns `{ tx, log } | null`, so the block hash is on `selectedTransaction.tx.blockhash`, not at the top level. The top-level `.blockhash` is always `undefined`, so `getBlock(undefined)` is called and the selected transaction's block context never resolves — the BlockDetails pane for a tx selected via search or by clicking a tx stays empty/stale (and an undefined hash can fail the fetch).

## Fix

Read the hash from `selectedTransaction.tx`, and only fetch the block when a hash is present (falling back to `null`).

## Verification

`npx tsc --noEmit` passes (exit 0) and `eslint` reports no errors on the file (the `any` warning matches the pre-existing pattern this code already used for `blockhash`, which is not in the typed shape). The extension UI path has no unit-test harness in the repo, so this is verified by typecheck/lint and inspection.
