### PR TITLE
Match only hexadecimal digits in Base64Fixed unicode escapes

### DIFF
--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -128,7 +128,9 @@ namespace NeoExpress
         public static string Base64Fixed(string str)
         {
             //Unicode e.g. \u002B
-            MatchCollection mc = Regex.Matches(str, @"\\u([\w]{2})([\w]{2})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            // Match only genuine hexadecimal escapes; a broader \w class would also match
+            // non-hex sequences (for example \uZZZZ) that then throw when parsed as hex.
+            MatchCollection mc = Regex.Matches(str, @"\\u([0-9a-fA-F]{2})([0-9a-fA-F]{2})", RegexOptions.Compiled);
             byte[] bts = new byte[2];
             foreach (Match m in mc)
             {

--- a/test/test.workflowvalidation/Base64FixedTests.cs
+++ b/test/test.workflowvalidation/Base64FixedTests.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Base64FixedTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class Base64FixedTests
+{
+    [Fact]
+    public void Base64Fixed_decodes_a_hex_unicode_escape()
+    {
+        // "+" is the escaped form of '+' in a Base64 string.
+        var input = "DCECbzTesnBofh/Xng1SofChKkBC7jhVmLxCN1vk" + "\\u002B" + "49xa2pBVuezJw==";
+
+        var result = Extensions.Base64Fixed(input);
+
+        result.Should().Be("DCECbzTesnBofh/Xng1SofChKkBC7jhVmLxCN1vk+49xa2pBVuezJw==");
+    }
+
+    [Fact]
+    public void Base64Fixed_leaves_a_non_hex_unicode_sequence_unchanged()
+    {
+        // The escape characters are word characters but not hexadecimal digits. The previous
+        // \w-based pattern matched them and then threw when parsing them as hex.
+        const string input = @"abc\uZZZZdef";
+
+        var result = Extensions.Base64Fixed(input);
+
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void TryGetBytesFromBase64String_returns_false_for_a_non_hex_unicode_sequence()
+    {
+        // A Try method must not throw for malformed input.
+        var act = () => @"\uZZZZ".TryGetBytesFromBase64String(out _);
+
+        act.Should().NotThrow().Which.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`neoxp execute` aborted with an opaque parse error when the supplied script string contained a `\u` sequence followed by non-hexadecimal word characters.

`Base64Fixed` converts escaped unicode characters back to ASCII with this pattern:

```csharp
MatchCollection mc = Regex.Matches(str, @"\\u([\w]{2})([\w]{2})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
...
bts[0] = (byte)int.Parse(m.Groups[2].Value, NumberStyles.HexNumber);
```

`\w` matches any word character (including `g`–`z`, `G`–`Z` and `_`), but each captured pair is parsed as hexadecimal. An input such as `\uZZZZ` matches the pattern yet throws `FormatException: The input string 'ZZ' was not in a correct format.` when parsed.

`Base64Fixed` runs inside `TryGetBytesFromBase64String`, so that `Try` method threw instead of returning `false`. `ExecuteCommand.ConvertTextToScript` relies on the `Try` contract — the thrown exception skipped the `?? LoadFileScript(...)` fallback and surfaced as a raw error.

## Fix

Restrict the pattern to hexadecimal digits (`[0-9a-fA-F]`) so only genuine escapes are converted. Non-hex sequences are left untouched and flow on to `Convert.TryFromBase64String`, which reports them normally.

## Testing

- New `Base64FixedTests`:
  - decodes a valid `+` escape to `+`,
  - leaves a non-hex `\uZZZZ` sequence unchanged,
  - `TryGetBytesFromBase64String` returns `false` (does not throw) for a non-hex `\u` sequence.
- The two crash-guard tests fail on the unpatched pattern (`FormatException`) and pass with the fix.
- `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
