### PR TITLE
Accept RPC params for NEP compliance checks

### DIFF
--- a/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressRpcServerPlugin.cs
@@ -700,11 +700,11 @@ namespace NeoExpress.Node
         }
 
         [RpcMethod]
-        public JToken ExpressIsNep11Compliant(JToken @param)
+        public JToken ExpressIsNep11Compliant(JArray @params)
         {
             if (neoSystem is null)
                 throw new NullReferenceException(nameof(neoSystem));
-            var nep11Hash = AsScriptHash(@param);
+            var nep11Hash = AsScriptHash(RequiredParam(@params, 0));
 
             using var snapshot = neoSystem.GetSnapshotCache();
             var nep11 = new Nep11Token(neoSystem.Settings, snapshot, nep11Hash);
@@ -716,11 +716,11 @@ namespace NeoExpress.Node
         }
 
         [RpcMethod]
-        public JToken ExpressIsNep17Compliant(JToken @param)
+        public JToken ExpressIsNep17Compliant(JArray @params)
         {
             if (neoSystem is null)
                 throw new NullReferenceException(nameof(neoSystem));
-            var nep17Hash = AsScriptHash(@param);
+            var nep17Hash = AsScriptHash(RequiredParam(@params, 0));
 
             using var snapshot = neoSystem.GetSnapshotCache();
             var nep17 = new Nep17Token(neoSystem.Settings, snapshot, nep17Hash);

--- a/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
+++ b/test/test.workflowvalidation/ExpressRpcServerPluginTests.cs
@@ -24,6 +24,18 @@ namespace test.workflowvalidation;
 public class ExpressRpcServerPluginTests
 {
     [Theory]
+    [InlineData(nameof(ExpressRpcServerPlugin.ExpressIsNep11Compliant))]
+    [InlineData(nameof(ExpressRpcServerPlugin.ExpressIsNep17Compliant))]
+    public void ContractComplianceRpcMethods_AcceptRpcParameterArray(string methodName)
+    {
+        var method = typeof(ExpressRpcServerPlugin).GetMethod(methodName);
+
+        method.Should().NotBeNull();
+        method!.GetParameters().Should().ContainSingle()
+            .Which.ParameterType.Should().Be(typeof(JArray));
+    }
+
+    [Theory]
     [InlineData(3, 0, 0, true)]
     [InlineData(3, 2, 2, true)]
     [InlineData(3, 3, 3, false)]


### PR DESCRIPTION
## Summary
- make expressisnep11compliant and expressisnep17compliant accept the RPC params array like the other plugin RPC methods
- read the contract hash from parameter 0
- add coverage for the RPC method parameter shape

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter ExpressRpcServerPluginTests --verbosity minimal
- dotnet test neo-express.sln --configuration Release --no-build --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal