### PR TITLE
Don't prompt for a storage location when only one workspace folder is open

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
@@ -88,11 +88,14 @@ export default class ServerListDetector extends DetectorBase {
         );
       } else {
         let workspaceFolder = workspaceFolders[0];
-        if (workspaceFolders.length > 0) {
+        if (workspaceFolders.length > 1) {
           workspaceFolder = await IoHelpers.multipleChoiceFiles(
             "Please chose a location to store blockchain configuration.",
             ...workspaceFolders
           );
+        }
+        if (!workspaceFolder) {
+          return;
         }
         const fileToEdit = posixPath(workspaceFolder, "neo-servers.json");
         if (!fs.existsSync(fileToEdit)) {


### PR DESCRIPTION
## Problem

`ServerListDetector.customize()` ([serverListDetector.ts:90-97](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts#L90)) prompts for a storage location whenever `workspaceFolders.length > 0`:

```ts
let workspaceFolder = workspaceFolders[0];
if (workspaceFolders.length > 0) {
  workspaceFolder = await IoHelpers.multipleChoiceFiles(...);
}
const fileToEdit = posixPath(workspaceFolder, "neo-servers.json");
```

With exactly one folder open this pops a needless single-item quick-pick. Worse, if the user dismisses it, `multipleChoiceFiles` returns `""` and the code proceeds to write `neo-servers.json` at `posixPath("", "neo-servers.json")` — a relative/garbage path.

## Fix

Prompt only when there is more than one folder (`> 1`), and return early if the picker is dismissed (empty string).

## Verification

`npx tsc --noEmit` and `eslint` pass with no errors. Verified by typecheck/lint and inspection.
