### PR TITLE
Report an empty debug-info archive instead of crashing

### DIFF
--- a/src/bctklib/models/DebugInfo.cs
+++ b/src/bctklib/models/DebugInfo.cs
@@ -219,6 +219,10 @@ namespace Neo.BlockchainToolkit.Models
         internal static async Task<DebugInfo> LoadCompressedAsync(System.IO.Stream stream)
         {
             using var archive = new ZipArchive(stream);
+            if (archive.Entries.Count == 0)
+            {
+                throw new FormatException("Debug info archive contains no entries");
+            }
             using var entryStream = archive.Entries[0].Open();
             return await LoadAsync(entryStream).ConfigureAwait(false);
         }

--- a/test/test.bctklib/DebugInfoTest.cs
+++ b/test/test.bctklib/DebugInfoTest.cs
@@ -28,6 +28,19 @@ namespace test.bctklib
         const string TEST_HASH = "0xf69e5188632deb3a9273519efc86cb68da8d42b8";
 
         [Fact]
+        public async Task LoadCompressedAsync_reports_an_empty_archive()
+        {
+            using var ms = new MemoryStream();
+            using (new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            { }
+            ms.Position = 0;
+
+            // An empty .nefdbgnfo archive previously crashed on Entries[0].
+            await Assert.ThrowsAsync<FormatException>(
+                () => DebugInfo.LoadCompressedAsync(ms));
+        }
+
+        [Fact]
         public void can_parse_no_docroot()
         {
             var text = Utility.GetResource("registrar-no-docroot.debug.json");


### PR DESCRIPTION
## Problem

`DebugInfo.LoadCompressedAsync` ([DebugInfo.cs:219-224](https://github.com/neo-project/neo-express/blob/master/src/bctklib/models/DebugInfo.cs#L219)) opens `archive.Entries[0]` without checking the archive has any entries:

```csharp
using var archive = new ZipArchive(stream);
using var entryStream = archive.Entries[0].Open();
```

A structurally valid but **empty** (zero-entry) ZIP saved as a `.nefdbgnfo` file makes `Entries[0]` throw an opaque `ArgumentOutOfRangeException`.

## Fix

Throw a clear `FormatException` when the archive contains no entries.

## Tests

Added `LoadCompressedAsync_reports_an_empty_archive` to `DebugInfoTest`: an empty zip archive now throws `FormatException`. Removing the guard makes it fail (verified). Release build is clean and `dotnet format --verify-no-changes` reports no changes.
