### PR TITLE
Send Neo Express terminal input to the process stdin

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressTerminal.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressTerminal.ts
@@ -35,7 +35,9 @@ export default class NeoExpressTerminal {
       // Ctrl+C
       this.close();
     } else if (this.process?.exitCode === null) {
-      this.process.send(data);
+      // The child is spawned with default stdio (no IPC channel), so send()
+      // cannot deliver keystrokes; write them to the process stdin instead.
+      this.process.stdin?.write(data);
     } else {
       this.closeEmitter.fire();
     }


### PR DESCRIPTION
## Problem

The integrated "Neo Express" terminal forwards typed keystrokes via `ChildProcess.send()` ([neoExpressTerminal.ts:38](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressTerminal.ts#L38)):

```ts
} else if (this.process?.exitCode === null) {
  this.process.send(data);
}
```

The process is spawned with default stdio (`childProcess.spawn(shellPath, shellArgs)` — pipes, no `ipc`), so there is no IPC channel. `ChildProcess.send()` requires one and fails at runtime (and `send()` is structured IPC, not stdin bytes regardless). The result is that typing into the Neo Express terminal does not reach neoxp's stdin (only Ctrl+C, handled separately, works).

## Fix

Write the input to the process stdin (`this.process.stdin?.write(data)`), which is the pipe created by the default spawn.

## Verification

`npx tsc --noEmit` and `eslint` pass with no errors. Verified by typecheck/lint and inspection.
