### PR TITLE
Use policy VUB for oracle responses

### DIFF
--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -187,7 +187,7 @@ namespace NeoExpress.Node
             {
                 Version = 0,
                 Nonce = unchecked((uint)response.Id),
-                ValidUntilBlock = requestTx.BlockIndex + settings.MaxValidUntilBlockIncrement,
+                ValidUntilBlock = requestTx.BlockIndex + snapshot.GetMaxValidUntilBlockIncrement(settings),
                 Signers = new[]
                 {
                     new Signer

--- a/test/test.workflowvalidation/NodeUtilityOracleResponseTests.cs
+++ b/test/test.workflowvalidation/NodeUtilityOracleResponseTests.cs
@@ -10,11 +10,15 @@
 
 using FluentAssertions;
 using Neo;
+using Neo.BlockchainToolkit;
 using Neo.Cryptography.ECC;
+using Neo.IO;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.Persistence.Providers;
+using Neo.SmartContract;
 using Neo.SmartContract.Native;
+using Neo.VM;
 using NeoExpress.Node;
 using Xunit;
 
@@ -22,6 +26,8 @@ namespace test.workflowvalidation;
 
 public class NodeUtilityOracleResponseTests
 {
+    const byte Prefix_Transaction = 11;
+
     [Fact]
     public void CreateResponseTx_throws_descriptive_error_when_original_transaction_missing()
     {
@@ -55,5 +61,63 @@ public class NodeUtilityOracleResponseTests
             .Which.Should().NotBeOfType<System.NullReferenceException>();
         action.Should().Throw<System.Exception>()
             .WithMessage($"*original transaction {UInt256.Zero}*");
+    }
+
+    [Fact]
+    public void CreateResponseTx_uses_policy_max_valid_until_block_increment()
+    {
+        var policySettings = ProtocolSettings.Default with
+        {
+            MaxValidUntilBlockIncrement = 55,
+            StandbyCommittee = [ECCurve.Secp256r1.G],
+            ValidatorsCount = 1
+        };
+        var runtimeSettings = policySettings with
+        {
+            MaxValidUntilBlockIncrement = 100
+        };
+
+        using var store = new MemoryStore();
+        store.EnsureLedgerInitialized(policySettings);
+        using var snapshot = new StoreCache(store.GetSnapshot());
+
+        var originalTx = new Transaction
+        {
+            Attributes = System.Array.Empty<TransactionAttribute>(),
+            Script = System.Array.Empty<byte>(),
+            Signers = System.Array.Empty<Signer>(),
+            Witnesses = System.Array.Empty<Witness>()
+        };
+        snapshot.Add(
+            new KeyBuilder(NativeContract.Ledger.Id, Prefix_Transaction).Add(originalTx.Hash),
+            new StorageItem(new TransactionState
+            {
+                BlockIndex = 7,
+                State = VMState.HALT,
+                Transaction = originalTx
+            }));
+
+        var request = new OracleRequest
+        {
+            OriginalTxid = originalTx.Hash,
+            GasForResponse = 0,
+            Url = string.Empty,
+            Filter = string.Empty,
+            CallbackContract = UInt160.Zero,
+            CallbackMethod = string.Empty,
+            UserData = System.Array.Empty<byte>(),
+        };
+        var response = new OracleResponse
+        {
+            Id = 1,
+            Code = OracleResponseCode.Success,
+            Result = System.Array.Empty<byte>(),
+        };
+        var oracleNodes = new[] { ECCurve.Secp256r1.G };
+
+        var tx = NodeUtility.CreateResponseTx(snapshot, request, response, oracleNodes, runtimeSettings);
+
+        tx.Should().NotBeNull();
+        tx!.ValidUntilBlock.Should().Be(7 + policySettings.MaxValidUntilBlockIncrement);
     }
 }


### PR DESCRIPTION
## Summary
- use the policy-backed max valid-until-block increment when creating oracle response transactions
- add coverage for the case where the Policy value differs from the protocol settings object

## Testing
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter NodeUtilityOracleResponseTests --verbosity minimal
- dotnet test neo-express.sln --configuration Release --no-build --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal