### PR TITLE
Give a clear error for a neo-express file with no consensus nodes

### DIFF
--- a/src/neoxp/ExpressChainManagerFactory.cs
+++ b/src/neoxp/ExpressChainManagerFactory.cs
@@ -127,6 +127,11 @@ namespace NeoExpress
 
             var chain = fileSystem.LoadChain(path);
 
+            if (chain.ConsensusNodes.Count == 0)
+            {
+                throw new Exception($"{path} is not a valid neo-express file: it has no consensus nodes");
+            }
+
             // validate neo-express file by ensuring stored node zero default account SignatureRedeemScript matches a generated script
             var account = chain.ConsensusNodes[0].Wallet.DefaultAccount ?? throw new InvalidOperationException("consensus node 0 missing default account");
             var keyPair = new KeyPair(account.PrivateKey.HexToBytes());


### PR DESCRIPTION
## Problem

`ExpressChainManagerFactory.LoadChain` indexes `chain.ConsensusNodes[0]` immediately after loading ([ExpressChainManagerFactory.cs:131](https://github.com/neo-project/neo-express/blob/master/src/neoxp/ExpressChainManagerFactory.cs#L131)):

```csharp
var chain = fileSystem.LoadChain(path);
var account = chain.ConsensusNodes[0].Wallet.DefaultAccount ?? ...
```

A syntactically valid `.neo-express` file with an empty `"consensus-nodes"` array (e.g. `{ "magic": 1, "consensus-nodes": [] }`) makes `[0]` throw a bare `ArgumentOutOfRangeException`, so **every** command that loads the chain crashes with an opaque low-level error instead of a clear message.

## Fix

Check for an empty consensus-node list and throw a clear message naming the file before indexing.

## Verification

Release build is clean and `dotnet format --verify-no-changes` reports no changes. The guard manifests deterministically (`List[0]` on an empty list throws); `LoadChain` reads from disk and has no unit-test harness for this path, so this is verified by build and inspection.
