### PR TITLE
Make the export commands scriptable with a --password option

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -158,7 +158,8 @@ Usage: neoxp export [Options]
 
 Arguments:
 [Options]:
-  -i|--input <INPUT>  Path to neo-express data file
+  -i|--input <INPUT>        Path to neo-express data file
+  -p|--password <PASSWORD>  Password to use for the exported wallets (prompted for if unspecified)
 ```
 
 The `export` command saves the wallet and settings of each consensus node in a standard format. The exported files can be found under the root directory of neoxp.exe. This allows for standard Neo node implementations such as Neo-CLI to connect to a running Neo-Express blockchain network.
@@ -233,9 +234,10 @@ Usage: neoxp wallet export [Options] <Name>
 
 Arguments:
 [Options]:
-  -i|--input <INPUT>    Path to neo-express data file
-  -o|--output <OUTPUT>  NEP-6 wallet name (Defaults to Neo-Express name if unspecified)
-  -f|--force            Overwrite existing data
+  -i|--input <INPUT>        Path to neo-express data file
+  -o|--output <OUTPUT>      NEP-6 wallet name (Defaults to Neo-Express name if unspecified)
+  -f|--force                Overwrite existing data
+  -p|--password <PASSWORD>  Password to use for the exported NEP-6 wallet (prompted for if unspecified)
 <Name>: Wallet name
 ```
 

--- a/src/neoxp/Commands/ExportCommand.cs
+++ b/src/neoxp/Commands/ExportCommand.cs
@@ -33,9 +33,13 @@ namespace NeoExpress.Commands
         [Option(Description = "Path to neo-express data file")]
         internal string Input { get; init; } = string.Empty;
 
+        [Option(Description = "Password to use for the exported wallets (prompted for if unspecified)")]
+        internal string Password { get; init; } = string.Empty;
+
         internal void Execute(System.IO.TextWriter writer)
         {
-            var password = Prompt.GetPassword("Input password to use for exported wallets");
+            var password = Extensions.ResolveExportPassword(Password, Console.IsInputRedirected,
+                () => Prompt.GetPassword("Input password to use for exported wallets"));
             var (chainManager, _) = chainManagerFactory.LoadChain(Input);
             var chain = chainManager.Chain;
             var folder = fileSystem.Directory.GetCurrentDirectory();

--- a/src/neoxp/Commands/WalletCommand.Export.cs
+++ b/src/neoxp/Commands/WalletCommand.Export.cs
@@ -42,6 +42,9 @@ namespace NeoExpress.Commands
             [Option(Description = "Overwrite existing data")]
             internal bool Force { get; }
 
+            [Option(Description = "Password to use for the exported NEP-6 wallet (prompted for if unspecified)")]
+            internal string Password { get; init; } = string.Empty;
+
             internal string Execute()
             {
                 var output = string.IsNullOrEmpty(Output)
@@ -68,7 +71,8 @@ namespace NeoExpress.Commands
                     }
                 }
 
-                var password = Prompt.GetPassword("Input password to use for exported wallet");
+                var password = Extensions.ResolveExportPassword(Password, Console.IsInputRedirected,
+                    () => Prompt.GetPassword("Input password to use for exported wallet"));
                 var devWallet = DevWallet.FromExpressWallet(chainManager.ProtocolSettings, wallet);
                 devWallet.Export(output, password);
                 return output;

--- a/src/neoxp/Extensions/Extensions.cs
+++ b/src/neoxp/Extensions/Extensions.cs
@@ -61,6 +61,18 @@ namespace NeoExpress
             Console.WriteLine($"\x1b[33mWarning: {value}\x1b[0m");
         }
 
+        // Shared by the export commands: prefer an explicitly provided password, refuse to
+        // prompt when input is redirected (batch scripts and CI would block forever), and
+        // fall back to an interactive prompt otherwise.
+        public static string ResolveExportPassword(string password, bool isInputRedirected, Func<string> promptForPassword)
+        {
+            if (!string.IsNullOrEmpty(password))
+                return password;
+            if (isInputRedirected)
+                throw new Exception("A password is required in non-interactive mode. Specify one with --password.");
+            return promptForPassword();
+        }
+
         public static bool TryGetUtf8String(this ReadOnlySpan<byte> data, out string text)
         {
             try

--- a/test/test.workflowvalidation/ExportPasswordTests.cs
+++ b/test/test.workflowvalidation/ExportPasswordTests.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExportPasswordTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ExportPasswordTests
+{
+    [Fact]
+    public void a_provided_password_is_used_without_prompting()
+    {
+        var prompted = false;
+
+        var result = Extensions.ResolveExportPassword("secret", isInputRedirected: true, () => { prompted = true; return "from-prompt"; });
+
+        result.Should().Be("secret");
+        prompted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void an_interactive_session_prompts_when_no_password_is_provided()
+    {
+        var result = Extensions.ResolveExportPassword(string.Empty, isInputRedirected: false, () => "from-prompt");
+
+        result.Should().Be("from-prompt");
+    }
+
+    [Fact]
+    public void a_non_interactive_session_fails_clearly_instead_of_blocking_on_a_prompt()
+    {
+        var prompted = false;
+
+        var act = () => Extensions.ResolveExportPassword(string.Empty, isInputRedirected: true, () => { prompted = true; return "from-prompt"; });
+
+        act.Should().Throw<Exception>().WithMessage("*--password*");
+        prompted.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`neoxp wallet export` and the top-level `neoxp export` unconditionally called `Prompt.GetPassword`, so neither command could be used from a batch script or CI: with redirected input the prompt blocked or consumed unrelated stdin. Every other password-consuming command (`transfer`, `contract deploy/invoke/run`, `execute`, `policy`, `candidate`, `oracle response`) already exposes `--password` with prompt-as-fallback.

## Change

Add the standard `-p|--password` option to both export commands, resolved through one shared helper:

- an explicitly provided password is used as-is (no prompt);
- no password + redirected input → a clear error: `A password is required in non-interactive mode. Specify one with --password.` instead of blocking;
- interactive sessions keep the existing prompt, unchanged.

Both commands are documented in `docs/command-reference.md`.

## Testing

- New `ExportPasswordTests` (3 tests) cover: provided password used without prompting, interactive fallback prompts, non-interactive failure names `--password` and never invokes the prompt.
- End-to-end: created a chain + wallet, ran `wallet export alice --password ... </dev/null` — produced a valid NEP-6 file (scrypt parameters + 1 account); the same command without `--password` and redirected stdin fails with the clear error.
- `dotnet build -c Release`, `dotnet format --verify-no-changes` clean; help renders `-p|--password` on both commands.
