### PR TITLE
Resolve keyed state reads with a point lookup instead of a scan

### DIFF
--- a/src/bctklib/persistence/ICacheClient.cs
+++ b/src/bctklib/persistence/ICacheClient.cs
@@ -15,6 +15,10 @@ internal interface ICacheClient : IDisposable
     bool TryGetCachedStorage(UInt160 contractHash, ReadOnlyMemory<byte> key, out byte[]? value);
     void CacheStorage(UInt160 contractHash, ReadOnlyMemory<byte> key, byte[]? value);
     bool TryGetCachedFoundStates(UInt160 contractHash, byte? prefix, out IEnumerable<(ReadOnlyMemory<byte> key, byte[] value)> value);
+    // Point lookup into the cached found states for (contractHash, prefix). Returns false when
+    // that record set has not been cached yet; returns true with a null value when the record
+    // set is cached but does not contain the key.
+    bool TryGetCachedState(UInt160 contractHash, byte? prefix, ReadOnlyMemory<byte> key, out byte[]? value);
     void DropCachedFoundStates(UInt160 contractHash, byte? prefix);
     ICacheSnapshot GetFoundStatesSnapshot(UInt160 contractHash, byte? prefix);
 }

--- a/src/bctklib/persistence/StateServiceStore.MemoryCacheClient.cs
+++ b/src/bctklib/persistence/StateServiceStore.MemoryCacheClient.cs
@@ -8,6 +8,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.BlockchainToolkit.Utilities;
 using System.Collections.Concurrent;
 
 namespace Neo.BlockchainToolkit.Persistence
@@ -17,8 +18,27 @@ namespace Neo.BlockchainToolkit.Persistence
         internal sealed class MemoryCacheClient : ICacheClient
         {
             readonly ConcurrentDictionary<int, byte[]?> storageMap = new();
-            readonly ConcurrentDictionary<int, IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap = new();
+            readonly ConcurrentDictionary<int, FoundStates> foundStateMap = new();
             private bool disposed;
+
+            // Cached found states keep both the download-ordered list (for the enumerating
+            // API) and a content-keyed index so a single record resolves with one lookup
+            // instead of a scan.
+            sealed class FoundStates
+            {
+                public readonly IReadOnlyList<(ReadOnlyMemory<byte> key, byte[] value)> Items;
+                public readonly Dictionary<ReadOnlyMemory<byte>, byte[]> Index;
+
+                public FoundStates(List<(ReadOnlyMemory<byte> key, byte[] value)> items)
+                {
+                    Items = items;
+                    Index = new Dictionary<ReadOnlyMemory<byte>, byte[]>(items.Count, MemorySequenceComparer.Default);
+                    foreach (var (key, value) in items)
+                    {
+                        Index[key] = value;
+                    }
+                }
+            }
 
             public void Dispose()
             {
@@ -70,13 +90,29 @@ namespace Neo.BlockchainToolkit.Persistence
                     throw new ObjectDisposedException(nameof(MemoryCacheClient));
 
                 var hash = GetStorageKey(contractHash, prefix);
-                if (foundStateMap.TryGetValue(hash, out var list))
+                if (foundStateMap.TryGetValue(hash, out var states))
                 {
-                    value = list;
+                    value = states.Items;
                     return true;
                 }
 
                 value = Enumerable.Empty<(ReadOnlyMemory<byte> key, byte[] value)>();
+                return false;
+            }
+
+            public bool TryGetCachedState(UInt160 contractHash, byte? prefix, ReadOnlyMemory<byte> key, out byte[]? value)
+            {
+                if (disposed)
+                    throw new ObjectDisposedException(nameof(MemoryCacheClient));
+
+                var hash = GetStorageKey(contractHash, prefix);
+                if (foundStateMap.TryGetValue(hash, out var states))
+                {
+                    value = states.Index.TryGetValue(key, out var item) ? item : null;
+                    return true;
+                }
+
+                value = null;
                 return false;
             }
 
@@ -102,12 +138,12 @@ namespace Neo.BlockchainToolkit.Persistence
 
             class Snapshot : ICacheSnapshot
             {
-                readonly ConcurrentDictionary<int, IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap;
+                readonly ConcurrentDictionary<int, FoundStates> foundStateMap;
                 readonly int hash;
                 List<(ReadOnlyMemory<byte> key, byte[] value)> entries = new();
                 bool disposed = false;
 
-                public Snapshot(ConcurrentDictionary<int, IList<(ReadOnlyMemory<byte>, byte[])>> foundStateMap, int hash)
+                public Snapshot(ConcurrentDictionary<int, FoundStates> foundStateMap, int hash)
                 {
                     this.foundStateMap = foundStateMap;
                     this.hash = hash;
@@ -132,7 +168,7 @@ namespace Neo.BlockchainToolkit.Persistence
                 {
                     ObjectDisposedException.ThrowIf(disposed, nameof(MemoryCacheClient.Snapshot));
 
-                    if (!foundStateMap.TryAdd(hash, entries))
+                    if (!foundStateMap.TryAdd(hash, new FoundStates(entries)))
                     {
                         throw new Exception("Failed to add cached entries");
                     }

--- a/src/bctklib/persistence/StateServiceStore.RocksDbCacheClient.cs
+++ b/src/bctklib/persistence/StateServiceStore.RocksDbCacheClient.cs
@@ -124,6 +124,25 @@ namespace Neo.BlockchainToolkit.Persistence
                 }
             }
 
+            public bool TryGetCachedState(UInt160 contractHash, byte? prefix, ReadOnlyMemory<byte> key, out byte[]? value)
+            {
+                if (disposed)
+                    throw new ObjectDisposedException(nameof(RocksDbCacheClient));
+
+                // the found-states column family is keyed by the storage key, so a single
+                // record resolves with one point lookup instead of iterating the family
+                var familyName = GetCachedFoundStateFamilyName(contractHash, prefix);
+                if (db.TryGetColumnFamily(familyName, out var columnFamily))
+                {
+                    using var slice = db.GetSlice(key.Span, columnFamily);
+                    value = slice.Valid ? slice.GetValue().ToArray() : null;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
             public ICacheSnapshot GetFoundStatesSnapshot(UInt160 contractHash, byte? prefix)
             {
                 if (disposed)

--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -314,8 +314,17 @@ namespace Neo.BlockchainToolkit.Persistence
 
             byte[]? GetFromStates(UInt160 contractHash, byte? prefix, ReadOnlyMemory<byte> key)
             {
-                return FindStates(contractHash, prefix)
-                    .FirstOrDefault(kvp => MemorySequenceComparer.Equals(kvp.key.Span, key.Span)).value;
+                // resolve the key with a point lookup into the cached record set instead of
+                // scanning every cached record; download the record set on the first miss
+                if (cacheClient.TryGetCachedState(contractHash, prefix, key, out var value))
+                    return value;
+
+                _ = DownloadStates(contractHash, prefix, CancellationToken.None);
+
+                if (cacheClient.TryGetCachedState(contractHash, prefix, key, out value))
+                    return value;
+
+                throw new Exception("DownloadStates failed");
             }
         }
 

--- a/test/test.bctklib/CacheClientPointLookupTests.cs
+++ b/test/test.bctklib/CacheClientPointLookupTests.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CacheClientPointLookupTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Persistence;
+using Neo.BlockchainToolkit.Utilities;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace test.bctklib
+{
+    using static Utility;
+
+    public class CacheClientPointLookupTests
+    {
+        static readonly UInt160 CONTRACT = UInt160.Parse("0x0000000000000000000000000000000000000001");
+
+        static void SeedFoundStates(ICacheClient client, byte? prefix, params (byte[] key, byte[] value)[] records)
+        {
+            using var snapshot = client.GetFoundStatesSnapshot(CONTRACT, prefix);
+            foreach (var (key, value) in records)
+            {
+                snapshot.Add(key, value);
+            }
+            snapshot.Commit();
+        }
+
+        static void AssertPointLookupMatchesEnumeration(ICacheClient client, byte? prefix)
+        {
+            var records = new[]
+            {
+                (key: new byte[] { 1, 10 }, value: new byte[] { 100 }),
+                (key: new byte[] { 1, 20 }, value: new byte[] { 101 }),
+                (key: new byte[] { 1, 30 }, value: new byte[] { 102 }),
+            };
+
+            // before the record set is cached, the point lookup cannot answer
+            client.TryGetCachedState(CONTRACT, prefix, records[0].key, out _).Should().BeFalse();
+
+            SeedFoundStates(client, prefix, records);
+
+            // hits: every record resolves and matches the enumerating API
+            client.TryGetCachedFoundStates(CONTRACT, prefix, out var enumerated).Should().BeTrue();
+            var byEnumeration = enumerated.ToArray();
+            foreach (var (key, value) in records)
+            {
+                client.TryGetCachedState(CONTRACT, prefix, key, out var pointValue).Should().BeTrue();
+                pointValue.Should().Equal(value);
+                byEnumeration.Single(kvp => MemorySequenceComparer.Equals(kvp.key.Span, key)).value.Should().Equal(value);
+            }
+
+            // definitive miss: the set is cached but the key is absent
+            client.TryGetCachedState(CONTRACT, prefix, new byte[] { 9, 9 }, out var missing).Should().BeTrue();
+            missing.Should().BeNull();
+        }
+
+        [Fact]
+        public void memory_cache_point_lookup_matches_enumeration()
+        {
+            using var client = new StateServiceStore.MemoryCacheClient();
+            AssertPointLookupMatchesEnumeration(client, null);
+        }
+
+        [Fact]
+        public void memory_cache_point_lookup_matches_enumeration_with_prefix()
+        {
+            using var client = new StateServiceStore.MemoryCacheClient();
+            AssertPointLookupMatchesEnumeration(client, 1);
+        }
+
+        [Fact]
+        public void rocksdb_cache_point_lookup_matches_enumeration()
+        {
+            using var path = new CleanupPath();
+            using var db = RocksDbUtility.OpenDb(path);
+            using var client = new StateServiceStore.RocksDbCacheClient(db, shared: true, nameof(CacheClientPointLookupTests));
+            AssertPointLookupMatchesEnumeration(client, null);
+        }
+
+        [Fact]
+        public void rocksdb_cache_point_lookup_matches_enumeration_with_prefix()
+        {
+            using var path = new CleanupPath();
+            using var db = RocksDbUtility.OpenDb(path);
+            using var client = new StateServiceStore.RocksDbCacheClient(db, shared: true, nameof(CacheClientPointLookupTests));
+            AssertPointLookupMatchesEnumeration(client, 1);
+        }
+
+        [Fact]
+        public void prefixed_and_unprefixed_record_sets_stay_separate()
+        {
+            using var client = new StateServiceStore.MemoryCacheClient();
+            SeedFoundStates(client, 1, (new byte[] { 1, 10 }, new byte[] { 100 }));
+
+            client.TryGetCachedState(CONTRACT, 1, new byte[] { 1, 10 }, out var hit).Should().BeTrue();
+            hit.Should().Equal(new byte[] { 100 });
+            // the null-prefix record set was never cached, so it cannot answer
+            client.TryGetCachedState(CONTRACT, null, new byte[] { 1, 10 }, out _).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`StateServiceStore` resolved a single storage key for deployed contracts by enumerating the contract's **entire** cached record set:

```csharp
byte[]? GetFromStates(UInt160 contractHash, byte? prefix, ReadOnlyMemory<byte> key)
{
    return FindStates(contractHash, prefix)
        .FirstOrDefault(kvp => MemorySequenceComparer.Equals(kvp.key.Span, key.Span)).value;
}
```

Every `ApplicationEngine` storage read during worknet execution pays this, scaling with the contract's record count. For `RocksDbCacheClient` (the worknet `run`/`fastfwd` path) the enumeration walks the whole column family allocating a key and a value array per record visited — even though that column family is keyed by the exact storage key and the same file already uses direct `db.GetSlice` point lookups for the singleton-storage cache.

## Change

- `ICacheClient.TryGetCachedState(contractHash, prefix, key, out value)` — returns `false` when the record set has not been cached yet, `true` with `null` for a definitive miss.
- `RocksDbCacheClient` answers with a single `GetSlice` on the found-states column family.
- `MemoryCacheClient` indexes each record set by key content (`MemorySequenceComparer`) when the download snapshot commits; the download-ordered list is kept for the enumerating API.
- `GetFromStates` now: point lookup → on first use, download the record set (existing `DownloadStates` path, unchanged) → point lookup. `Seek`/`Find` still use the enumerating API.

## Verification

- New `CacheClientPointLookupTests` (5 tests): on **both** cache clients, the point lookup returns exactly what the enumerating API returns for every seeded record; a cached-but-absent key is a definitive `null`; an undownloaded record set reports unanswerable (`false`) rather than an empty hit; prefixed and unprefixed record sets stay separate.
- Full `test.bctklib` suite: 356 passed unchanged (covers the `StateServiceStore` read paths end to end).
- `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.

Note: touches the same `MemoryCacheClient` file as #768; whichever merges second I will rebase.
