### PR TITLE
Add CheckpointFixture.CreateEngine to cut contract-test setup ceremony

### DIFF
--- a/src/bctklib/smart-contract/TestApplicationEngine.cs
+++ b/src/bctklib/smart-contract/TestApplicationEngine.cs
@@ -91,6 +91,7 @@ namespace Neo.BlockchainToolkit.SmartContract
         readonly Dictionary<UInt160, OneOf<ContractState, Script>> executedScripts = new();
         readonly Dictionary<UInt160, Dictionary<int, int>> hitMaps = new();
         readonly Dictionary<UInt160, Dictionary<int, (int branchCount, int continueCount)>> branchMaps = new();
+        readonly List<IDisposable> disposables = new();
         readonly WitnessChecker witnessChecker;
         readonly IFileSystem? fileSystem;
         BranchInstructionInfo? branchInstructionInfo = null;
@@ -159,8 +160,17 @@ namespace Neo.BlockchainToolkit.SmartContract
             if (disposing)
             {
                 coverageWriter?.Dispose();
+                for (var i = disposables.Count - 1; i >= 0; i--)
+                    disposables[i].Dispose();
+                disposables.Clear();
             }
             base.Dispose(disposing);
+        }
+
+        public T AddDisposable<T>(T disposable) where T : IDisposable
+        {
+            disposables.Add(disposable ?? throw new ArgumentNullException(nameof(disposable)));
+            return disposable;
         }
 
         public IReadOnlyDictionary<int, int> GetHitMap(UInt160 contractHash)

--- a/src/test-harness/Extensions.cs
+++ b/src/test-harness/Extensions.cs
@@ -11,8 +11,10 @@
 using Neo;
 using Neo.BlockchainToolkit;
 using Neo.BlockchainToolkit.Persistence;
+using Neo.BlockchainToolkit.SmartContract;
 using Neo.BlockchainToolkit.Utilities;
 using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
@@ -247,6 +249,38 @@ namespace NeoTestHarness
             var byteStore = (IReadOnlyStore)fixture.CheckpointStore;
             var store = new MemoryTrackingStore(byteStore);
             return new StoreCache(store.GetSnapshot());
+        }
+
+        // One-call engine construction for the common test shape: snapshot the fixture's
+        // checkpoint and build a TestApplicationEngine over it with the fixture's own
+        // protocol settings. Disposing the returned engine also disposes the snapshot.
+        public static TestApplicationEngine CreateEngine(this CheckpointFixture fixture, UInt160? signer = null, WitnessScope witnessScope = WitnessScope.CalledByEntry)
+        {
+            var snapshot = fixture.GetSnapshot();
+            var container = signer is null
+                ? TestApplicationEngine.CreateTestTransaction()
+                : TestApplicationEngine.CreateTestTransaction(signer, witnessScope);
+            return new FixtureApplicationEngine(snapshot, fixture.ProtocolSettings, container);
+        }
+
+        sealed class FixtureApplicationEngine : TestApplicationEngine
+        {
+            readonly StoreCache snapshot;
+
+            public FixtureApplicationEngine(StoreCache snapshot, ProtocolSettings settings, Neo.Network.P2P.Payloads.Transaction container)
+                : base(snapshot, container: container, settings: settings)
+            {
+                this.snapshot = snapshot;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                if (disposing)
+                {
+                    snapshot.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/test-harness/Extensions.cs
+++ b/src/test-harness/Extensions.cs
@@ -260,27 +260,9 @@ namespace NeoTestHarness
             var container = signer is null
                 ? TestApplicationEngine.CreateTestTransaction()
                 : TestApplicationEngine.CreateTestTransaction(signer, witnessScope);
-            return new FixtureApplicationEngine(snapshot, fixture.ProtocolSettings, container);
-        }
-
-        sealed class FixtureApplicationEngine : TestApplicationEngine
-        {
-            readonly StoreCache snapshot;
-
-            public FixtureApplicationEngine(StoreCache snapshot, ProtocolSettings settings, Neo.Network.P2P.Payloads.Transaction container)
-                : base(snapshot, container: container, settings: settings)
-            {
-                this.snapshot = snapshot;
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                base.Dispose(disposing);
-                if (disposing)
-                {
-                    snapshot.Dispose();
-                }
-            }
+            var engine = new TestApplicationEngine(snapshot, container: container, settings: fixture.ProtocolSettings);
+            engine.AddDisposable(snapshot);
+            return engine;
         }
     }
 }

--- a/test/test-harness/CreateEngineTests.cs
+++ b/test/test-harness/CreateEngineTests.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CreateEngineTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Persistence;
+using Neo.Cryptography.ECC;
+using Neo.Network.P2P.Payloads;
+using Neo.VM;
+using Neo.Wallets;
+using NeoTestHarness;
+using Xunit;
+
+namespace test.harness;
+
+public class CreateEngineTests : IDisposable
+{
+    const uint NETWORK = 0x746E7534;
+    const byte ADDRESS_VERSION = 53;
+
+    readonly string dbPath;
+    readonly string checkpointPath;
+    readonly TestFixture fixture;
+
+    public CreateEngineTests()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"neo-express-create-engine-{Guid.NewGuid():N}");
+        dbPath = Path.Combine(root, "db");
+        checkpointPath = Path.Combine(root, "test.neoxp-checkpoint");
+        Directory.CreateDirectory(dbPath);
+
+        using (var db = RocksDbUtility.OpenDb(dbPath))
+        {
+            // the engine reads ledger state, so persist the genesis block before checkpointing
+            var key = new KeyPair(Enumerable.Range(1, 32).Select(i => (byte)i).ToArray());
+            var settings = ProtocolSettings.Default with
+            {
+                Network = NETWORK,
+                AddressVersion = ADDRESS_VERSION,
+                ValidatorsCount = 1,
+                StandbyCommittee = new ECPoint[] { key.PublicKey },
+            };
+            using (var store = new RocksDbStore(db, readOnly: false, shared: true))
+            {
+                store.EnsureLedgerInitialized(settings);
+            }
+            RocksDbUtility.CreateCheckpoint(db, checkpointPath, NETWORK, ADDRESS_VERSION, UInt160.Zero);
+        }
+
+        fixture = new TestFixture(checkpointPath);
+    }
+
+    public void Dispose()
+    {
+        fixture.Dispose();
+        var root = Path.GetDirectoryName(checkpointPath)!;
+        if (Directory.Exists(root))
+            Directory.Delete(root, true);
+    }
+
+    [Fact]
+    public void create_engine_builds_a_working_engine_with_the_fixture_settings()
+    {
+        using var engine = fixture.CreateEngine();
+
+        engine.ProtocolSettings.Network.Should().Be(NETWORK);
+        engine.ProtocolSettings.AddressVersion.Should().Be(ADDRESS_VERSION);
+
+        engine.ExecuteScript(new Script(new[] { (byte)OpCode.PUSH1 })).Should().Be(VMState.HALT);
+        engine.ResultStack.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void create_engine_applies_the_requested_signer()
+    {
+        var signer = UInt160.Parse("0x0000000000000000000000000000000000000001");
+
+        using var engine = fixture.CreateEngine(signer, WitnessScope.Global);
+
+        var tx = engine.ScriptContainer.Should().BeOfType<Transaction>().Which;
+        tx.Signers.Should().ContainSingle().Which.Account.Should().Be(signer);
+        tx.Signers[0].Scopes.Should().Be(WitnessScope.Global);
+    }
+
+    [Fact]
+    public void engines_are_independent_and_dispose_cleanly()
+    {
+        var first = fixture.CreateEngine();
+        first.Dispose();
+        first.Dispose(); // double dispose is safe
+
+        using var second = fixture.CreateEngine();
+        second.ExecuteScript(new Script(new[] { (byte)OpCode.PUSH1 })).Should().Be(VMState.HALT);
+    }
+
+    sealed class TestFixture : CheckpointFixture
+    {
+        public TestFixture(string checkpointPath) : base(checkpointPath)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Every harness-based contract test repeats the same preamble (both sample tests in `samples/test/contract-tests.cs` duplicate it verbatim):

```csharp
var settings = chain.GetProtocolSettings();
using var snapshot = fixture.GetSnapshot();
using var engine = new TestApplicationEngine(snapshot, settings);
```

— even resolving settings the roundabout way through `FindChain().GetProtocolSettings()` when `CheckpointFixture.ProtocolSettings` already exposes the checkpoint's own settings. A Foundry/Anchor test body starts in one call.

## Change

Add a `CreateEngine` extension on `CheckpointFixture`:

```csharp
using var engine = fixture.CreateEngine();                       // default test transaction
using var engine = fixture.CreateEngine(signer, WitnessScope.Global);  // signed variant
```

It snapshots the checkpoint (the existing `GetSnapshot` path), builds a `TestApplicationEngine` with the fixture's own `ProtocolSettings`, and returns an engine that owns the snapshot — its `Dispose` also disposes the snapshot, so one `using` line replaces the three-line ceremony. The explicit `GetSnapshot` path is unchanged.

The samples still build against published packages, so they are left as-is; they can adopt the one-line form once a package with this API ships.

## Testing

New `CreateEngineTests` build a real checkpoint at runtime (RocksDB → genesis-initialized ledger → `RocksDbUtility.CreateCheckpoint`) and drive the full path through a `CheckpointFixture`:

- the engine carries the checkpoint's network/address-version and executes a script to `HALT`;
- the signer overload produces a transaction container with the requested account and witness scope;
- engines are independent, and double-dispose is safe.

Full `test-harness` suite (10 passed), `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
