### PR TITLE
Report an invalid policy file clearly instead of crashing or hiding it

### DIFF
--- a/src/neoxp/Models/PolicyValues.cs
+++ b/src/neoxp/Models/PolicyValues.cs
@@ -43,13 +43,13 @@ namespace NeoExpress.Models
 
         public static PolicyValues FromJson(JObject json)
         {
-            var gasPerBlock = ParseGasValue(json[nameof(GasPerBlock)]!);
-            var minimumDeploymentFee = ParseGasValue(json[nameof(MinimumDeploymentFee)]!);
-            var candidateRegistrationFee = ParseGasValue(json[nameof(CandidateRegistrationFee)]!);
-            var oracleRequestFee = ParseGasValue(json[nameof(OracleRequestFee)]!);
-            var networkFeePerByte = ParseGasValue(json[nameof(NetworkFeePerByte)]!);
-            var storageFeeFactor = SafeCast.ToUInt32((BigInteger)json[nameof(StorageFeeFactor)]!.AsNumber());
-            var executionFeeFactor = SafeCast.ToUInt32((BigInteger)json[nameof(ExecutionFeeFactor)]!.AsNumber());
+            var gasPerBlock = ParseGasValue(Required(nameof(GasPerBlock)));
+            var minimumDeploymentFee = ParseGasValue(Required(nameof(MinimumDeploymentFee)));
+            var candidateRegistrationFee = ParseGasValue(Required(nameof(CandidateRegistrationFee)));
+            var oracleRequestFee = ParseGasValue(Required(nameof(OracleRequestFee)));
+            var networkFeePerByte = ParseGasValue(Required(nameof(NetworkFeePerByte)));
+            var storageFeeFactor = SafeCast.ToUInt32((BigInteger)Required(nameof(StorageFeeFactor)).AsNumber());
+            var executionFeeFactor = SafeCast.ToUInt32((BigInteger)Required(nameof(ExecutionFeeFactor)).AsNumber());
 
             return new PolicyValues
             {
@@ -61,6 +61,11 @@ namespace NeoExpress.Models
                 StorageFeeFactor = storageFeeFactor,
                 ExecutionFeeFactor = executionFeeFactor,
             };
+
+            // A missing key would otherwise dereference null and throw an opaque
+            // NullReferenceException; name the absent value instead.
+            JToken Required(string name) => json[name]
+                ?? throw new FormatException($"policy is missing required value \"{name}\"");
 
             static BigDecimal ParseGasValue(JToken json) => new BigDecimal(BigInteger.Parse(json.AsString()), NativeContract.GAS.Decimals);
         }

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -675,12 +675,20 @@ namespace NeoExpress
                 using var stream = fileSystem.File.OpenRead(filename);
                 using var reader = new StreamReader(stream);
                 var text = await reader.ReadToEndAsync().ConfigureAwait(false);
-                var json = (Neo.Json.JObject)Neo.Json.JObject.Parse(text)!;
                 try
                 {
+                    // Parse inside the try so malformed JSON is reported below rather than
+                    // throwing an unhandled exception and crashing the command.
+                    var json = (Neo.Json.JObject)Neo.Json.JObject.Parse(text)!;
                     return PolicyValues.FromJson(json!);
                 }
-                catch { }
+                catch (Exception ex) when (ex is FormatException or InvalidCastException)
+                {
+                    // The file exists but its contents are not a valid policy (malformed JSON,
+                    // wrong root type, or a missing/invalid value). Report why instead of
+                    // swallowing the cause and surfacing a generic "could not load" message.
+                    throw new Exception($"Policy file {filename} is invalid: {ex.Message}");
+                }
             }
 
             return new None();

--- a/test/test.workflowvalidation/PolicyValuesTests.cs
+++ b/test/test.workflowvalidation/PolicyValuesTests.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// PolicyValuesTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.Json;
+using NeoExpress.Models;
+using System;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class PolicyValuesTests
+{
+    [Fact]
+    public void FromJson_names_a_missing_required_value()
+    {
+        // Valid JSON, but the ExecutionFeeFactor key is absent. This must be reported as a
+        // missing value rather than dereferencing null and throwing a NullReferenceException.
+        var json = (JObject)JObject.Parse(
+            "{\"GasPerBlock\":\"500000000\",\"MinimumDeploymentFee\":\"1000000000\","
+            + "\"CandidateRegistrationFee\":\"100000000000\",\"OracleRequestFee\":\"50000000\","
+            + "\"NetworkFeePerByte\":\"1000\",\"StorageFeeFactor\":100000}")!;
+
+        var act = () => PolicyValues.FromJson(json);
+
+        act.Should().Throw<FormatException>().WithMessage("*ExecutionFeeFactor*");
+    }
+
+    [Fact]
+    public void FromJson_round_trips_a_complete_policy()
+    {
+        var original = new PolicyValues
+        {
+            GasPerBlock = new Neo.BigDecimal((System.Numerics.BigInteger)500000000, 8),
+            MinimumDeploymentFee = new Neo.BigDecimal((System.Numerics.BigInteger)1000000000, 8),
+            CandidateRegistrationFee = new Neo.BigDecimal((System.Numerics.BigInteger)100000000000, 8),
+            OracleRequestFee = new Neo.BigDecimal((System.Numerics.BigInteger)50000000, 8),
+            NetworkFeePerByte = new Neo.BigDecimal((System.Numerics.BigInteger)1000, 8),
+            StorageFeeFactor = 100000,
+            ExecutionFeeFactor = 30,
+        };
+
+        var result = PolicyValues.FromJson(original.ToJson());
+
+        result.StorageFeeFactor.Should().Be(original.StorageFeeFactor);
+        result.ExecutionFeeFactor.Should().Be(original.ExecutionFeeFactor);
+        result.GasPerBlock.Value.Should().Be(original.GasPerBlock.Value);
+    }
+}


### PR DESCRIPTION
## Summary

`policy sync` mishandled an invalid policy file in two ways:

1. **Malformed JSON crashed the command.** `TryLoadPolicyFromFileSystemAsync` parsed the file with `JObject.Parse` *outside* the `try`, so a syntactically invalid file threw an unhandled exception.
2. **A missing value was hidden.** A file that was valid JSON but missing a required key (e.g. `ExecutionFeeFactor`) dereferenced `null` inside `PolicyValues.FromJson` and threw a `NullReferenceException`. An empty `catch { }` swallowed it, so the method returned `None` and the caller reported only the generic `Could not load policy values from "<source>"` — with no hint that the file existed but was incomplete.

## Fix

- `PolicyValues.FromJson`: look up each required value through a `Required(name)` helper that throws `FormatException($"policy is missing required value \"{name}\"")` instead of dereferencing `null`.
- `TryLoadPolicyFromFileSystemAsync`: parse the JSON inside the `try`, and replace the empty `catch { }` with `catch (Exception ex) when (ex is FormatException or InvalidCastException)` that throws `Policy file <path> is invalid: <reason>`. A missing file still returns `None`; an existing-but-invalid file is now reported with its cause.

## Testing

- New `PolicyValuesTests.FromJson_names_a_missing_required_value` asserts the `FormatException` names the absent key; it fails on the unpatched code (`NullReferenceException`) and passes with the fix.
- `PolicyValuesTests.FromJson_round_trips_a_complete_policy` guards the happy path.
- `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
