### PR TITLE
Release the previous monitor when switching the active connection

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/activeConnection.ts
+++ b/extentions/neo3-visual-tracker/src/extension/activeConnection.ts
@@ -65,6 +65,10 @@ export default class ActiveConnection {
         blockchainIdentifier,
         rpcClient: new neonCore.rpc.RPCClient(rpcUrl),
       };
+      // Release the previous connection's monitor before replacing it. The pool
+      // is ref-counted, so overwriting without disposing leaks the old monitor,
+      // whose refresh loop keeps polling the previous RPC URL forever.
+      this.connection?.blockchainMonitor.dispose();
       this.connection = connection;
       await this.onChangeEmitter.fire(connection.blockchainIdentifier);
     } else {


### PR DESCRIPTION
## Problem

`ActiveConnection.connect()` ([activeConnection.ts:60-69](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/activeConnection.ts#L60)) obtains a monitor from the ref-counted `BlockchainMonitorPool` and overwrites `this.connection` **without disposing the previous connection's monitor** (only the `else`/disconnect branch disposes):

```ts
const blockchainMonitor = this.blockchainMonitorPool.getMonitor(rpcUrl);
...
this.connection = connection;  // previous monitor never released
```

`getMonitor` increments a ref count and `dispose` decrements it. Because the old monitor is never disposed on a switch, its ref count never drops, so the previous `BlockchainMonitorInternal` keeps its refresh loop polling the old RPC URL **forever**. Switching the active connection (a common workflow, also triggered by contract-invoke when the target blockchain differs) leaks a polling monitor each time.

## Fix

Dispose the prior monitor before replacing it. Ref-counting makes this safe even when reconnecting to the same URL (the new `getMonitor` increments before the old `dispose` decrements).

## Verification

`npx tsc --noEmit` and `eslint` pass with no errors. Verified by typecheck/lint and inspection.
