### PR TITLE
Undo OfflineNode's global side effects on dispose

### DIFF
--- a/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
@@ -47,6 +47,9 @@ namespace NeoExpress.Node
             appLogsStore?.Dispose();
             notificationsSnapshot?.Dispose();
             notificationsStore?.Dispose();
+            // the Plugin constructor adds this instance to the global plugin list; remove it
+            // so a NeoSystem created later does not call into this disposed instance
+            _ = Plugins.Remove(this);
         }
 
         protected override void OnSystemLoaded(NeoSystem system)

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -44,10 +44,13 @@ namespace NeoExpress.Node
         readonly Lazy<KeyPair[]> consensusNodesKeys;
         readonly object engineLock = new();
         readonly List<WeakReference<ApplicationEngine>> engineRefs = new();
+        readonly IApplicationEngineProvider? priorEngineProvider;
+        readonly bool engineProviderSet;
         bool disposedValue;
 
         public ProtocolSettings ProtocolSettings => neoSystem.Settings;
 
+        // OfflineNode takes ownership of expressStorage and disposes it when it is disposed.
         public OfflineNode(ProtocolSettings settings, RocksDbExpressStorage expressStorage, ExpressWallet nodeWallet, ExpressChain chain, bool enableTrace)
         {
             this.nodeWallet = DevWallet.FromExpressWallet(settings, nodeWallet);
@@ -55,13 +58,19 @@ namespace NeoExpress.Node
             this.expressStorage = expressStorage;
             consensusNodesKeys = new Lazy<KeyPair[]>(() => chain.GetConsensusNodeKeys());
 
+            // Pass the store provider instance directly instead of registering it in the
+            // global StoreFactory: a registration cannot be removed, so a second OfflineNode
+            // constructed in the same process would throw on the duplicate provider name.
             var storeProvider = new ExpressStoreProvider(expressStorage);
-            StoreFactory.RegisterProvider(storeProvider);
             if (enableTrace)
-            { ApplicationEngine.Provider = new ExpressApplicationEngineProvider(); }
+            {
+                priorEngineProvider = ApplicationEngine.Provider;
+                engineProviderSet = true;
+                ApplicationEngine.Provider = new ExpressApplicationEngineProvider();
+            }
 
             persistencePlugin = new ExpressPersistencePlugin();
-            neoSystem = new NeoSystem(settings, storeProvider.Name);
+            neoSystem = new NeoSystem(settings, storeProvider, null);
 
             ApplicationEngine.InstanceHandler += OnApplicationEngineCreated;
         }
@@ -84,6 +93,11 @@ namespace NeoExpress.Node
                 }
                 persistencePlugin.Dispose();
                 neoSystem.Dispose();
+                if (engineProviderSet)
+                {
+                    ApplicationEngine.Provider = priorEngineProvider;
+                }
+                expressStorage.Dispose();
                 disposedValue = true;
             }
         }

--- a/test/test.workflowvalidation/OfflineNodeDisposeTests.cs
+++ b/test/test.workflowvalidation/OfflineNodeDisposeTests.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OfflineNodeDisposeTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Neo.SmartContract;
+using NeoExpress;
+using NeoExpress.Node;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+// mutates the global ApplicationEngine.Provider, so keep the class isolated
+[Collection("OfflineNodeDispose")]
+public class OfflineNodeDisposeTests
+{
+    [Fact]
+    public void a_disposed_offline_node_releases_the_store_and_restores_the_engine_provider()
+    {
+        var chain = ExpressChainManagerFactory.CreateChain(1, null);
+        var settings = chain.GetProtocolSettings();
+        var nodePath = Path.Combine(Path.GetTempPath(), $"neo-express-offline-node-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(nodePath);
+        try
+        {
+            var priorProvider = ApplicationEngine.Provider;
+
+            // enableTrace sets the global engine provider; dispose must restore it
+            using (var node = new OfflineNode(settings, new RocksDbExpressStorage(nodePath), chain.ConsensusNodes[0].Wallet, chain, enableTrace: true))
+            {
+            }
+            ApplicationEngine.Provider.Should().BeSameAs(priorProvider);
+
+            // a second node over the same path must construct cleanly: the first dispose
+            // released the RocksDB lock, and no global store-provider registration is left
+            // behind to collide with
+            using (var node = new OfflineNode(settings, new RocksDbExpressStorage(nodePath), chain.ConsensusNodes[0].Wallet, chain, enableTrace: false))
+            {
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(nodePath))
+                Directory.Delete(nodePath, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Constructing an `OfflineNode` mutated four pieces of global or unmanaged state that `Dispose` never undid:

1. **The RocksDB handle leaked.** `ExpressChainManager.GetOfflineNode` constructs `RocksDbExpressStorage` inline and hands it to the node — nobody else holds it — yet `Dispose` never disposed it, so the RocksDB `LOCK` stayed held for the rest of the process.
2. **The store provider registration leaked.** The constructor registered an `ExpressStoreProvider` in the global `StoreFactory`; registration cannot be removed, so a second `OfflineNode` in the same process throws `ArgumentException` on the duplicate name.
3. **The engine provider leaked.** With `enableTrace`, the constructor overwrote the global `ApplicationEngine.Provider` and never restored it.
4. **The plugin registration leaked.** `ExpressPersistencePlugin.Dispose` unhooked its events but left the instance in Neo's global `Plugin.Plugins` list, so the next `NeoSystem` called `OnSystemLoaded` on the disposed instance, which throws `OnSystemLoaded already called`.

Any flow that opens the offline node twice in one process hits these in sequence.

## Change

- Pass the store provider instance directly to the `NeoSystem(ProtocolSettings, IStoreProvider, string)` constructor overload instead of registering it globally (nothing else resolves the offline store by name).
- Capture the prior `ApplicationEngine.Provider` when `enableTrace` sets it, and restore it in `Dispose`.
- Dispose `expressStorage` in `Dispose` (ownership documented on the constructor).
- Remove the persistence plugin from the global plugin list in its `Dispose`.

The run-forever node paths (`ExpressChainManager.RunAsync`, worknet `run`) keep their global registrations — those processes exit rather than dispose.

## Testing

- New `OfflineNodeDisposeTests` constructs and disposes two `OfflineNode`s sequentially over the same node path and asserts the engine provider is restored. On the previous code it fails (each leak surfaces in turn as the earlier ones are fixed: RocksDB lock → duplicate provider name → `OnSystemLoaded already called`); with the fix it passes.
- Full `test.workflowvalidation` suite: 133 passed.
- `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
