### PR TITLE
Deploy with the target network magic instead of hardcoded TestNet

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/commands/neoCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoCommands.ts
@@ -138,11 +138,15 @@ export default class NeoCommands {
       const manifest = neonCore.sc.ContractManifest.fromJson(
         manifestJson as unknown as neonCore.sc.ContractManifestJson
       );
+      // Sign with the target network's magic, not a hardcoded TestNet value, so
+      // deployments to private/express and other custom networks produce a valid
+      // witness instead of a signature the node rejects.
+      const version = await new neonCore.rpc.RPCClient(rpcAddress).getVersion();
       const result = await neonExperimental.deployContract(
         neonCore.sc.NEF.fromBuffer(contractByteCode),
         manifest,
         {
-          networkMagic: neonCore.CONST.MAGIC_NUMBER.TestNet,
+          networkMagic: version.protocol.network,
           rpcAddress,
           account,
         }


### PR DESCRIPTION
## Problem

`NeoCommands.contractDeploy` ([neoCommands.ts:145](https://github.com/neo-project/neo-express/blob/master/extentions/neo3-visual-tracker/src/extension/commands/neoCommands.ts#L145)) passes a hardcoded TestNet magic for every deployment:

```ts
const result = await neonExperimental.deployContract(nef, manifest, {
  networkMagic: neonCore.CONST.MAGIC_NUMBER.TestNet,
  rpcAddress,
  account,
});
```

`deployContract` -> `transaction.sign(account, config.networkMagic)` uses that magic to produce the witness. The command only blocks MainNet by name, so it still permits private/express and other custom networks — where signing with TestNet magic yields a signature the target node rejects (the deploy fails or the transaction is invalid).

## Fix

Query the target node (`getVersion()`) and sign with its `protocol.network` magic (confirmed present on `GetVersionResult`), so deployments to any network produce a valid witness.

## Verification

`npx tsc --noEmit` and `eslint` pass with no errors. Verified by typecheck/lint and inspection.
