### PR TITLE
Filter integration tests in CI by trait instead of class-name strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       run: dotnet build neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-restore --verbosity normal
 
     - name: Test
-      run: dotnet test neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
+      run: dotnet test neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal --filter "Category!=Integration"
 
     - name: Pack for Install
       run: dotnet pack neo-express.sln --configuration ${{ env.CONFIGURATION }} --output ./out --no-build --verbosity normal

--- a/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
@@ -20,6 +20,7 @@ namespace test.workflowvalidation;
 /// These tests validate the more complex neoxp commands from test.yml
 /// </summary>
 [Collection("PackExclusive")]
+[Trait("Category", "Integration")]
 public class NeoxpAdvancedIntegrationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;

--- a/test/test.workflowvalidation/NeoxpToolIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpToolIntegrationTests.cs
@@ -19,6 +19,7 @@ namespace test.workflowvalidation;
 /// These tests validate the same neoxp tool commands as the CI/CD pipeline
 /// </summary>
 [Collection("PackExclusive")]
+[Trait("Category", "Integration")]
 public class NeoxpToolIntegrationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;

--- a/test/test.workflowvalidation/WorkflowValidationTests.cs
+++ b/test/test.workflowvalidation/WorkflowValidationTests.cs
@@ -18,6 +18,7 @@ namespace test.workflowvalidation;
 /// These tests validate the same functionality as the CI/CD pipeline
 /// </summary>
 [Collection("PackExclusive")]
+[Trait("Category", "Integration")]
 public class WorkflowValidationTests : IDisposable
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
## Summary

The CI test step excluded the three tool-integration test classes with a chain of substring matches:

```
--filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
```

That filter is fragile: renaming one of the classes or adding a fourth integration class silently changes what CI runs, and nothing in the test code itself marks these classes as CI-excluded.

## Change

- Tag the three classes with `[Trait("Category", "Integration")]`.
- Change the CI invocation to `--filter "Category!=Integration"`.

All test projects use xUnit v3 with the VSTest runner, so the trait filter applies uniformly across the solution; untraited tests match a `!=` filter.

## Verification

Equivalence proven locally on `test.workflowvalidation`:

| filter | tests run |
|---|---|
| old FQN-exclusion chain | 121 passed |
| `Category!=Integration` | 121 passed |
| `Category=Integration` (inverse) | selects exactly the same 12 tests the substring patterns matched |

`dotnet format --verify-no-changes` clean.
