### PR TITLE
Guard against an unfetchable transaction in the invoke-file panel

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/panelControllers/invokeFilePanelController.ts
+++ b/extentions/neo3-visual-tracker/src/extension/panelControllers/invokeFilePanelController.ts
@@ -485,7 +485,7 @@ export default class InvokeFilePanelController extends PanelControllerBase<
               _.txid,
               true
             );
-            const confirmed = !!(tx?.tx as any).blockhash;
+            const confirmed = !!(tx?.tx as any)?.blockhash;
             return {
               txid: _.txid,
               blockchain: _.blockchain,


### PR DESCRIPTION
## Problem

`InvokeFilePanelController.updateTransactionList` polls each tracked transaction on every refresh tick and computes ([invokeFilePanelController.ts:488](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/panelControllers/invokeFilePanelController.ts#L488)):

```ts
const tx = await connection?.blockchainMonitor.getTransaction(_.txid, true);
const confirmed = !!(tx?.tx as any).blockhash;
```

`getTransaction` returns `null` for an unknown or still-pending transaction, so `tx?.tx` is `undefined` and `(undefined as any).blockhash` throws. The local try/catch swallows it (returns the original entry), so such transactions **never transition from "pending" to "confirmed"** in the recent-transactions list even after they confirm.

## Fix

Guard the property access (`(tx?.tx as any)?.blockhash`).

## Verification

`npx tsc --noEmit` passes and `eslint` reports no errors. Verified by typecheck/lint and inspection.
