### PR TITLE
Preserve hardfork settings in neotrace

### DIFF
--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -18,12 +18,14 @@ using Neo.IO;
 using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC;
+using Neo.Network.RPC.Models;
 using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.VM;
 using NeoTrace.Commands;
 using OneOf;
+using System.Collections.Immutable;
 using SysIO = System.IO;
 
 namespace NeoTrace
@@ -157,9 +159,15 @@ namespace NeoTrace
         {
             using var rpcClient = new RpcClient(uri);
             var version = await rpcClient.GetVersionAsync().ConfigureAwait(false);
+            return CreateProtocolSettings(version);
+        }
+
+        internal static ProtocolSettings CreateProtocolSettings(RpcVersion version)
+        {
             return ProtocolSettings.Default with
             {
                 AddressVersion = version.Protocol.AddressVersion,
+                Hardforks = version.Protocol.Hardforks.ToImmutableDictionary(),
                 InitialGasDistribution = version.Protocol.InitialGasDistribution,
                 MaxTraceableBlocks = version.Protocol.MaxTraceableBlocks,
                 MaxTransactionsPerBlock = version.Protocol.MaxTransactionsPerBlock,

--- a/src/trace/Properties/AssemblyInfo.cs
+++ b/src/trace/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// AssemblyInfo.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("test.workflowvalidation")]

--- a/test/test.workflowvalidation/NeotraceProtocolSettingsTests.cs
+++ b/test/test.workflowvalidation/NeotraceProtocolSettingsTests.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NeotraceProtocolSettingsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.Network.RPC.Models;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class NeotraceProtocolSettingsTests
+{
+    [Fact]
+    public void CreateProtocolSettings_PreservesHardforkHeights()
+    {
+        var version = new RpcVersion
+        {
+            Protocol = new RpcVersion.RpcProtocol
+            {
+                AddressVersion = ProtocolSettings.Default.AddressVersion,
+                Hardforks = new Dictionary<Hardfork, uint>
+                {
+                    [Hardfork.HF_Echidna] = 100,
+                    [Hardfork.HF_Gorgon] = 200
+                },
+                InitialGasDistribution = ProtocolSettings.Default.InitialGasDistribution,
+                MaxTraceableBlocks = ProtocolSettings.Default.MaxTraceableBlocks,
+                MaxTransactionsPerBlock = ProtocolSettings.Default.MaxTransactionsPerBlock,
+                MemoryPoolMaxTransactions = ProtocolSettings.Default.MemoryPoolMaxTransactions,
+                MillisecondsPerBlock = ProtocolSettings.Default.MillisecondsPerBlock,
+                Network = ProtocolSettings.Default.Network,
+                StandbyCommittee = ProtocolSettings.Default.StandbyCommittee,
+                ValidatorsCount = ProtocolSettings.Default.ValidatorsCount
+            }
+        };
+
+        var settings = NeoTrace.Program.CreateProtocolSettings(version);
+
+        settings.Hardforks[Hardfork.HF_Echidna].Should().Be(100);
+        settings.Hardforks[Hardfork.HF_Gorgon].Should().Be(200);
+    }
+}

--- a/test/test.workflowvalidation/test.workflowvalidation.csproj
+++ b/test/test.workflowvalidation/test.workflowvalidation.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\bctklib\bctklib.csproj" />
+    <ProjectReference Include="..\..\src\trace\neotrace.csproj" />
     <ProjectReference Include="..\..\src\neoxp\neoxp.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- preserve hardfork activation heights when neotrace maps RPC version data into ProtocolSettings
- add a focused protocol-mapping regression test

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter NeotraceProtocolSettingsTests --verbosity minimal
- dotnet test neo-express.sln --configuration Release --no-build --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal