### PR TITLE
Support candidate and execute operations in batch files

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -879,12 +879,17 @@ the same as using the `checkpoint restore` command.
 
 The commands supported in a batch file include:
 
+* `candidate register`
+* `candidate unregister`
+* `candidate vote`
+* `candidate unvote`
 * `checkpoint create`
 * `contract deploy`
 * `contract download`
 * `contract invoke`
 * `contract run`
 * `contract update`
+* `execute`
 * `fastfwd`
 * `oracle enable`
 * `oracle response`

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -18,9 +18,62 @@ namespace NeoExpress.Commands
     partial class BatchCommand
     {
         [Command]
-        [Subcommand(typeof(Checkpoint), typeof(Contract), typeof(FastForward), typeof(Oracle), typeof(Policy), typeof(Transfer), typeof(TransferNFT), typeof(Wallet))]
+        [Subcommand(typeof(Candidate), typeof(Checkpoint), typeof(Contract), typeof(Execute), typeof(FastForward), typeof(Oracle), typeof(Policy), typeof(Transfer), typeof(TransferNFT), typeof(Wallet))]
         internal class BatchFileCommands
         {
+            [Command("candidate")]
+            [Subcommand(typeof(Register), typeof(UnRegister), typeof(Vote), typeof(UnVote))]
+            internal class Candidate
+            {
+                [Command("register")]
+                internal class Register
+                {
+                    [Argument(0, Description = "Account to register candidate")]
+                    [Required]
+                    internal string Account { get; init; } = string.Empty;
+
+                    [Option(Description = "password to use for NEP-2/NEP-6 account")]
+                    internal string Password { get; init; } = string.Empty;
+                }
+
+                [Command("unregister")]
+                internal class UnRegister
+                {
+                    [Argument(0, Description = "Account to unregister candidate")]
+                    [Required]
+                    internal string Account { get; init; } = string.Empty;
+
+                    [Option(Description = "password to use for NEP-2/NEP-6 account")]
+                    internal string Password { get; init; } = string.Empty;
+                }
+
+                [Command("vote")]
+                internal class Vote
+                {
+                    [Argument(0, Description = "Account to vote")]
+                    [Required]
+                    internal string Account { get; init; } = string.Empty;
+
+                    [Argument(1, Description = "Candidate publickey")]
+                    [Required]
+                    internal string PublicKey { get; init; } = string.Empty;
+
+                    [Option(Description = "password to use for NEP-2/NEP-6 account")]
+                    internal string Password { get; init; } = string.Empty;
+                }
+
+                [Command("unvote")]
+                internal class UnVote
+                {
+                    [Argument(0, Description = "Account to unvote")]
+                    [Required]
+                    internal string Account { get; init; } = string.Empty;
+
+                    [Option(Description = "password to use for NEP-2/NEP-6 account")]
+                    internal string Password { get; init; } = string.Empty;
+                }
+            }
+
             [Command("checkpoint")]
             [Subcommand(typeof(Create))]
             internal class Checkpoint
@@ -164,6 +217,30 @@ namespace NeoExpress.Commands
                     [Option(Description = "Data parameter for update method on contract (Format: JSON)")]
                     internal string Data { get; init; } = string.Empty;
                 }
+            }
+
+            [Command("execute")]
+            internal class Execute
+            {
+                [Argument(0, Description = "A neo-vm script (Format: HEX, BASE64, Filename)")]
+                [Required]
+                internal string InputText { get; init; } = string.Empty;
+
+                [Option(Description = "Account to pay invocation GAS fee")]
+                internal string Account { get; init; } = string.Empty;
+
+                [Option(Description = "Witness Scope for transaction signer(s) (Allowed: None, CalledByEntry, Global)")]
+                [AllowedValues(StringComparison.OrdinalIgnoreCase, "None", "CalledByEntry", "Global")]
+                internal WitnessScope WitnessScope { get; init; } = WitnessScope.CalledByEntry;
+
+                [Option(Description = "Invoke contract for results (does not cost GAS)")]
+                internal bool Results { get; init; } = false;
+
+                [Option("--gas|-g", CommandOptionType.SingleValue, Description = "Additional GAS to apply to the contract invocation")]
+                internal decimal AdditionalGas { get; init; } = 0;
+
+                [Option(Description = "password to use for NEP-2/NEP-6 account")]
+                internal string Password { get; init; } = string.Empty;
             }
 
             [Command("fastfwd")]

--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -18,7 +18,17 @@ namespace NeoExpress.Commands
     partial class BatchCommand
     {
         [Command]
-        [Subcommand(typeof(Candidate), typeof(Checkpoint), typeof(Contract), typeof(Execute), typeof(FastForward), typeof(Oracle), typeof(Policy), typeof(Transfer), typeof(TransferNFT), typeof(Wallet))]
+        [Subcommand(
+            typeof(Candidate),
+            typeof(Checkpoint),
+            typeof(Contract),
+            typeof(Execute),
+            typeof(FastForward),
+            typeof(Oracle),
+            typeof(Policy),
+            typeof(Transfer),
+            typeof(TransferNFT),
+            typeof(Wallet))]
         internal class BatchFileCommands
         {
             [Command("candidate")]

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -133,6 +133,36 @@ namespace NeoExpress.Commands
                                     writer).ConfigureAwait(false);
                                 break;
                             }
+                        case CommandLineApplication<BatchFileCommands.Candidate.Register> cmd:
+                            {
+                                await txExec.RegisterCandidateAsync(
+                                    cmd.Model.Account,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Candidate.UnRegister> cmd:
+                            {
+                                await txExec.UnregisterCandidateAsync(
+                                    cmd.Model.Account,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Candidate.Vote> cmd:
+                            {
+                                await txExec.VoteAsync(
+                                    cmd.Model.Account,
+                                    cmd.Model.PublicKey,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Candidate.UnVote> cmd:
+                            {
+                                await txExec.VoteAsync(
+                                    cmd.Model.Account,
+                                    null,
+                                    cmd.Model.Password).ConfigureAwait(false);
+                                break;
+                            }
                         case CommandLineApplication<BatchFileCommands.Contract.Deploy> cmd:
                             {
                                 await txExec.ContractDeployAsync(
@@ -222,6 +252,32 @@ namespace NeoExpress.Commands
                                     cmd.Model.Password,
                                     cmd.Model.WitnessScope,
                                     data).ConfigureAwait(false);
+                                break;
+                            }
+                        case CommandLineApplication<BatchFileCommands.Execute> cmd:
+                            {
+                                if (string.IsNullOrEmpty(cmd.Model.Account) && !cmd.Model.Results)
+                                    throw new Exception("Either Account or --results must be specified");
+
+                                var script = ExecuteCommand.ConvertTextToScript(cmd.Model.InputText)
+                                    ?? ExecuteCommand.LoadFileScript(root.Resolve(cmd.Model.InputText))
+                                    ?? throw new Exception($"Invalid script: {cmd.Model.InputText}");
+                                if (cmd.Model.Results)
+                                {
+                                    await txExec.InvokeForResultsAsync(
+                                        script,
+                                        cmd.Model.Account,
+                                        cmd.Model.WitnessScope).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    await txExec.ContractInvokeAsync(
+                                        script,
+                                        cmd.Model.Account,
+                                        cmd.Model.Password,
+                                        cmd.Model.WitnessScope,
+                                        cmd.Model.AdditionalGas).ConfigureAwait(false);
+                                }
                                 break;
                             }
                         case CommandLineApplication<BatchFileCommands.FastForward> cmd:

--- a/src/neoxp/Commands/ExecuteCommand.cs
+++ b/src/neoxp/Commands/ExecuteCommand.cs
@@ -115,7 +115,7 @@ namespace NeoExpress.Commands
 
 
 
-        private static Script? LoadFileScript(string fileName)
+        internal static Script? LoadFileScript(string fileName)
         {
             try
             {
@@ -145,7 +145,7 @@ namespace NeoExpress.Commands
         }
 
 
-        private static Script? ConvertTextToScript(string inputScript)
+        internal static Script? ConvertTextToScript(string inputScript)
         {
             if (inputScript.TryGetBytesFromHexString(out var hexBytes) && TryConvertBytesToScript(hexBytes, out var s1))
             {

--- a/test/test.workflowvalidation/BatchCommandParserTests.cs
+++ b/test/test.workflowvalidation/BatchCommandParserTests.cs
@@ -159,4 +159,61 @@ public class BatchCommandParserTests
         result.SelectedCommand.GetValidationResult()
             .Should().Be(System.ComponentModel.DataAnnotations.ValidationResult.Success);
     }
+
+    [Theory]
+    [InlineData("register")]
+    [InlineData("unregister")]
+    [InlineData("unvote")]
+    public void Candidate_account_commands_are_recognized_batch_subcommands(string verb)
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("candidate", verb, "alice");
+
+        result.SelectedCommand.GetValidationResult().Should().Be(ValidationResult.Success);
+    }
+
+    [Fact]
+    public void Candidate_vote_requires_a_public_key()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var missingKey = app.Parse("candidate", "vote", "alice");
+        missingKey.SelectedCommand.GetValidationResult().Should().NotBe(ValidationResult.Success);
+
+        var complete = app.Parse("candidate", "vote", "alice", "02158c68fa3a03dbc73a6e20b4bbe626ecb02e765c72b95bd8c2c8f6b52f4a95b0");
+        complete.SelectedCommand.GetValidationResult().Should().Be(ValidationResult.Success);
+        var model = ((CommandLineApplication<BatchCommand.BatchFileCommands.Candidate.Vote>)complete.SelectedCommand).Model;
+        model.Account.Should().Be("alice");
+        model.PublicKey.Should().StartWith("02158c");
+    }
+
+    [Fact]
+    public void Execute_is_a_recognized_batch_subcommand()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("execute", "0c14aa", "--account", "genesis", "--gas", "1.5");
+
+        result.SelectedCommand.GetValidationResult().Should().Be(ValidationResult.Success);
+        var model = ((CommandLineApplication<BatchCommand.BatchFileCommands.Execute>)result.SelectedCommand).Model;
+        model.InputText.Should().Be("0c14aa");
+        model.Account.Should().Be("genesis");
+        model.AdditionalGas.Should().Be(1.5m);
+        model.Results.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_requires_a_script_argument()
+    {
+        var app = new CommandLineApplication<BatchCommand.BatchFileCommands>();
+        app.Conventions.UseDefaultConventions();
+
+        var result = app.Parse("execute");
+
+        result.SelectedCommand.GetValidationResult().Should().NotBe(ValidationResult.Success);
+    }
 }


### PR DESCRIPTION
## Summary

Batch files (`neoxp batch`, also consumed by `neoxp create --batch-filename`) mirror `checkpoint`, `contract`, `fastfwd`, `oracle`, `policy`, `transfer`, `transfernft` and `wallet create` — but the candidate governance commands (`register`, `unregister`, `vote`, `unvote`) and `execute` had no batch mirror, even though they are all plain offline-signable transactions through the same `TransactionExecutor`. Governance test scenarios and raw-script setup steps had to be scripted externally, paying process startup per command.

## Change

- New batch subcommands `candidate register|unregister|vote|unvote` and `execute`, with the same arguments and options as the real commands minus the batch-global `--input`/`--trace`/`--json`, dispatched to the existing `RegisterCandidateAsync`/`UnregisterCandidateAsync`/`VoteAsync`/`ContractInvokeAsync`/`InvokeForResultsAsync` executor methods.
- The `execute` mirror accepts HEX/Base64 scripts inline and resolves a script file name against the batch root (like the other file-taking batch commands), and enforces the same "Account or `--results`" rule as the CLI command. The `ConvertTextToScript`/`LoadFileScript` helpers it reuses became `internal`.
- Batch command list in `docs/command-reference.md` updated.

## Testing

- Six new `BatchCommandParserTests` cases: each candidate verb parses and validates, `vote` requires the public key, `execute` binds script/account/gas and rejects a missing script (19 parser tests total).
- **Live end-to-end**: created a chain and ran an 8-line batch — `transfer`, `candidate register`, `candidate vote`, `execute 11 --results` (returned `HALT`, stack `1`), `execute 11 --account node1` (invocation tx submitted), `candidate unvote`, `candidate unregister` — every line succeeded, exit 0.
- Full non-integration suite: 138 passed. `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
