### PR TITLE
Report malformed checkpoint ADDRESS metadata as an invalid archive

### DIFF
--- a/src/bctklib/persistence/RocksDbUtility.cs
+++ b/src/bctklib/persistence/RocksDbUtility.cs
@@ -195,7 +195,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 ExtractCheckpoint(checkPointArchive, restorePath);
                 return metadata;
             }
-            catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException)
+            catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException or FormatException or OverflowException)
             {
                 throw new Exception($"Checkpoint {checkPointArchive} is not a valid checkpoint archive: {ex.Message}");
             }

--- a/test/test.bctklib/RocksDbUtilityOpenTests.cs
+++ b/test/test.bctklib/RocksDbUtilityOpenTests.cs
@@ -32,5 +32,35 @@ namespace test.bctklib
             // captured stack; a plain `throw ex;` would reset the stack and omit it.
             ex.StackTrace.Should().Contain("End of stack trace from previous location");
         }
+
+        // Restoring a checkpoint whose ADDRESS metadata file is malformed (for example a
+        // non-numeric network value) must be reported as an invalid checkpoint archive rather
+        // than surfacing the raw FormatException/OverflowException thrown while parsing it.
+        [Fact]
+        public void RestoreCheckpoint_reports_a_malformed_address_metadata_file()
+        {
+            var archivePath = Path.Combine(Path.GetTempPath(), $"neo-express-bad-checkpoint-{Guid.NewGuid():N}.neoxp-checkpoint");
+            var restorePath = Path.Combine(Path.GetTempPath(), $"neo-express-restore-{Guid.NewGuid():N}");
+            try
+            {
+                using (var archive = System.IO.Compression.ZipFile.Open(archivePath, System.IO.Compression.ZipArchiveMode.Create))
+                {
+                    var entry = archive.CreateEntry("ADDRESS" + ".neo-express");
+                    using var writer = new StreamWriter(entry.Open());
+                    writer.Write("not-a-number\n53\nNXV7ZhHiyM1aHXwpVsRZC6BwNFP2jghXAq\n");
+                }
+
+                var act = () => RocksDbUtility.RestoreCheckpoint(archivePath, restorePath);
+
+                act.Should().Throw<Exception>().WithMessage("*not a valid checkpoint archive*");
+            }
+            finally
+            {
+                if (File.Exists(archivePath))
+                    File.Delete(archivePath);
+                if (Directory.Exists(restorePath))
+                    Directory.Delete(restorePath, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Restoring a checkpoint whose `ADDRESS.neo-express` metadata file is corrupt surfaced a raw parse error instead of the intended "not a valid checkpoint archive" message.

`RocksDbUtility.RestoreCheckpoint` wraps validation failures in a clear error, but its catch filter only covered `InvalidDataException` and `EndOfStreamException`:

```csharp
catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException)
```

`GetCheckpointMetadata` parses the ADDRESS metadata with `uint.Parse` (network), `byte.Parse` (address version) and `ToScriptHash`. A corrupt file (non-numeric network, out-of-range address version, malformed address) makes these throw `FormatException` or `OverflowException`, which escaped the filter and propagated as an opaque parse error such as:

```
The input string 'not-a-number' was not in a correct format.
```

## Fix

Include `FormatException` and `OverflowException` in the catch filter so a malformed ADDRESS metadata file is reported as an invalid checkpoint archive.

## Testing

- New `RocksDbUtilityOpenTests.RestoreCheckpoint_reports_a_malformed_address_metadata_file` builds a checkpoint archive with a non-numeric network line and asserts the "not a valid checkpoint archive" message. It fails on the unpatched code (raw `FormatException`) and passes with the fix.
- `dotnet build -c Release`, full `RocksDbUtility`/`Checkpoint` test filter (6 passed), and `dotnet format --verify-no-changes` all clean.
