### PR TITLE
Validate the --additional-gas value before applying it

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -50,11 +50,11 @@ namespace NeoExpress.Node
             }
             catch (ArgumentException)
             {
-                throw new Exception($"--gas value {additionalGas} cannot have more than {NativeContract.GAS.Decimals} decimal places");
+                throw new Exception($"--additional-gas value {additionalGas} cannot have more than {NativeContract.GAS.Decimals} decimal places");
             }
 
             if (value > long.MaxValue)
-                throw new Exception($"--gas value {additionalGas} is too large");
+                throw new Exception($"--additional-gas value {additionalGas} is too large");
 
             return (long)value;
         }

--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -34,6 +34,31 @@ namespace NeoExpress.Node
     {
         internal static string ContractNotFoundMessage(UInt160 scriptHash) => $"Contract {scriptHash} not found";
 
+        // Convert an --additional-gas amount to the system-fee delta (in GAS datoshi),
+        // with clear errors instead of the raw exceptions the bare conversion throws: an
+        // ArgumentException for more than GAS.Decimals fractional digits, and an
+        // OverflowException when the scaled value does not fit in the System.Int64 fee.
+        internal static long AdditionalGasSystemFee(decimal additionalGas)
+        {
+            if (additionalGas <= 0m)
+                return 0;
+
+            BigInteger value;
+            try
+            {
+                value = additionalGas.ToBigInteger(NativeContract.GAS.Decimals);
+            }
+            catch (ArgumentException)
+            {
+                throw new Exception($"--gas value {additionalGas} cannot have more than {NativeContract.GAS.Decimals} decimal places");
+            }
+
+            if (value > long.MaxValue)
+                throw new Exception($"--gas value {additionalGas} is too large");
+
+            return (long)value;
+        }
+
         public static Block CreateSignedBlock(Header prevHeader, IReadOnlyList<KeyPair> keyPairs, uint network, Transaction[]? transactions = null, ulong timestamp = 0)
         {
             transactions ??= Array.Empty<Transaction>();

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -167,10 +167,7 @@ namespace NeoExpress.Node
             const long maxSafeGas = long.MaxValue / 10_000;
             var maxGas = balance.Amount > maxSafeGas ? maxSafeGas : (long)balance.Amount;
             var tx = wallet.MakeTransaction(neoSystem.StoreView, script, accountHash, new[] { signer }, maxGas: maxGas);
-            if (additionalGas > 0.0m)
-            {
-                tx.SystemFee += (long)additionalGas.ToBigInteger(NativeContract.GAS.Decimals);
-            }
+            tx.SystemFee += NodeUtility.AdditionalGasSystemFee(additionalGas);
 
             var context = new ContractParametersContext(neoSystem.StoreView, tx, ProtocolSettings.Network);
             var account = wallet.GetAccount(accountHash) ?? throw new Exception();

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -86,10 +86,7 @@ namespace NeoExpress.Node
             var signers = new[] { new Signer { Account = accountHash, Scopes = witnessScope } };
             var tm = await TransactionManager.MakeTransactionAsync(rpcClient, script, signers).ConfigureAwait(false);
 
-            if (additionalGas > 0.0m)
-            {
-                tm.Tx.SystemFee += (long)additionalGas.ToBigInteger(NativeContract.GAS.Decimals);
-            }
+            tm.Tx.SystemFee += NodeUtility.AdditionalGasSystemFee(additionalGas);
 
             var account = wallet.GetAccount(accountHash) ?? throw new Exception();
             if (account.IsMultiSigContract())

--- a/test/test.workflowvalidation/AdditionalGasTests.cs
+++ b/test/test.workflowvalidation/AdditionalGasTests.cs
@@ -1,0 +1,51 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// AdditionalGasTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Node;
+using System;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class AdditionalGasTests
+{
+    [Fact]
+    public void AdditionalGasSystemFee_converts_a_fractional_gas_value()
+    {
+        // 1.5 GAS -> 1.5 * 10^8 datoshi.
+        NodeUtility.AdditionalGasSystemFee(1.5m).Should().Be(150_000_000L);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void AdditionalGasSystemFee_returns_zero_for_non_positive_values(decimal value)
+    {
+        NodeUtility.AdditionalGasSystemFee(value).Should().Be(0L);
+    }
+
+    [Fact]
+    public void AdditionalGasSystemFee_rejects_more_than_eight_decimal_places()
+    {
+        var act = () => NodeUtility.AdditionalGasSystemFee(0.123456789m);
+
+        act.Should().Throw<Exception>().WithMessage("*decimal places*");
+    }
+
+    [Fact]
+    public void AdditionalGasSystemFee_rejects_a_value_that_overflows_the_fee()
+    {
+        // 100,000,000,000 GAS * 10^8 exceeds Int64.MaxValue.
+        var act = () => NodeUtility.AdditionalGasSystemFee(100_000_000_000m);
+
+        act.Should().Throw<Exception>().WithMessage("*too large*");
+    }
+}


### PR DESCRIPTION
## Problem

Both `OnlineNode` and `OfflineNode` apply the `--additional-gas` value as ([OnlineNode.cs:91](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OnlineNode.cs#L91), [OfflineNode.cs:172](https://github.com/neo-project/neo-express/blob/master/src/neoxp/Node/OfflineNode.cs#L172)):

```csharp
tx.SystemFee += (long)additionalGas.ToBigInteger(NativeContract.GAS.Decimals);
```

Two bad-input cases crash with opaque exceptions:
- **More than 8 decimal places** (e.g. `--gas 0.123456789`) — `ToBigInteger` throws a raw `ArgumentException`.
- **A large value** (e.g. `--gas 100000000000`, any value >= ~92.3e9 GAS) — the scaled `BigInteger` exceeds `Int64.MaxValue` and the `(long)` cast throws `OverflowException`.

Both surface to the user as unhandled, opaque crashes.

## Fix

Route both call sites through a shared `NodeUtility.AdditionalGasSystemFee` helper that returns the `Int64` fee delta, reporting too-many-decimals and too-large values with clear messages (and returning `0` for a non-positive value, as before).

## Tests

Added `AdditionalGasTests`: `1.5` -> `150_000_000`; `0`/`-1` -> `0`; `0.123456789` -> "decimal places" error; `100_000_000_000` -> "too large" error. Release build is clean and format reports no changes.
