### PR TITLE
Key the memory storage cache by contract and key, not a 32-bit hash

### DIFF
--- a/src/bctklib/persistence/StateServiceStore.MemoryCacheClient.cs
+++ b/src/bctklib/persistence/StateServiceStore.MemoryCacheClient.cs
@@ -8,6 +8,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.BlockchainToolkit.Utilities;
 using System.Collections.Concurrent;
 
 namespace Neo.BlockchainToolkit.Persistence
@@ -16,8 +17,11 @@ namespace Neo.BlockchainToolkit.Persistence
     {
         internal sealed class MemoryCacheClient : ICacheClient
         {
-            readonly ConcurrentDictionary<int, byte[]?> storageMap = new();
-            readonly ConcurrentDictionary<int, IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap = new();
+            // Key the caches by the actual (contract, key) pair rather than by its 32-bit
+            // hash code. Using the hash as the identity meant two distinct storage keys
+            // could collide and silently serve each other's cached value.
+            readonly ConcurrentDictionary<(UInt160 contractHash, ReadOnlyMemory<byte> key), byte[]?> storageMap = new(StorageKeyComparer.Instance);
+            readonly ConcurrentDictionary<(UInt160 contractHash, byte? prefix), IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap = new();
             private bool disposed;
 
             public void Dispose()
@@ -28,21 +32,21 @@ namespace Neo.BlockchainToolkit.Persistence
                 }
             }
 
-            static int GetStorageKey(UInt160 contractHash, byte? prefix)
+            sealed class StorageKeyComparer : IEqualityComparer<(UInt160 contractHash, ReadOnlyMemory<byte> key)>
             {
-                var hashBuilder = new HashCode();
-                hashBuilder.Add(contractHash);
-                if (prefix.HasValue)
-                    hashBuilder.Add(prefix.Value);
-                return hashBuilder.ToHashCode();
-            }
+                public static StorageKeyComparer Instance { get; } = new();
 
-            static int GetStorageKey(UInt160 contractHash, ReadOnlyMemory<byte> key)
-            {
-                var hashBuilder = new HashCode();
-                hashBuilder.Add(contractHash);
-                hashBuilder.AddBytes(key.Span);
-                return hashBuilder.ToHashCode();
+                public bool Equals((UInt160 contractHash, ReadOnlyMemory<byte> key) x, (UInt160 contractHash, ReadOnlyMemory<byte> key) y)
+                    => x.contractHash == y.contractHash
+                        && MemorySequenceComparer.Equals(x.key.Span, y.key.Span);
+
+                public int GetHashCode((UInt160 contractHash, ReadOnlyMemory<byte> key) obj)
+                {
+                    var hashBuilder = new HashCode();
+                    hashBuilder.Add(obj.contractHash);
+                    hashBuilder.AddBytes(obj.key.Span);
+                    return hashBuilder.ToHashCode();
+                }
             }
 
             public bool TryGetCachedStorage(UInt160 contractHash, ReadOnlyMemory<byte> key, out byte[]? value)
@@ -50,8 +54,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 if (disposed)
                     throw new ObjectDisposedException(nameof(MemoryCacheClient));
 
-                var hash = GetStorageKey(contractHash, key);
-                return storageMap.TryGetValue(hash, out value);
+                return storageMap.TryGetValue((contractHash, key), out value);
             }
 
             public void CacheStorage(UInt160 contractHash, ReadOnlyMemory<byte> key, byte[]? value)
@@ -59,8 +62,9 @@ namespace Neo.BlockchainToolkit.Persistence
                 if (disposed)
                     throw new ObjectDisposedException(nameof(MemoryCacheClient));
 
-                var hash = GetStorageKey(contractHash, key);
-                if (!storageMap.TryAdd(hash, value))
+                // Copy the key so the stored identity stays stable even if the caller
+                // reuses the underlying buffer.
+                if (!storageMap.TryAdd((contractHash, key.ToArray()), value))
                     throw new Exception($"Key already exists {Convert.ToHexString(key.Span)}");
             }
 
@@ -69,8 +73,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 if (disposed)
                     throw new ObjectDisposedException(nameof(MemoryCacheClient));
 
-                var hash = GetStorageKey(contractHash, prefix);
-                if (foundStateMap.TryGetValue(hash, out var list))
+                if (foundStateMap.TryGetValue((contractHash, prefix), out var list))
                 {
                     value = list;
                     return true;
@@ -85,10 +88,9 @@ namespace Neo.BlockchainToolkit.Persistence
                 if (disposed)
                     throw new ObjectDisposedException(nameof(MemoryCacheClient));
 
-                var hash = GetStorageKey(contractHash, prefix);
-                if (foundStateMap.ContainsKey(hash))
+                if (foundStateMap.ContainsKey((contractHash, prefix)))
                     throw new Exception($"{contractHash}-{prefix} already cached");
-                return new Snapshot(foundStateMap, hash);
+                return new Snapshot(foundStateMap, (contractHash, prefix));
             }
 
             public void DropCachedFoundStates(UInt160 contractHash, byte? prefix)
@@ -96,21 +98,20 @@ namespace Neo.BlockchainToolkit.Persistence
                 if (disposed)
                     throw new ObjectDisposedException(nameof(MemoryCacheClient));
 
-                var hash = GetStorageKey(contractHash, prefix);
-                _ = foundStateMap.TryRemove(hash, out _);
+                _ = foundStateMap.TryRemove((contractHash, prefix), out _);
             }
 
             class Snapshot : ICacheSnapshot
             {
-                readonly ConcurrentDictionary<int, IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap;
-                readonly int hash;
+                readonly ConcurrentDictionary<(UInt160 contractHash, byte? prefix), IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap;
+                readonly (UInt160 contractHash, byte? prefix) key;
                 List<(ReadOnlyMemory<byte> key, byte[] value)> entries = new();
                 bool disposed = false;
 
-                public Snapshot(ConcurrentDictionary<int, IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap, int hash)
+                public Snapshot(ConcurrentDictionary<(UInt160 contractHash, byte? prefix), IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap, (UInt160 contractHash, byte? prefix) key)
                 {
                     this.foundStateMap = foundStateMap;
-                    this.hash = hash;
+                    this.key = key;
                 }
 
                 public void Dispose()
@@ -132,7 +133,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 {
                     ObjectDisposedException.ThrowIf(disposed, nameof(MemoryCacheClient.Snapshot));
 
-                    if (!foundStateMap.TryAdd(hash, entries))
+                    if (!foundStateMap.TryAdd(key, entries))
                     {
                         throw new Exception("Failed to add cached entries");
                     }

--- a/test/test.bctklib/MemoryCacheClientTests.cs
+++ b/test/test.bctklib/MemoryCacheClientTests.cs
@@ -1,0 +1,118 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// MemoryCacheClientTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class MemoryCacheClientTests
+    {
+        static readonly UInt160 CONTRACT_A = UInt160.Parse("0x0000000000000000000000000000000000000001");
+        static readonly UInt160 CONTRACT_B = UInt160.Parse("0x0000000000000000000000000000000000000002");
+
+        [Fact]
+        public void distinct_keys_that_collide_under_a_32bit_hash_keep_their_own_values()
+        {
+            // The cache previously used HashCode.ToHashCode() over (contract, key) as the
+            // dictionary key, so two distinct storage keys whose 32-bit hashes collide served
+            // each other's value. Search for such a colliding pair (birthday bound makes this
+            // fast) and prove each key reads back its own value.
+            var (first, second) = FindCollidingKeys(CONTRACT_A);
+            using var client = new StateServiceStore.MemoryCacheClient();
+
+            client.CacheStorage(CONTRACT_A, first, new byte[] { 1 });
+            client.CacheStorage(CONTRACT_A, second, new byte[] { 2 });
+
+            client.TryGetCachedStorage(CONTRACT_A, first, out var firstValue).Should().BeTrue();
+            client.TryGetCachedStorage(CONTRACT_A, second, out var secondValue).Should().BeTrue();
+            firstValue.Should().Equal(new byte[] { 1 });
+            secondValue.Should().Equal(new byte[] { 2 });
+        }
+
+        [Fact]
+        public void the_same_key_under_different_contracts_keeps_separate_values()
+        {
+            using var client = new StateServiceStore.MemoryCacheClient();
+            var key = new byte[] { 0x0a, 0x0b };
+
+            client.CacheStorage(CONTRACT_A, key, new byte[] { 1 });
+            client.CacheStorage(CONTRACT_B, key, new byte[] { 2 });
+
+            client.TryGetCachedStorage(CONTRACT_A, key, out var valueA).Should().BeTrue();
+            client.TryGetCachedStorage(CONTRACT_B, key, out var valueB).Should().BeTrue();
+            valueA.Should().Equal(new byte[] { 1 });
+            valueB.Should().Equal(new byte[] { 2 });
+        }
+
+        [Fact]
+        public void a_cached_key_is_matched_by_content_not_by_buffer_identity()
+        {
+            using var client = new StateServiceStore.MemoryCacheClient();
+            var buffer = new byte[] { 0x0a, 0x0b };
+
+            client.CacheStorage(CONTRACT_A, buffer, new byte[] { 1 });
+            // Mutating the caller's buffer after caching must not corrupt the cached identity.
+            buffer[0] = 0xff;
+
+            client.TryGetCachedStorage(CONTRACT_A, new byte[] { 0x0a, 0x0b }, out var value).Should().BeTrue();
+            value.Should().Equal(new byte[] { 1 });
+            client.TryGetCachedStorage(CONTRACT_A, new byte[] { 0xff, 0x0b }, out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public void found_states_are_kept_per_contract_and_prefix()
+        {
+            using var client = new StateServiceStore.MemoryCacheClient();
+
+            using (var snapshot = client.GetFoundStatesSnapshot(CONTRACT_A, 1))
+            {
+                snapshot.Add(new byte[] { 1 }, new byte[] { 10 });
+                snapshot.Commit();
+            }
+            using (var snapshot = client.GetFoundStatesSnapshot(CONTRACT_A, 2))
+            {
+                snapshot.Add(new byte[] { 2 }, new byte[] { 20 });
+                snapshot.Commit();
+            }
+
+            client.TryGetCachedFoundStates(CONTRACT_A, 1, out var prefix1).Should().BeTrue();
+            client.TryGetCachedFoundStates(CONTRACT_A, 2, out var prefix2).Should().BeTrue();
+            client.TryGetCachedFoundStates(CONTRACT_B, 1, out _).Should().BeFalse();
+            Assert.Single(prefix1);
+            Assert.Single(prefix2);
+        }
+
+        // Replicates the hash the cache previously used as its dictionary key and finds two
+        // distinct keys that collide under it. ~80k random keys hit a 32-bit collision with
+        // high probability (birthday bound); the loop is capped well above that.
+        static (byte[] first, byte[] second) FindCollidingKeys(UInt160 contract)
+        {
+            var seen = new Dictionary<int, byte[]>();
+            for (var i = 0; i < 5_000_000; i++)
+            {
+                var key = Encoding.UTF8.GetBytes($"key-{i}");
+                var hashBuilder = new HashCode();
+                hashBuilder.Add(contract);
+                hashBuilder.AddBytes(key);
+                var hash = hashBuilder.ToHashCode();
+                if (seen.TryGetValue(hash, out var existing))
+                    return (existing, key);
+                seen.Add(hash, key);
+            }
+            throw new Exception("No 32-bit hash collision found within the search bound");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`MemoryCacheClient` — the default `StateServiceStore` cache used by worknet and checkpoint-based state reads — used `ConcurrentDictionary<int, ...>` where the `int` key was `HashCode.ToHashCode()` over the contract hash and storage key:

```csharp
readonly ConcurrentDictionary<int, byte[]?> storageMap = new();
...
var hash = GetStorageKey(contractHash, key);   // HashCode over (contract, key)
return storageMap.TryGetValue(hash, out value);
```

The 32-bit hash was the cache *identity*, not a bucket. When two distinct `(contract, key)` pairs collide:

- `TryGetCachedStorage` silently returns the other key's cached value (wrong contract storage data), or
- `CacheStorage` throws `Key already exists <hex>` for a key that was never cached.

The birthday bound makes this realistic: the regression test finds a genuine colliding pair within ~100k generated keys. `RocksDbCacheClient` (the persistent variant) already keys by the full contract hash + key bytes, confirming the memory variant was an oversight.

## Change

- `storageMap` is keyed by `(UInt160 contractHash, ReadOnlyMemory<byte> key)` with a comparer combining `UInt160` equality and byte-content equality (`MemorySequenceComparer`). The key bytes are copied on add, so a caller reusing its buffer cannot corrupt the stored identity.
- `foundStateMap` is keyed by the `(UInt160 contractHash, byte? prefix)` pair directly (value-type tuple equality is exact).

The class is `internal`; no public API changes.

## Testing

- `distinct_keys_that_collide_under_a_32bit_hash_keep_their_own_values` reproduces the old hash and finds a real colliding pair, then asserts each key reads back its own value. On the unpatched code it fails with `Key already exists 6B65792D3939303838` — the collision manifesting; with the fix it passes.
- Additional tests: same key under different contracts stays separate, cached identity is content-based (immune to caller buffer mutation), found-states separated per contract/prefix.
- Full `StateServiceStore`/cache filter (7 passed), `dotnet build -c Release`, `dotnet format --verify-no-changes` clean.
