### PR TITLE
Guard against a neo-express config with no consensus-nodes

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts
@@ -39,7 +39,9 @@ export default class BlockchainIdentifier {
       const nodePorts = neoExpressConfig["consensus-nodes"]
         ?.map((_: any) => parseInt(_["rpc-port"]))
         .filter((_: any) => !!_);
-      if (!nodePorts.length) {
+      // nodePorts is undefined when the config has no "consensus-nodes" key;
+      // guard the access so a partial config is skipped instead of throwing.
+      if (!nodePorts?.length) {
         Log.log(LOG_PREFIX, "No RPC ports found", configPath);
         return undefined;
       }


### PR DESCRIPTION
## Problem

`BlockchainIdentifier.fromNeoExpressConfig` ([blockchainIdentifier.ts:39-45](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts#L39)):

```ts
const nodePorts = neoExpressConfig["consensus-nodes"]
  ?.map((_: any) => parseInt(_["rpc-port"]))
  .filter((_: any) => !!_);
if (!nodePorts.length) { ... }
```

The optional chain makes `nodePorts` `undefined` when the config has no `"consensus-nodes"` key, so `nodePorts.length` throws a `TypeError`. The surrounding try/catch only logs to a hidden output channel and returns `undefined`, so a malformed/partial `.neo-express` file is **silently omitted from the Blockchains tree** with no user-visible error.

## Fix

Guard the length access (`!nodePorts?.length`) so a partial config is skipped cleanly instead of throwing.

## Verification

`npx tsc --noEmit` and `eslint` pass with no errors. Verified by typecheck/lint and inspection.
