### PR TITLE
Open the wallet panel for an address with no autocomplete name

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/panelControllers/walletPanelController.ts
+++ b/extentions/neo3-visual-tracker/src/extension/panelControllers/walletPanelController.ts
@@ -22,7 +22,7 @@ export default class WalletPanelController extends PanelControllerBase<
     super(
       {
         view: "wallet",
-        panelTitle: autoComplete.data.addressNames[address][0] || address,
+        panelTitle: autoComplete.data.addressNames[address]?.[0] || address,
         autoCompleteData: autoComplete.data,
         address,
         addressInfo: null,
@@ -31,7 +31,7 @@ export default class WalletPanelController extends PanelControllerBase<
       context
     );
     autoComplete.onChange((autoCompleteData) => {
-      const name = autoComplete.data.addressNames[address][0] || address;
+      const name = autoComplete.data.addressNames[address]?.[0] || address;
       this.updateViewState({ panelTitle: name, autoCompleteData });
     });
     activeConnection.onChange(() => this.updateBalances());


### PR DESCRIPTION
## Problem

`WalletPanelController` computes the panel title from the autocomplete address-name map ([walletPanelController.ts:25,34](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/panelControllers/walletPanelController.ts#L25)):

```ts
panelTitle: autoComplete.data.addressNames[address][0] || address,
```

`addressNames` is typed `{ [addr]: string[] }`. For any address **not** present in the map — e.g. an arbitrary address opened via the `openWallet` command or a command URI — `addressNames[address]` is `undefined`, so `[0]` throws `TypeError: Cannot read properties of undefined (reading '0')`, aborting construction so the wallet view never opens. The same unguarded access is repeated in the `onChange` handler.

## Fix

Guard the index access (`addressNames[address]?.[0] || address`) in both places so it falls back to the raw address.

## Verification

`npx tsc --noEmit` and `eslint` pass with no errors. Verified by typecheck/lint and inspection.
