### PR TITLE
Report malformed invocation-file arguments as an invalid file

### DIFF
--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -69,8 +69,12 @@ namespace Neo.BlockchainToolkit
                 var document = await JContainer.LoadAsync(jsonReader).ConfigureAwait(false);
                 return LoadInvocationScript(document);
             }
-            catch (Exception ex) when (ex is JsonException or FormatException or InvalidCastException or IOException)
+            catch (Exception ex) when (ex is JsonException or FormatException or InvalidCastException or IOException
+                or ArgumentException or IndexOutOfRangeException)
             {
+                // ArgumentException covers an unsupported parameter token type; IndexOutOfRangeException
+                // covers an empty or null public key reaching ECPoint.Parse. Both mean the file is
+                // malformed, so report it as such instead of surfacing a raw low-level exception.
                 throw new Exception($"Invocation file {path} is invalid: {ex.Message}");
             }
         }
@@ -495,7 +499,9 @@ namespace Neo.BlockchainToolkit
 
         internal ContractParameter ParseObjectParameter(JObject json)
         {
-            var type = Enum.Parse<ContractParameterType>(json.Value<string>("type") ?? throw new JsonException("missing type field"));
+            var typeString = json.Value<string>("type") ?? throw new JsonException("missing type field");
+            if (!Enum.TryParse<ContractParameterType>(typeString, out var type))
+                throw new FormatException($"invalid parameter type \"{typeString}\"");
             var valueProp = json["value"] ?? throw new JsonException("missing value field");
 
             object value = type switch

--- a/test/test.bctklib/ContractParameterParserTest.cs
+++ b/test/test.bctklib/ContractParameterParserTest.cs
@@ -356,6 +356,48 @@ namespace test.bctklib
         }
 
         [Fact]
+        public async Task LoadInvocationScriptAsync_reports_an_invalid_parameter_type()
+        {
+            // A parameter with an unrecognized "type" string must be reported as an invalid
+            // invocation file, not surface the raw "Requested value 'X' was not found." from
+            // Enum.Parse.
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var invocationPath = fileSystem.Path.Combine(rootPath, "bad-type.neo-invoke.json");
+            var content = "[{\"contract\":\"0xbcbbcd38fb0c097be28e6aef0177f5d65534eb3b\",\"operation\":\"x\","
+                + "\"args\":[{\"type\":\"NotAType\",\"value\":\"1\"}]}]";
+            fileSystem.AddFile(invocationPath, new MockFileData(content));
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var action = () => parser.LoadInvocationScriptAsync(invocationPath);
+
+            var exception = await action.Should().ThrowAsync<Exception>();
+            exception.Which.Message.Should().StartWith($"Invocation file {invocationPath} is invalid:");
+            exception.Which.Message.Should().Contain("NotAType");
+            exception.Which.InnerException.Should().BeNull();
+        }
+
+        [Theory]
+        // A null public-key value reaches ECPoint.Parse and previously threw a raw
+        // IndexOutOfRangeException; a bare float argument previously threw a raw ArgumentException.
+        [InlineData("[{\"contract\":\"0xbcbbcd38fb0c097be28e6aef0177f5d65534eb3b\",\"operation\":\"x\",\"args\":[{\"type\":\"PublicKey\",\"value\":null}]}]")]
+        [InlineData("[{\"contract\":\"0xbcbbcd38fb0c097be28e6aef0177f5d65534eb3b\",\"operation\":\"x\",\"args\":[1.5]}]")]
+        public async Task LoadInvocationScriptAsync_reports_a_malformed_argument(string content)
+        {
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var invocationPath = fileSystem.Path.Combine(rootPath, "bad-arg.neo-invoke.json");
+            fileSystem.AddFile(invocationPath, new MockFileData(content));
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var action = () => parser.LoadInvocationScriptAsync(invocationPath);
+
+            var exception = await action.Should().ThrowAsync<Exception>();
+            exception.Which.Message.Should().StartWith($"Invocation file {invocationPath} is invalid:");
+            exception.Which.InnerException.Should().BeNull();
+        }
+
+        [Fact]
         public async Task LoadInvocationScriptAsync_rejects_oversized_invocation_file()
         {
             var fileSystem = new MockFileSystem();


### PR DESCRIPTION
## Summary

An invocation file (`.neo-invoke.json`) with a malformed argument surfaced raw, context-free errors instead of the standard "invocation file is invalid" message.

`LoadInvocationScriptAsync` turns malformed files into a clear error, but its catch filter only covered `JsonException`, `FormatException`, `InvalidCastException` and `IOException`. Several argument-parsing failures throw other types that escaped the wrapping:

| Input | Raw exception (before) |
|---|---|
| `{"type":"NotAType","value":"1"}` | `ArgumentException: Requested value 'NotAType' was not found.` (from `Enum.Parse`) |
| a bare float argument, e.g. `1.5` | `ArgumentException: Invalid JTokenType Float` |
| `{"type":"PublicKey","value":null}` | `IndexOutOfRangeException: Index was outside the bounds of the array.` (from `ECPoint.Parse`) |

Well-formed-but-invalid values that already throw `FormatException` (out-of-range integers, non-hex hashes, numeric public keys) were reported correctly; these three paths were not.

## Fix

- Resolve the parameter `type` with `Enum.TryParse` and throw a `FormatException` that names the offending value, so the most common mistake (a mistyped type) gets a clear message.
- Widen the `LoadInvocationScriptAsync` catch filter to include `ArgumentException` and `IndexOutOfRangeException`, so an unsupported argument token or an empty/null public key is reported as an invalid invocation file rather than a raw low-level exception.

## Testing

- `LoadInvocationScriptAsync_reports_an_invalid_parameter_type` asserts the wrapped message names the bad type.
- `LoadInvocationScriptAsync_reports_a_malformed_argument` (theory) covers the null public key (previously `IndexOutOfRangeException`) and a float argument (previously `ArgumentException`).
- All three fail on the unpatched code and pass with the fix; full `ContractParameterParser`/`ParseParameter` suite (41 passed), `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
