### PR TITLE
Confirm transactions instantly on single-node chains with chain.AutoMine

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -24,6 +24,30 @@ Example usage:
   }
 ```
 
+## `chain.AutoMine`
+
+When `chain.AutoMine` is enabled on a single-node chain, transactions submitted against a running
+node — transfers, contract deploys and invocations, `execute`, policy and candidate operations —
+are confirmed immediately: instead of entering the mempool and waiting for the next dBFT block
+(15 seconds by default, 1 second minimum), Neo-Express wraps the transaction in a consensus-signed
+block and submits the block directly, the same way the offline node and the `fastfwd` command
+already produce blocks. The regular dBFT block timer keeps running alongside and continues to mint
+empty blocks on its normal schedule.
+
+`chain.AutoMine` is specified as a boolean and defaults to `false`. It only takes effect on
+single-node chains, where the Neo-Express process holds every consensus key; the setting is
+ignored on four- and seven-node chains. In the unlikely event that a submitted block races an
+in-flight dBFT block at the same height, Neo-Express retries once on the new chain tip and then
+falls back to normal mempool submission.
+
+Example usage:
+
+``` json
+  "settings": {
+    "chain.AutoMine": "true" // Confirm transactions immediately on a single node chain
+  }
+```
+
 ## `rpc.BindAddress`
 
 The `rpc.BindAddress` Neo-Express setting corresponds to the `BindAddress`

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -113,6 +113,50 @@ namespace NeoExpress.Node
 
             var tx = await tm.SignAsync().ConfigureAwait(false);
 
+            if (ShouldAutoMine(chain))
+            {
+                return await SubmitAutoMinedBlockAsync(tx).ConfigureAwait(false);
+            }
+
+            return await rpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
+        }
+
+        // Instant transaction confirmation is opt-in via the chain.AutoMine setting and only
+        // supported on single-node chains, where the express process holds every consensus key.
+        internal static bool ShouldAutoMine(ExpressChain chain)
+            => chain.ConsensusNodes.Count == 1
+                && chain.TryReadSetting<bool>("chain.AutoMine", bool.TryParse, out var autoMine)
+                && autoMine;
+
+        // Confirm the transaction immediately by wrapping it in a consensus-signed block and
+        // submitting the block, the same way OfflineNode.SubmitTransactionAsync and
+        // FastForwardAsync already do, instead of waiting out the dBFT block interval.
+        // Submitting can race an in-flight dBFT proposal at the same height (the first block
+        // at a height wins), so retry once on the new tip and fall back to the mempool if the
+        // race is lost twice.
+        async Task<UInt256> SubmitAutoMinedBlockAsync(Transaction tx)
+        {
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                var prevHash = await rpcClient.GetBestBlockHashAsync().ConfigureAwait(false);
+                var prevHeaderHex = await rpcClient.GetBlockHeaderHexAsync($"{prevHash}").ConfigureAwait(false);
+                var prevHeader = Convert.FromBase64String(prevHeaderHex).AsSerializable<Header>();
+
+                var block = NodeUtility.CreateSignedBlock(prevHeader,
+                    consensusNodesKeys.Value,
+                    ProtocolSettings.Network,
+                    new[] { tx });
+                try
+                {
+                    await rpcClient.SubmitBlockAsync(block.ToArray()).ConfigureAwait(false);
+                    return tx.Hash;
+                }
+                catch (RpcException)
+                {
+                    // lost the race with a dBFT-proposed block at this height
+                }
+            }
+
             return await rpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
         }
 

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -33,6 +33,7 @@ namespace NeoExpress.Node
         readonly ExpressChain chain;
         readonly RpcClient rpcClient;
         readonly Lazy<KeyPair[]> consensusNodesKeys;
+        readonly bool autoMine;
         bool disposedValue;
 
         public ProtocolSettings ProtocolSettings { get; }
@@ -43,6 +44,7 @@ namespace NeoExpress.Node
             this.chain = chain;
             rpcClient = new RpcClient(new Uri($"http://localhost:{node.RpcPort}"), protocolSettings: settings);
             consensusNodesKeys = new Lazy<KeyPair[]>(() => chain.GetConsensusNodeKeys());
+            autoMine = ShouldAutoMine(chain);
         }
 
         public void Dispose()
@@ -113,7 +115,7 @@ namespace NeoExpress.Node
 
             var tx = await tm.SignAsync().ConfigureAwait(false);
 
-            if (ShouldAutoMine(chain))
+            if (autoMine)
             {
                 return await SubmitAutoMinedBlockAsync(tx).ConfigureAwait(false);
             }

--- a/test/test.workflowvalidation/AutoMineTests.cs
+++ b/test/test.workflowvalidation/AutoMineTests.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// AutoMineTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress;
+using NeoExpress.Node;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class AutoMineTests
+{
+    [Fact]
+    public void auto_mine_is_off_by_default()
+    {
+        var chain = ExpressChainManagerFactory.CreateChain(1, null);
+
+        OnlineNode.ShouldAutoMine(chain).Should().BeFalse();
+    }
+
+    [Fact]
+    public void auto_mine_is_on_for_a_single_node_chain_with_the_setting()
+    {
+        var chain = ExpressChainManagerFactory.CreateChain(1, null);
+        chain.Settings["chain.AutoMine"] = "true";
+
+        OnlineNode.ShouldAutoMine(chain).Should().BeTrue();
+    }
+
+    [Fact]
+    public void auto_mine_is_off_for_a_multi_node_chain_even_with_the_setting()
+    {
+        var chain = ExpressChainManagerFactory.CreateChain(4, null);
+        chain.Settings["chain.AutoMine"] = "true";
+
+        OnlineNode.ShouldAutoMine(chain).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("false")]
+    [InlineData("0")]
+    [InlineData("yes")]
+    [InlineData("")]
+    public void auto_mine_is_off_for_a_disabled_or_invalid_setting(string value)
+    {
+        var chain = ExpressChainManagerFactory.CreateChain(1, null);
+        chain.Settings["chain.AutoMine"] = value;
+
+        OnlineNode.ShouldAutoMine(chain).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Against a running node, every transaction — transfers, contract deploys/invokes, `execute`, policy and candidate operations — enters the mempool and waits out the dBFT block interval (15s default, 1s minimum). The offline node already gives instant finality (`OfflineNode.SubmitTransactionAsync` wraps each transaction in a consensus-signed block), so the same command against a *stopped* chain confirms immediately while the dev loop against `neoxp run` pays a full block interval per step. This is the latency Anvil/Hardhat eliminate with automine.

## Change

Add an opt-in **`chain.AutoMine`** setting. On single-node chains — where the express process holds every consensus key — `OnlineNode.ExecuteAsync` wraps the signed transaction in a consensus-signed block (`NodeUtility.CreateSignedBlock`, the code `fastfwd` and the offline node already rely on) and submits the block via `submitblock`, instead of `sendrawtransaction`:

- **Opt-in**: defaults to off; nothing changes without the setting.
- **Single-node only**: ignored on 4/7-node chains (other validators would have to sign).
- **Race-safe**: if the submitted block loses a race with an in-flight dBFT proposal at the same height, it retries once on the new tip, then falls back to normal mempool submission.
- The regular dBFT timer keeps minting empty blocks on its normal schedule alongside.

Documented in `docs/settings.md`.

## Verification

Live A/B test against a running node with a **60-second** block interval:

| | height before → 1s after transfer |
|---|---|
| `"chain.AutoMine": "true"` | 2 → **3** (transaction confirmed instantly, balance visible immediately) |
| no setting (control) | 2 → 2 (mempool behavior unchanged) |

- New `AutoMineTests` (7 cases) cover the gate: off by default, on for single-node + setting, ignored on multi-node chains, ignored for `false`/`0`/invalid/empty values.
- Full non-integration suite: 133 passed. `dotnet build -c Release` and `dotnet format --verify-no-changes` clean.
