### PR TITLE
Add a neo-worknet fastfwd command

### DIFF
--- a/docs/worknet-command-reference.md
+++ b/docs/worknet-command-reference.md
@@ -56,6 +56,33 @@ the branched chain. Based on understanding of Neo-Express usage patterns, multip
 not typically used. If four or seven conesnsus node support in Neo-WorkNet is important to you, please
 file an issue in our [GitHub repo](https://github.com/neo-project/neo-express/issues)
 
+## neo-worknet fastfwd
+
+```
+Mint empty blocks to fast forward the block chain
+
+Usage: neo-worknet fastfwd [options] <Count>
+
+Arguments:
+  Count                                   Number of blocks to mint
+
+Options:
+  -t|--timestamp-delta <TIMESTAMP_DELTA>  Timestamp delta for last generated block
+  -?|-h|--help                            Show help information.
+  --input                                 Path to .neo-worknet data file
+```
+
+The `fastfwd` command mints the specified number of empty blocks, signed by the worknet
+consensus account. This is useful for testing contracts with time-dependent behavior such as
+vesting cliffs or auction expiry. Like the equivalent Neo-Express command, the
+`--timestamp-delta` option additionally advances the timestamp of the last minted block by
+the specified amount — either a whole number of seconds or a .NET TimeSpan string such as
+`1.02:03:04` (one day, two hours, three minutes and four seconds). The timestamps of the
+minted blocks are spaced evenly across the delta.
+
+The node must be stopped when running `fastfwd`; the blocks are appended directly to the
+local chain data.
+
 ## neo-worknet prefetch
 
 ```

--- a/src/bctklib/BlockProducer.cs
+++ b/src/bctklib/BlockProducer.cs
@@ -1,0 +1,211 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// BlockProducer.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Cryptography;
+using Neo.Extensions;
+using Neo.IO;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using Neo.Wallets;
+
+namespace Neo.BlockchainToolkit
+{
+    // Dev-chain block production shared by the Neo-Express and Neo-WorkNet fast forward
+    // implementations: build empty blocks signed by the chain's consensus keys and either
+    // hand them to a submit callback (running node) or persist them directly to a store.
+    public static class BlockProducer
+    {
+        public const uint MaxFastForwardCount = 100_000;
+
+        public static Block CreateSignedBlock(Header prevHeader, IReadOnlyList<KeyPair> keyPairs, uint network, Transaction[]? transactions = null, ulong timestamp = 0)
+        {
+            transactions ??= Array.Empty<Transaction>();
+
+            var blockHeight = prevHeader.Index + 1;
+
+            // dBFT assigns each block a random nonce. Mirror that here so the block
+            // nonce contribution to System.Runtime.GetRandom varies per block instead
+            // of being a constant 0, which otherwise makes on-chain randomness behave
+            // differently from a real network.
+            Span<byte> nonceBuffer = stackalloc byte[sizeof(ulong)];
+            System.Security.Cryptography.RandomNumberGenerator.Fill(nonceBuffer);
+            var nonce = BitConverter.ToUInt64(nonceBuffer);
+
+            var block = new Block
+            {
+                Header = new Header
+                {
+                    Version = 0,
+                    Nonce = nonce,
+                    PrevHash = prevHeader.Hash,
+                    MerkleRoot = MerkleTree.ComputeRoot(transactions.Select(t => t.Hash).ToArray()),
+                    Timestamp = timestamp > prevHeader.Timestamp
+                        ? timestamp
+                        : Math.Max(DateTime.UtcNow.ToTimestampMS(), prevHeader.Timestamp + 1),
+                    Index = blockHeight,
+                    PrimaryIndex = 0,
+                    NextConsensus = prevHeader.NextConsensus,
+                    Witness = Witness.Empty
+                },
+                Transactions = transactions
+            };
+
+            // generate the block header witness. Logic lifted from ConsensusContext.CreateBlock
+            var m = keyPairs.Count - (keyPairs.Count - 1) / 3;
+            var contract = Contract.CreateMultiSigContract(m, keyPairs.Select(k => k.PublicKey).ToList());
+            var signingContext = new ContractParametersContext(null, new BlockScriptHashes(prevHeader.NextConsensus), network);
+            for (int i = 0; i < keyPairs.Count; i++)
+            {
+                var signature = block.Header.Sign(keyPairs[i], network);
+                signingContext.AddSignature(contract, keyPairs[i].PublicKey, signature);
+                if (signingContext.Completed)
+                    break;
+            }
+            if (!signingContext.Completed)
+                throw new Exception("block signing incomplete");
+            block.Header.Witness = signingContext.GetWitnesses()[0];
+
+            return block;
+        }
+
+        public static async Task FastForwardAsync(Header prevHeader, uint blockCount, TimeSpan timestampDelta, KeyPair[] keyPairs, uint network, Func<Block, Task> submitBlockAsync)
+        {
+            if (timestampDelta.TotalSeconds < 0)
+                throw new ArgumentException($"Negative {nameof(timestampDelta)} not supported");
+            if (blockCount == 0)
+                return;
+
+            var timestamp = Math.Max(DateTime.UtcNow.ToTimestampMS(), prevHeader.Timestamp + 1);
+            var delta = (ulong)timestampDelta.TotalMilliseconds;
+
+            if (blockCount == 1)
+            {
+                var block = CreateSignedBlock(
+                    prevHeader, keyPairs, network, timestamp: timestamp + delta);
+                await submitBlockAsync(block).ConfigureAwait(false);
+            }
+            else
+            {
+                var period = delta / (blockCount - 1);
+                for (int i = 0; i < blockCount; i++)
+                {
+                    var block = CreateSignedBlock(
+                        prevHeader, keyPairs, network, timestamp: timestamp);
+                    await submitBlockAsync(block).ConfigureAwait(false);
+                    prevHeader = block.Header;
+                    timestamp += period;
+                }
+            }
+        }
+
+        // Fast forward a chain that is not running by persisting the signed empty blocks
+        // directly to its store, using the same native OnPersist/PostPersist scripts the
+        // blockchain runs for every block.
+        public static void FastForward(IStore store, uint blockCount, TimeSpan timestampDelta, KeyPair[] keyPairs, ProtocolSettings settings)
+        {
+            Header prevHeader;
+            using (var snapshot = new StoreCache(store.GetSnapshot()))
+            {
+                var prevHash = NativeContract.Ledger.CurrentHash(snapshot);
+                prevHeader = NativeContract.Ledger.GetHeader(snapshot, prevHash)
+                    ?? throw new InvalidOperationException($"Block header {prevHash} is missing");
+            }
+
+            FastForwardAsync(prevHeader, blockCount, timestampDelta, keyPairs, settings.Network,
+                block =>
+                {
+                    Persist(store, block, settings);
+                    return Task.CompletedTask;
+                }).GetAwaiter().GetResult();
+        }
+
+        // replicated logic from Blockchain.Persist / Extensions.EnsureLedgerInitialized
+        static void Persist(IStore store, Block block, ProtocolSettings settings)
+        {
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            using (var engine = ApplicationEngine.Create(TriggerType.OnPersist, null, snapshot, block, settings, 0L))
+            {
+                using var scriptBuilder = new ScriptBuilder();
+                scriptBuilder.EmitSysCall(ApplicationEngine.System_Contract_NativeOnPersist);
+                engine.LoadScript(scriptBuilder.ToArray());
+                if (engine.Execute() != VMState.HALT)
+                    throw new InvalidOperationException($"NativeOnPersist failed for block {block.Index}", engine.FaultException);
+            }
+
+            using (var engine = ApplicationEngine.Create(TriggerType.PostPersist, null, snapshot, block, settings, 0L))
+            {
+                using var scriptBuilder = new ScriptBuilder();
+                scriptBuilder.EmitSysCall(ApplicationEngine.System_Contract_NativePostPersist);
+                engine.LoadScript(scriptBuilder.ToArray());
+                if (engine.Execute() != VMState.HALT)
+                    throw new InvalidOperationException($"NativePostPersist failed for block {block.Index}", engine.FaultException);
+            }
+
+            snapshot.Commit();
+        }
+
+        public static void ValidateCount(uint count)
+        {
+            if (count > MaxFastForwardCount)
+                throw new Exception($"Cannot mint more than {MaxFastForwardCount} blocks at once");
+        }
+
+        public static TimeSpan ParseTimestampDelta(string timestampDelta)
+        {
+            var delta = string.IsNullOrEmpty(timestampDelta)
+                ? TimeSpan.Zero
+                : ulong.TryParse(timestampDelta, out var @ulong)
+                    ? TimeSpan.FromSeconds(@ulong)
+                    : TimeSpan.TryParse(timestampDelta, out var timeSpan)
+                        ? timeSpan
+                        : throw new Exception($"Could not parse timestamp delta {timestampDelta}");
+
+            if (delta < TimeSpan.Zero)
+                throw new Exception($"Timestamp delta {timestampDelta} cannot be negative");
+
+            return delta;
+        }
+
+        // Need an IVerifiable.GetScriptHashesForVerifying implementation that doesn't
+        // depend on the DataCache snapshot parameter in order to create a
+        // ContractParametersContext without direct access to node data.
+        private class BlockScriptHashes : IVerifiable
+        {
+            private readonly UInt160[] hashes;
+
+            public BlockScriptHashes(UInt160 scriptHash)
+            {
+                hashes = new[] { scriptHash };
+            }
+
+            public UInt160[] GetScriptHashesForVerifying(DataCache snapshot) => hashes;
+
+            Witness[] IVerifiable.Witnesses
+            {
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
+            }
+
+            int ISerializable.Size => throw new NotImplementedException();
+
+            void ISerializable.Serialize(BinaryWriter writer) => throw new NotImplementedException();
+
+            void IVerifiable.SerializeUnsigned(BinaryWriter writer) => throw new NotImplementedException();
+
+            void ISerializable.Deserialize(ref MemoryReader reader) => throw new NotImplementedException();
+
+            void IVerifiable.DeserializeUnsigned(ref MemoryReader reader) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/neoxp/Commands/FastForwardCommand.cs
+++ b/src/neoxp/Commands/FastForwardCommand.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using McMaster.Extensions.CommandLineUtils;
+using Neo.BlockchainToolkit;
 using System.ComponentModel.DataAnnotations;
 
 namespace NeoExpress.Commands
@@ -16,7 +17,7 @@ namespace NeoExpress.Commands
     [Command("fastfwd", Description = "Mint empty blocks to fast forward the block chain")]
     class FastForwardCommand
     {
-        internal const uint MaxFastForwardCount = 100_000;
+        internal const uint MaxFastForwardCount = BlockProducer.MaxFastForwardCount;
 
         readonly ExpressChainManagerFactory chainManagerFactory;
 
@@ -58,25 +59,9 @@ namespace NeoExpress.Commands
         }
 
         internal static void ValidateCount(uint count)
-        {
-            if (count > MaxFastForwardCount)
-                throw new Exception($"Cannot mint more than {MaxFastForwardCount} blocks at once");
-        }
+            => BlockProducer.ValidateCount(count);
 
         internal static TimeSpan ParseTimestampDelta(string timestampDelta)
-        {
-            var delta = string.IsNullOrEmpty(timestampDelta)
-                ? TimeSpan.Zero
-                : ulong.TryParse(timestampDelta, out var @ulong)
-                    ? TimeSpan.FromSeconds(@ulong)
-                    : TimeSpan.TryParse(timestampDelta, out var timeSpan)
-                        ? timeSpan
-                        : throw new Exception($"Could not parse timestamp delta {timestampDelta}");
-
-            if (delta < TimeSpan.Zero)
-                throw new Exception($"Timestamp delta {timestampDelta} cannot be negative");
-
-            return delta;
-        }
+            => BlockProducer.ParseTimestampDelta(timestampDelta);
     }
 }

--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -59,87 +59,6 @@ namespace NeoExpress.Node
             return (long)value;
         }
 
-        public static Block CreateSignedBlock(Header prevHeader, IReadOnlyList<KeyPair> keyPairs, uint network, Transaction[]? transactions = null, ulong timestamp = 0)
-        {
-            transactions ??= Array.Empty<Transaction>();
-
-            var blockHeight = prevHeader.Index + 1;
-
-            // dBFT assigns each block a random nonce. Mirror that here so the block
-            // nonce contribution to System.Runtime.GetRandom varies per block instead
-            // of being a constant 0, which otherwise makes on-chain randomness behave
-            // differently from a real network.
-            Span<byte> nonceBuffer = stackalloc byte[sizeof(ulong)];
-            System.Security.Cryptography.RandomNumberGenerator.Fill(nonceBuffer);
-            var nonce = BitConverter.ToUInt64(nonceBuffer);
-
-            var block = new Block
-            {
-                Header = new Header
-                {
-                    Version = 0,
-                    Nonce = nonce,
-                    PrevHash = prevHeader.Hash,
-                    MerkleRoot = MerkleTree.ComputeRoot(transactions.Select(t => t.Hash).ToArray()),
-                    Timestamp = timestamp > prevHeader.Timestamp
-                        ? timestamp
-                        : Math.Max(DateTime.UtcNow.ToTimestampMS(), prevHeader.Timestamp + 1),
-                    Index = blockHeight,
-                    PrimaryIndex = 0,
-                    NextConsensus = prevHeader.NextConsensus,
-                    Witness = Witness.Empty
-                },
-                Transactions = transactions
-            };
-
-            // generate the block header witness. Logic lifted from ConsensusContext.CreateBlock
-            var m = keyPairs.Count - (keyPairs.Count - 1) / 3;
-            var contract = Contract.CreateMultiSigContract(m, keyPairs.Select(k => k.PublicKey).ToList());
-            var signingContext = new ContractParametersContext(null, new BlockScriptHashes(prevHeader.NextConsensus), network);
-            for (int i = 0; i < keyPairs.Count; i++)
-            {
-                var signature = block.Header.Sign(keyPairs[i], network);
-                signingContext.AddSignature(contract, keyPairs[i].PublicKey, signature);
-                if (signingContext.Completed)
-                    break;
-            }
-            if (!signingContext.Completed)
-                throw new Exception("block signing incomplete");
-            block.Header.Witness = signingContext.GetWitnesses()[0];
-
-            return block;
-        }
-
-        public static async Task FastForwardAsync(Header prevHeader, uint blockCount, TimeSpan timestampDelta, KeyPair[] keyPairs, uint network, Func<Block, Task> submitBlockAsync)
-        {
-            if (timestampDelta.TotalSeconds < 0)
-                throw new ArgumentException($"Negative {nameof(timestampDelta)} not supported");
-            if (blockCount == 0)
-                return;
-
-            var timestamp = Math.Max(DateTime.UtcNow.ToTimestampMS(), prevHeader.Timestamp + 1);
-            var delta = (ulong)timestampDelta.TotalMilliseconds;
-
-            if (blockCount == 1)
-            {
-                var block = CreateSignedBlock(
-                    prevHeader, keyPairs, network, timestamp: timestamp + delta);
-                await submitBlockAsync(block).ConfigureAwait(false);
-            }
-            else
-            {
-                var period = delta / (blockCount - 1);
-                for (int i = 0; i < blockCount; i++)
-                {
-                    var block = CreateSignedBlock(
-                        prevHeader, keyPairs, network, timestamp: timestamp);
-                    await submitBlockAsync(block).ConfigureAwait(false);
-                    prevHeader = block.Header;
-                    timestamp += period;
-                }
-            }
-        }
-
         public static void SignOracleResponseTransaction(ProtocolSettings settings, ExpressChain chain, Transaction tx, IReadOnlyList<ECPoint> oracleNodes)
         {
             var signatures = new Dictionary<ECPoint, byte[]>();
@@ -581,35 +500,5 @@ namespace NeoExpress.Node
             }
         }
 
-        // Need an IVerifiable.GetScriptHashesForVerifying implementation that doesn't
-        // depend on the DataCache snapshot parameter in order to create a
-        // ContractParametersContext without direct access to node data.
-        private class BlockScriptHashes : IVerifiable
-        {
-            private readonly UInt160[] hashes;
-
-            public BlockScriptHashes(UInt160 scriptHash)
-            {
-                hashes = new[] { scriptHash };
-            }
-
-            public UInt160[] GetScriptHashesForVerifying(DataCache snapshot) => hashes;
-
-            Witness[] IVerifiable.Witnesses
-            {
-                get => throw new NotImplementedException();
-                set => throw new NotImplementedException();
-            }
-
-            int ISerializable.Size => throw new NotImplementedException();
-
-            void ISerializable.Serialize(BinaryWriter writer) => throw new NotImplementedException();
-
-            void IVerifiable.SerializeUnsigned(BinaryWriter writer) => throw new NotImplementedException();
-
-            void ISerializable.Deserialize(ref MemoryReader reader) => throw new NotImplementedException();
-
-            void IVerifiable.DeserializeUnsigned(ref MemoryReader reader) => throw new NotImplementedException();
-        }
     }
 }

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -10,6 +10,7 @@
 
 using Akka.Actor;
 using Neo;
+using Neo.BlockchainToolkit;
 using Neo.BlockchainToolkit.Models;
 using Neo.BlockchainToolkit.SmartContract;
 using Neo.Cryptography.ECC;
@@ -221,7 +222,7 @@ namespace NeoExpress.Node
             var prevHash = NativeContract.Ledger.CurrentHash(neoSystem.StoreView);
             var prevHeader = NativeContract.Ledger.GetHeader(neoSystem.StoreView, prevHash);
 
-            await NodeUtility.FastForwardAsync(prevHeader,
+            await BlockProducer.FastForwardAsync(prevHeader,
                 blockCount,
                 timestampDelta,
                 consensusNodesKeys.Value,
@@ -249,7 +250,7 @@ namespace NeoExpress.Node
 
             var prevHash = NativeContract.Ledger.CurrentHash(neoSystem.StoreView);
             var prevHeader = NativeContract.Ledger.GetHeader(neoSystem.StoreView, prevHash);
-            var block = NodeUtility.CreateSignedBlock(prevHeader,
+            var block = BlockProducer.CreateSignedBlock(prevHeader,
                 consensusNodesKeys.Value,
                 neoSystem.Settings.Network,
                 transactions);

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using Neo;
+using Neo.BlockchainToolkit;
 using Neo.BlockchainToolkit.Models;
 using Neo.Cryptography.ECC;
 using Neo.Extensions;
@@ -73,7 +74,7 @@ namespace NeoExpress.Node
             var prevHeaderHex = await rpcClient.GetBlockHeaderHexAsync($"{prevHash}").ConfigureAwait(false);
             var prevHeader = Convert.FromBase64String(prevHeaderHex).AsSerializable<Header>();
 
-            await NodeUtility.FastForwardAsync(prevHeader,
+            await BlockProducer.FastForwardAsync(prevHeader,
                 blockCount,
                 timestampDelta,
                 consensusNodesKeys.Value,

--- a/src/worknet/Commands/FastForwardCommand.cs
+++ b/src/worknet/Commands/FastForwardCommand.cs
@@ -1,0 +1,67 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// FastForwardCommand.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using McMaster.Extensions.CommandLineUtils;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Persistence;
+using System.ComponentModel.DataAnnotations;
+using System.IO.Abstractions;
+
+namespace NeoWorkNet.Commands;
+
+[Command("fastfwd", Description = "Mint empty blocks to fast forward the block chain")]
+class FastForwardCommand
+{
+    readonly IFileSystem fs;
+
+    public FastForwardCommand(IFileSystem fs)
+    {
+        this.fs = fs;
+    }
+
+    [Argument(0, Description = "Number of blocks to mint")]
+    [Required]
+    internal uint Count { get; init; }
+
+    [Option(Description = "Timestamp delta for last generated block")]
+    internal string TimestampDelta { get; init; } = string.Empty;
+
+    internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
+    {
+        try
+        {
+            BlockProducer.ValidateCount(Count);
+            var delta = BlockProducer.ParseTimestampDelta(TimestampDelta);
+
+            var (filename, worknet) = await fs.LoadWorknetAsync(app).ConfigureAwait(false);
+            var dataDir = fs.GetWorknetDataDirectory(filename);
+            if (!fs.Directory.Exists(dataDir))
+                throw new Exception($"Cannot locate data directory {dataDir}");
+
+            var key = worknet.ConsensusWallet.GetAccounts().Single().GetKey()
+                ?? throw new Exception("Consensus wallet is missing a private key");
+            var settings = RunCommand.GetProtocolSettings(worknet);
+
+            using var db = RocksDbUtility.OpenDb(dataDir);
+            using var stateStore = new StateServiceStore(worknet.Uri, worknet.BranchInfo, db, true);
+            using var trackStore = new PersistentTrackingStore(db, stateStore, true);
+
+            BlockProducer.FastForward(trackStore, Count, delta, new[] { key }, settings);
+
+            await console.Out.WriteLineAsync($"{Count} empty blocks minted").ConfigureAwait(false);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            app.WriteException(ex);
+            return 1;
+        }
+    }
+}

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -57,7 +57,7 @@ partial class RunCommand
         }
     }
 
-    static ProtocolSettings GetProtocolSettings(WorknetFile worknetFile, uint secondsPerBlock = 0)
+    internal static ProtocolSettings GetProtocolSettings(WorknetFile worknetFile, uint secondsPerBlock = 0)
     {
         var account = worknetFile.ConsensusWallet.GetAccounts().Single();
         var key = account.GetKey() ?? throw new Exception();

--- a/src/worknet/Program.cs
+++ b/src/worknet/Program.cs
@@ -18,7 +18,7 @@ namespace NeoWorkNet;
 
 [Command("neo-worknet", Description = "Branch a public Neo N3 blockchain for private development use", UsePagerForHelpText = false)]
 [VersionOption(ThisAssembly.AssemblyInformationalVersion)]
-[Subcommand(typeof(CreateCommand), typeof(PrefetchCommand), typeof(ResetCommand), typeof(RunCommand))]
+[Subcommand(typeof(CreateCommand), typeof(FastForwardCommand), typeof(PrefetchCommand), typeof(ResetCommand), typeof(RunCommand))]
 partial class Program
 {
     public static async Task<int> Main(string[] args)

--- a/test/test.bctklib/BlockProducerTests.cs
+++ b/test/test.bctklib/BlockProducerTests.cs
@@ -1,0 +1,90 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// BlockProducerTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit;
+using Neo.Cryptography.ECC;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract.Native;
+using Neo.Wallets;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class BlockProducerTests
+    {
+        static readonly KeyPair consensusKey = new(Enumerable.Range(1, 32).Select(i => (byte)i).ToArray());
+
+        static ProtocolSettings Settings => ProtocolSettings.Default with
+        {
+            Network = 0x746E7534,
+            ValidatorsCount = 1,
+            StandbyCommittee = new ECPoint[] { consensusKey.PublicKey },
+            SeedList = Array.Empty<string>(),
+        };
+
+        [Fact]
+        public void fast_forward_appends_the_requested_blocks_with_the_timestamp_delta()
+        {
+            var settings = Settings;
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+
+            BlockProducer.FastForward(store, 3, TimeSpan.FromHours(1), new[] { consensusKey }, settings);
+
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            NativeContract.Ledger.CurrentIndex(snapshot).Should().Be(3);
+
+            // walk the chain backwards, asserting the headers link and are signed
+            var header = NativeContract.Ledger.GetHeader(snapshot, NativeContract.Ledger.CurrentHash(snapshot));
+            var last = header;
+            for (var index = 3u; index >= 1; index--)
+            {
+                header.Index.Should().Be(index);
+                header.Witness.InvocationScript.Length.Should().BeGreaterThan(0);
+                header = NativeContract.Ledger.GetHeader(snapshot, header.PrevHash);
+            }
+            header.Index.Should().Be(0); // genesis
+
+            // the last block's timestamp is the first new block's timestamp plus the delta
+            var first = NativeContract.Ledger.GetHeader(snapshot, NativeContract.Ledger.GetBlockHash(snapshot, 1));
+            (last.Timestamp - first.Timestamp).Should().Be((ulong)TimeSpan.FromHours(1).TotalMilliseconds);
+        }
+
+        [Fact]
+        public void fast_forward_zero_blocks_is_a_no_op()
+        {
+            var settings = Settings;
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+
+            BlockProducer.FastForward(store, 0, TimeSpan.Zero, new[] { consensusKey }, settings);
+
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            NativeContract.Ledger.CurrentIndex(snapshot).Should().Be(0);
+        }
+
+        [Fact]
+        public void fast_forward_rejects_a_negative_timestamp_delta()
+        {
+            var settings = Settings;
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+
+            var act = () => BlockProducer.FastForward(store, 1, TimeSpan.FromSeconds(-1), new[] { consensusKey }, settings);
+
+            act.Should().Throw<ArgumentException>();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Testing time-dependent contract behavior (vesting cliffs, auction expiry, stale-price checks) is a primary use case for a forked chain, but Neo-WorkNet could only advance time by waiting wall-clock seconds. Neo-Express has had `fastfwd --timestamp-delta` for this from the start.

## Change

**bctklib** — new `BlockProducer` class:

- `CreateSignedBlock` and `FastForwardAsync` moved verbatim from the neoxp `NodeUtility` (they depend only on Neo package types), together with the shared count-cap/timestamp-delta parsing.
- New store-backed `FastForward(IStore, ...)` that persists the signed empty blocks by running the same native `OnPersist`/`PostPersist` scripts the blockchain runs for every block (the `EnsureLedgerInitialized` pattern) — full persist fidelity, not hand-rolled storage writes.

**neoxp** — `FastForwardCommand`, `OnlineNode` and `OfflineNode` delegate to the moved code. No behavior change: the existing fastfwd tests (4) and the full command suite (132) pass unchanged.

**worknet** — new `neo-worknet fastfwd <count> [--timestamp-delta]` mirroring the neoxp command surface, applied to the stopped node's local chain data and signed by the worknet consensus account (the same 1-of-1 multisig the branch block's `NextConsensus` points at). Documented in `docs/worknet-command-reference.md`.

## Testing

- New `BlockProducerTests` in `test.bctklib`: fast-forwarding a genesis-initialized store appends the requested blocks — `Ledger.CurrentIndex` advances, headers chain by `PrevHash`, every header carries a witness, and the last block's timestamp is exactly the first new block's plus the delta; zero blocks is a no-op; negative delta rejected.
- Existing neoxp fastfwd tests (4 passed) and full `test.workflowvalidation` (132 passed) prove the move is behavior-neutral; full `test.bctklib` (354 passed).
- `dotnet build -c Release` for bctklib/neoxp/worknet and `dotnet format --verify-no-changes` clean; `neo-worknet fastfwd --help` renders correctly.
