### PR TITLE
Force disconnect on dispose so shutdown does not show a modal

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/activeConnection.ts
+++ b/extentions/neo3-visual-tracker/src/extension/activeConnection.ts
@@ -40,7 +40,9 @@ export default class ActiveConnection {
   dispose() {
     this.onChangeEmitter.dispose();
     this.statusBarItem.dispose();
-    this.disconnect();
+    // Force the disconnect so extension shutdown does not pop a modal
+    // "Disconnect from ...?" confirmation dialog.
+    this.disconnect(true);
   }
 
   async connect(


### PR DESCRIPTION
## Problem

`ActiveConnection` is registered in `context.subscriptions`, so VS Code calls `dispose()` on extension deactivation / window close. `dispose()` ([activeConnection.ts:43](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/activeConnection.ts#L43)) called `this.disconnect()` with no `force` argument:

```ts
dispose() {
  this.onChangeEmitter.dispose();
  this.statusBarItem.dispose();
  this.disconnect();
}
```

`disconnect(force?)` only skips the confirmation when `force` is truthy; otherwise it awaits `IoHelpers.yesNo("Disconnect from ...?")` — a **modal dialog**. So a modal confirmation is popped during extension shutdown (and the unawaited call may not finish disposing the monitor before teardown).

## Fix

Pass `force` so the disconnect runs silently on dispose.

## Verification

`npx tsc --noEmit` and `eslint` both pass with no errors. The shutdown path has no unit-test harness in the repo, so this is verified by typecheck/lint and inspection.
