### PR TITLE
Reject negative and separator-laden transfer amounts

### DIFF
--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -528,7 +528,17 @@ namespace NeoExpress
                 return new All();
             }
 
-            if (decimal.TryParse(quantity, System.Globalization.CultureInfo.InvariantCulture, out var amount))
+            // A token amount is a non-negative decimal: allow only a decimal point and
+            // surrounding whitespace. The default (NumberStyles.Number) would otherwise
+            // accept a leading sign (so "-5" became a negative transfer) and thousands
+            // separators (so a mistyped "1,5" silently parsed as 15).
+            const System.Globalization.NumberStyles styles =
+                System.Globalization.NumberStyles.AllowDecimalPoint
+                | System.Globalization.NumberStyles.AllowLeadingWhite
+                | System.Globalization.NumberStyles.AllowTrailingWhite;
+
+            if (decimal.TryParse(quantity, styles, System.Globalization.CultureInfo.InvariantCulture, out var amount)
+                && amount >= 0)
             {
                 return amount;
             }

--- a/test/test.workflowvalidation/ParseQuantityTests.cs
+++ b/test/test.workflowvalidation/ParseQuantityTests.cs
@@ -36,4 +36,23 @@ public class ParseQuantityTests
             CultureInfo.CurrentCulture = original;
         }
     }
+
+    [Theory]
+    [InlineData("-5")]      // negative amount
+    [InlineData("1,5")]     // thousands separator mistaken for a decimal point
+    [InlineData("1,000")]   // thousands separator
+    [InlineData("+10")]     // leading sign
+    [InlineData("0x10")]    // not a decimal
+    public void ParseQuantity_rejects_invalid_amounts(string quantity)
+    {
+        var act = () => TransactionExecutor.ParseQuantity(quantity);
+
+        act.Should().Throw<System.Exception>().WithMessage("*Invalid quantity*");
+    }
+
+    [Fact]
+    public void ParseQuantity_accepts_all()
+    {
+        TransactionExecutor.ParseQuantity("all").IsT1.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Problem

`TransactionExecutor.ParseQuantity` ([TransactionExecutor.cs:531](https://github.com/neo-project/neo-express/blob/master/src/neoxp/TransactionExecutor.cs#L531)) parses the transfer amount with the default `decimal.TryParse(string, IFormatProvider, out)` overload, i.e. `NumberStyles.Number` — which allows a **leading sign** and **thousands separators**:

- `neoxp transfer -5 gas alice bob` parses `-5` as a **negative amount**.
- A mistyped `neoxp transfer 1,5 gas alice bob` silently parses as **15** (the `,` is read as a thousands separator) instead of being rejected.
- `+10`, `1,000`, `  10  ` are likewise accepted.

A token transfer amount should be a non-negative decimal.

## Fix

Restrict the styles to `AllowDecimalPoint | AllowLeadingWhite | AllowTrailingWhite` and reject negative values, so malformed amounts fail with the existing `Invalid quantity value` error. `1.5` and `all` still work.

## Tests

Added a theory rejecting `-5`, `1,5`, `1,000`, `+10`, `0x10`, plus an `all` case; the existing invariant-culture `1.5` test still passes. Reverting to `NumberStyles.Number` makes the rejection cases fail (verified). Release build is clean, format reports no changes.
