### PR TITLE
Support --disable-log on neo-worknet run

### DIFF
--- a/docs/worknet-command-reference.md
+++ b/docs/worknet-command-reference.md
@@ -107,6 +107,7 @@ Usage: neo-worknet run [options]
 
 Options:
   -s|--seconds-per-block <SECONDS_PER_BLOCK>  Time between blocks
+  --disable-log                               Disable verbose data logging
   -?|-h|--help                                Show help information.
   --input                                     Path to .neo-worknet data file
 ```

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -37,6 +37,9 @@ partial class RunCommand
     [Option(Description = "Time between blocks")]
     internal uint? SecondsPerBlock { get; }
 
+    [Option("--disable-log", Description = "Disable verbose data logging")]
+    internal bool DisableLog { get; set; }
+
     internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
     {
         try
@@ -47,7 +50,7 @@ partial class RunCommand
                 throw new Exception($"Cannot locate data directory {dataDir}");
 
             var secondsPerBlock = SecondsPerBlock ?? 0;
-            await RunAsync(worknet, dataDir, secondsPerBlock, console, token).ConfigureAwait(false);
+            await RunAsync(worknet, dataDir, secondsPerBlock, DisableLog, console, token).ConfigureAwait(false);
             return 0;
         }
         catch (Exception ex)
@@ -72,7 +75,7 @@ partial class RunCommand
         };
     }
 
-    static async Task RunAsync(WorknetFile worknet, string dataDir, uint secondsPerBlock, IConsole console, CancellationToken token)
+    static async Task RunAsync(WorknetFile worknet, string dataDir, uint secondsPerBlock, bool disableLog, IConsole console, CancellationToken token)
     {
         var tcs = new TaskCompletionSource<bool>();
         _ = Task.Run(() =>
@@ -89,7 +92,8 @@ partial class RunCommand
                 StoreFactory.RegisterProvider(storeProvider);
 
                 using var persistencePlugin = new ToolkitPersistencePlugin(db);
-                using var logPlugin = new WorkNetLogPlugin(console, Utility.GetDiagnosticWriter(console));
+                using var logPlugin = new WorkNetLogPlugin(console,
+                    disableLog ? null : Utility.GetDiagnosticWriter(console));
                 using var dbftPlugin = new DBFTPlugin(GetConsensusSettings(worknet));
                 using var rpcServerPlugin = new WorknetRpcServerPlugin(GetRpcServerSettings(worknet), persistencePlugin, worknet.Uri);
                 using var neoSystem = new NeoSystem(protocolSettings, storeProvider.Name);


### PR DESCRIPTION
## Summary

`neo-worknet create` and `neo-worknet prefetch` both expose `--disable-log` to silence the verbose `StateServiceStore` diagnostic output, but `run` — the command that produces by far the most of it, logging every remote state fetch during normal operation — always wired `Utility.GetDiagnosticWriter(console)` into `WorkNetLogPlugin`.

## Change

Add the same `--disable-log` option to `run` and pass a `null` diagnostic writer when set. The `WorkNetLogPlugin` constructor already accepts a nullable writer and skips the diagnostic subscription when it is null, so this is a pass-through. Block/transaction logging (`OnCommitting`, Neo utility logs) is unaffected — only the state-fetch diagnostics are silenced, exactly as in `create`/`prefetch`.

`docs/worknet-command-reference.md` updated.

## Testing

- `dotnet build -c Release` clean, `dotnet format --verify-no-changes` clean.
- Help smoke on the built binary: `neo-worknet run --help` renders `--disable-log  Disable verbose data logging` alongside the existing options.
- The null-writer path is the exact code path `create --disable-log` and `prefetch --disable-log` already exercise via the same `KeyValuePairObserver`/`WorkNetLogPlugin` wiring.
