### PR TITLE
Describe signing failures instead of throwing bare exceptions

### DIFF
--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -173,7 +173,8 @@ namespace NeoExpress.Node
             }
 
             var context = new ContractParametersContext(neoSystem.StoreView, tx, ProtocolSettings.Network);
-            var account = wallet.GetAccount(accountHash) ?? throw new Exception();
+            var account = wallet.GetAccount(accountHash)
+                ?? throw new Exception($"Account {accountHash} not found in wallet {wallet.Name}");
             if (account.IsMultiSigContract())
             {
                 var multiSigWallets = chain.GetMultiSigWallets(neoSystem.Settings, accountHash);
@@ -191,7 +192,7 @@ namespace NeoExpress.Node
 
             if (!context.Completed)
             {
-                throw new Exception();
+                throw new Exception($"Failed to complete the signing context for account {accountHash}: not enough signing wallets are available");
             }
 
             tx.Witnesses = context.GetWitnesses();

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -91,27 +91,31 @@ namespace NeoExpress.Node
                 tm.Tx.SystemFee += (long)additionalGas.ToBigInteger(NativeContract.GAS.Decimals);
             }
 
-            var account = wallet.GetAccount(accountHash) ?? throw new Exception();
+            var account = wallet.GetAccount(accountHash)
+                ?? throw new Exception($"Account {accountHash} not found in wallet {wallet.Name}");
             if (account.IsMultiSigContract())
             {
                 var signatureCount = account.Contract.ParameterList.Length;
                 var multiSigWallets = chain.GetMultiSigWallets(ProtocolSettings, accountHash);
                 if (multiSigWallets.Count < signatureCount)
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException($"Multi-sig account {accountHash} requires {signatureCount} signatures but only {multiSigWallets.Count} signing wallets are available");
 
                 var publicKeys = multiSigWallets
-                    .Select(w => (w.GetAccount(accountHash)?.GetKey() ?? throw new Exception()).PublicKey)
+                    .Select(w => (w.GetAccount(accountHash)?.GetKey()
+                        ?? throw new Exception($"Wallet {w.Name} has no accessible private key for multi-sig account {accountHash}")).PublicKey)
                     .ToArray();
 
                 for (var i = 0; i < signatureCount; i++)
                 {
-                    var key = multiSigWallets[i].GetAccount(accountHash)?.GetKey() ?? throw new Exception();
+                    var key = multiSigWallets[i].GetAccount(accountHash)?.GetKey()
+                        ?? throw new Exception($"Wallet {multiSigWallets[i].Name} has no accessible private key for multi-sig account {accountHash}");
                     tm.AddMultiSig(key, signatureCount, publicKeys);
                 }
             }
             else
             {
-                tm.AddSignature(account.GetKey() ?? throw new Exception());
+                tm.AddSignature(account.GetKey()
+                    ?? throw new Exception($"Account {accountHash} has no accessible private key"));
             }
 
             var tx = await tm.SignAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary

The transaction-signing paths in `OnlineNode.ExecuteAsync` and `OfflineNode.ExecuteAsync` threw message-less exceptions for every failure mode:

```csharp
var account = wallet.GetAccount(accountHash) ?? throw new Exception();
...
if (multiSigWallets.Count < signatureCount)
    throw new InvalidOperationException();
...
tm.AddSignature(account.GetKey() ?? throw new Exception());
...
if (!context.Completed) { throw new Exception(); }
```

The CLI prints `ex.Message` via `WriteException`, so a user of `transfer`, `contract deploy/invoke/run` or `execute` hitting any of these saw only:

```
Exception of type 'System.Exception' was thrown.
```

— no hint of which account, wallet, or missing key was the problem.

## Change

Give each of the six throws (four in `OnlineNode`, two in `OfflineNode`) a specific message:

- `Account <hash> not found in wallet <name>`
- `Multi-sig account <hash> requires N signatures but only M signing wallets are available`
- `Wallet <name> has no accessible private key for multi-sig account <hash>`
- `Account <hash> has no accessible private key`
- `Failed to complete the signing context for account <hash>: not enough signing wallets are available`

Text only — no control-flow changes.

## Testing

- Full `test.workflowvalidation` suite: 132 passed (no behavioral regressions).
- `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
