### PR TITLE
Honor user overrides for NeoCsc optimize, inline and address version

### DIFF
--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -22,8 +22,10 @@
       <NeoCscDebugInfoPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).nefdbgnfo'))</NeoCscDebugInfoPath>
       <NeoCscAssemblyPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).asm'))</NeoCscAssemblyPath>
 
-      <NeoCscOptimize>true</NeoCscOptimize>
-      <NeoCscOptimize Condition="'$(Configuration)'=='Debug'">false</NeoCscOptimize>
+      <NeoCscOptimize Condition="'$(NeoCscOptimize)'=='' and '$(Configuration)'=='Debug'">false</NeoCscOptimize>
+      <NeoCscOptimize Condition="'$(NeoCscOptimize)'==''">true</NeoCscOptimize>
+      <NeoCscInline Condition="'$(NeoCscInline)'==''">$(NeoCscOptimize)</NeoCscInline>
+      <NeoCscAddressVersion Condition="'$(NeoCscAddressVersion)'==''">53</NeoCscAddressVersion>
       <NeoCscDebugInfo Condition="'$(NeoCscDebugInfo)'==''">true</NeoCscDebugInfo>
     </PropertyGroup>
 
@@ -40,11 +42,12 @@
     Condition="'$(NeoContractName)'!=''"
     Inputs="$(MSBuildProjectFullPath);@(Compile);" Outputs="@(NeoCscOutput)">
 
-    <NeoCsc 
+    <NeoCsc
+      AddressVersion="$(NeoCscAddressVersion)"
       Assembly="$(NeoContractAssembly)"
       BaseFileName="$(NeoContractName)"
       Debug="$(NeoCscDebugInfo)"
-      Inline="$(NeoCscOptimize)"
+      Inline="$(NeoCscInline)"
       Optimize="$(NeoCscOptimize)"
       Output="$(NeoContractOutput)"
       Sources="$(MSBuildProjectFullPath)"

--- a/test/test-build-tasks/NeoCscTests.cs
+++ b/test/test-build-tasks/NeoCscTests.cs
@@ -30,4 +30,35 @@ public class NeoCscTests
         Assert.Contains("--output \"C:\\Users\\John Doe\\bin\\sc\"", args);
         Assert.Contains("--base-name \"base name\"", args);
     }
+
+    [Theory]
+    // optimize and inline are independent flags: each emits its --no- switch on its own.
+    [InlineData(true, true, false, false)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, false, true)]
+    [InlineData(false, false, true, true)]
+    public void BuildArguments_emits_independent_optimize_and_inline_switches(
+        bool optimize, bool inline, bool expectNoOptimize, bool expectNoInline)
+    {
+        var args = NeoCsc.BuildArguments(
+            new[] { "contract.csproj" }, null, "",
+            debug: false, assembly: false, optimize: optimize, inline: inline, addressVersion: 53);
+
+        Assert.Equal(expectNoOptimize, args.Contains("--no-optimize"));
+        Assert.Equal(expectNoInline, args.Contains("--no-inline"));
+    }
+
+    [Fact]
+    public void BuildArguments_emits_address_version_only_when_not_default()
+    {
+        var defaultArgs = NeoCsc.BuildArguments(
+            new[] { "contract.csproj" }, null, "",
+            debug: false, assembly: false, optimize: true, inline: true, addressVersion: 53);
+        var customArgs = NeoCsc.BuildArguments(
+            new[] { "contract.csproj" }, null, "",
+            debug: false, assembly: false, optimize: true, inline: true, addressVersion: 42);
+
+        Assert.DoesNotContain("--address-version", defaultArgs);
+        Assert.Contains("--address-version 42", customArgs);
+    }
 }


### PR DESCRIPTION
## Summary

Three related problems in `Neo.BuildTasks.targets` around the `NeoCsc` invocation:

1. **`NeoCscOptimize` was silently unoverridable.** `ConfigureNeoCsc` set it unconditionally (`true`, then `false` for Debug), so a value set in the contract project file was overwritten. Verified with a probe project: setting `<NeoCscOptimize>false</NeoCscOptimize>` in Release still produced `Optimize=true`. There was no way to disable optimization in Release or enable it in Debug.
2. **Optimize and inline were conflated.** `ExecuteNeoCsc` passed `$(NeoCscOptimize)` to both the `Optimize` and `Inline` task parameters, though the `NeoCsc` task exposes them as independent flags (`--no-optimize` / `--no-inline`).
3. **`AddressVersion` was dead for MSBuild consumers.** The task property (emits `--address-version` when not 53) was never passed by any target, so no MSBuild property could reach it.

## Change

- Guard both `NeoCscOptimize` defaults with `Condition="'$(NeoCscOptimize)'==''"`, mirroring the existing `NeoCscDebugInfo` guard on the next line.
- Introduce `NeoCscInline`, defaulting to `$(NeoCscOptimize)` — existing builds behave identically, but the two flags are now independently overridable.
- Introduce `NeoCscAddressVersion` (default 53, the task default) and pass it to the task.

## Verification

Probe project evaluating `ConfigureNeoCsc` across scenarios:

| scenario | before | after |
|---|---|---|
| user sets `NeoCscOptimize=false`, Release | `Optimize=true` (clobbered) | `Optimize=false Inline=false` |
| defaults, Release | `true/true` | `true/true/53` (unchanged) |
| defaults, Debug | `false/false` | `false/false/53` (unchanged) |
| user sets `NeoCscInline=false` only | impossible | `Optimize=true Inline=false` |
| user sets `NeoCscAddressVersion=42` | ignored | `AddressVersion=42` |

New `NeoCsc.BuildArguments` tests cover the four optimize/inline combinations and address-version emission (only when non-default). Full `NeoCscTests` suite: 6 passed. `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
