### PR TITLE
Preserve worknet hardfork metadata

### DIFF
--- a/src/bctklib/models/BranchInfo.cs
+++ b/src/bctklib/models/BranchInfo.cs
@@ -10,6 +10,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Collections.Immutable;
 
 namespace Neo.BlockchainToolkit.Models
 {
@@ -24,12 +25,14 @@ namespace Neo.BlockchainToolkit.Models
         uint Index,
         UInt256 IndexHash,
         UInt256 RootHash,
-        IReadOnlyList<ContractInfo> Contracts)
+        IReadOnlyList<ContractInfo> Contracts,
+        IReadOnlyDictionary<Hardfork, uint>? Hardforks = null)
     {
         public ProtocolSettings ProtocolSettings => ProtocolSettings.Default with
         {
             AddressVersion = AddressVersion,
             Network = Network,
+            Hardforks = GetHardforkSettings(Hardforks),
         };
 
         public static BranchInfo Parse(JObject json)
@@ -39,6 +42,7 @@ namespace Neo.BlockchainToolkit.Models
             var index = json.Value<uint>("index");
             var indexHash = UInt256.Parse(json.Value<string>("index-hash"));
             var rootHash = UInt256.Parse(json.Value<string>("root-hash"));
+            var hardforks = ParseHardforks(json["hardforks"] as JObject);
 
             var contracts = new List<ContractInfo>();
             var contractsJson = json["contracts"] as JArray;
@@ -52,7 +56,7 @@ namespace Neo.BlockchainToolkit.Models
                     contracts.Add(new ContractInfo(id, hash, name));
                 }
             }
-            return new BranchInfo(network, addressVersion, index, indexHash, rootHash, contracts);
+            return new BranchInfo(network, addressVersion, index, indexHash, rootHash, contracts, hardforks);
         }
 
         public void WriteJson(JsonWriter writer)
@@ -63,6 +67,17 @@ namespace Neo.BlockchainToolkit.Models
             writer.WriteProperty("index", Index);
             writer.WriteProperty("index-hash", $"{IndexHash}");
             writer.WriteProperty("root-hash", $"{RootHash}");
+
+            if (Hardforks is not null)
+            {
+                writer.WritePropertyName("hardforks");
+                writer.WriteStartObject();
+                foreach (var hardfork in Hardforks.OrderBy(static h => h.Key))
+                {
+                    writer.WriteProperty($"{hardfork.Key}", hardfork.Value);
+                }
+                writer.WriteEndObject();
+            }
 
             writer.WritePropertyName("contracts");
             writer.WriteStartArray();
@@ -77,6 +92,28 @@ namespace Neo.BlockchainToolkit.Models
             writer.WriteEndArray();
 
             writer.WriteEndObject();
+        }
+
+        static IReadOnlyDictionary<Hardfork, uint>? ParseHardforks(JObject? json)
+        {
+            if (json is null)
+                return null;
+
+            return json.Properties()
+                .ToDictionary(
+                    static p => Enum.Parse<Hardfork>(p.Name, ignoreCase: true),
+                    static p => p.Value.Value<uint>());
+        }
+
+        static ImmutableDictionary<Hardfork, uint> GetHardforkSettings(IReadOnlyDictionary<Hardfork, uint>? hardforks)
+        {
+            if (hardforks is null)
+                return ProtocolSettings.Default.Hardforks;
+
+            var builder = ProtocolSettings.Default.Hardforks.ToBuilder();
+            foreach (var hardfork in hardforks)
+                builder[hardfork.Key] = hardfork.Value;
+            return builder.ToImmutable();
         }
     }
 }

--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -168,7 +168,8 @@ namespace Neo.BlockchainToolkit.Persistence
                 index,
                 blockHash,
                 stateRoot.RootHash,
-                contracts);
+                contracts,
+                version.Protocol.Hardforks);
 
             static async Task<IReadOnlyList<ContractInfo>> GetContractsAsync(RpcClient rpcClient, UInt256 rootHash)
             {

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -61,10 +61,8 @@ partial class RunCommand
     {
         var account = worknetFile.ConsensusWallet.GetAccounts().Single();
         var key = account.GetKey() ?? throw new Exception();
-        return ProtocolSettings.Default with
+        return worknetFile.BranchInfo.ProtocolSettings with
         {
-            Network = worknetFile.BranchInfo.Network,
-            AddressVersion = worknetFile.BranchInfo.AddressVersion,
             MillisecondsPerBlock = secondsPerBlock == 0 ? 15000 : secondsPerBlock * 1000,
             ValidatorsCount = 1,
             StandbyCommittee = new ECPoint[] { key.PublicKey },

--- a/test/test.bctklib/BranchInfoHardforkTests.cs
+++ b/test/test.bctklib/BranchInfoHardforkTests.cs
@@ -1,0 +1,99 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// BranchInfoHardforkTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class BranchInfoHardforkTests
+    {
+        [Fact]
+        public void Parse_preserves_hardforks_in_protocol_settings()
+        {
+            var json = CreateBranchJson();
+            json["hardforks"] = new JObject
+            {
+                ["HF_Echidna"] = 123u,
+                ["HF_Gorgon"] = 456u,
+            };
+
+            var branchInfo = BranchInfo.Parse(json);
+
+            branchInfo.Hardforks.Should().NotBeNull();
+            branchInfo.ProtocolSettings.Hardforks[Hardfork.HF_Basilisk]
+                .Should().Be(ProtocolSettings.Default.Hardforks[Hardfork.HF_Basilisk]);
+            branchInfo.ProtocolSettings.Hardforks[Hardfork.HF_Echidna].Should().Be(123u);
+            branchInfo.ProtocolSettings.Hardforks[Hardfork.HF_Gorgon].Should().Be(456u);
+        }
+
+        [Fact]
+        public void Parse_uses_default_hardforks_when_metadata_is_missing()
+        {
+            var branchInfo = BranchInfo.Parse(CreateBranchJson());
+
+            branchInfo.Hardforks.Should().BeNull();
+            branchInfo.ProtocolSettings.Hardforks.Should().BeEquivalentTo(ProtocolSettings.Default.Hardforks);
+        }
+
+        [Fact]
+        public void WriteJson_round_trips_hardfork_metadata()
+        {
+            var hardforks = new Dictionary<Hardfork, uint>
+            {
+                [Hardfork.HF_Echidna] = 123u,
+                [Hardfork.HF_Gorgon] = 456u,
+            };
+            var branchInfo = new BranchInfo(
+                5195086,
+                ProtocolSettings.Default.AddressVersion,
+                100,
+                UInt256.Zero,
+                UInt256.Zero,
+                new List<ContractInfo>(),
+                hardforks);
+
+            var json = WriteJson(branchInfo);
+            var parsed = BranchInfo.Parse(json);
+
+            json["hardforks"].Should().NotBeNull();
+            parsed.ProtocolSettings.Hardforks[Hardfork.HF_Echidna].Should().Be(123u);
+            parsed.ProtocolSettings.Hardforks[Hardfork.HF_Gorgon].Should().Be(456u);
+        }
+
+        static JObject CreateBranchJson()
+        {
+            return new JObject
+            {
+                ["network"] = 5195086,
+                ["address-version"] = ProtocolSettings.Default.AddressVersion,
+                ["index"] = 100,
+                ["index-hash"] = $"{UInt256.Zero}",
+                ["root-hash"] = $"{UInt256.Zero}",
+                ["contracts"] = new JArray(),
+            };
+        }
+
+        static JObject WriteJson(BranchInfo branchInfo)
+        {
+            using var writer = new StringWriter();
+            using var jsonWriter = new JsonTextWriter(writer);
+            branchInfo.WriteJson(jsonWriter);
+            jsonWriter.Flush();
+            return JObject.Parse(writer.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- store hardfork activation heights in branch metadata from RPC getversion
- round-trip the hardfork map in worknet branch JSON while keeping old files supported
- use BranchInfo.ProtocolSettings when running a worknet so fork settings are preserved

## Testing
- dotnet test test/test.bctklib/test.bctklib.csproj --configuration Release --filter BranchInfoHardforkTests --verbosity minimal
- dotnet test test/test.bctklib/test.bctklib.csproj --configuration Release --verbosity minimal
- dotnet test neo-express.sln --configuration Release --no-build --verbosity minimal --filter "FullyQualifiedName!~test.workflowvalidation.WorkflowValidationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpToolIntegrationTests&FullyQualifiedName!~test.workflowvalidation.NeoxpAdvancedIntegrationTests"
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal