### PR TITLE
Fix public chain NeoTrace replay

### DIFF
--- a/docs/trace-command-reference.md
+++ b/docs/trace-command-reference.md
@@ -12,6 +12,12 @@ to step through the recorded execution.
 Each traced transaction is written to a `<transaction-hash>.neo-trace` file in the current
 directory.
 
+NeoTrace records script execution, stack state, logs, notifications, and results for public
+chain transactions. It does not include per-instruction storage snapshots from StateService,
+because downloading full public-chain contract storage during every trace step can make
+large contracts impractical to replay. For local Neo-Express contract debugging with storage
+snapshots, use the `--trace` option on the relevant `neoxp` command.
+
 ## neotrace block
 
 ```

--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -42,6 +42,8 @@ namespace Neo.BlockchainToolkit.Persistence
         const byte NEO_Prefix_GasPerBlock = 29;
         const byte NEO_Prefix_VoterRewardPerCommittee = 23;
         const byte Oracle_Prefix_Request = 7;
+        const byte Policy_Prefix_BlockedAccount = 15;
+        const byte Policy_Prefix_WhitelistedFeeContracts = 16;
         const byte RoleMgmt_Prefix_NeoFSAlphabetNode = (byte)Role.NeoFSAlphabetNode;
         const byte RoleMgmt_Prefix_Oracle = (byte)Role.Oracle;
         const byte RoleMgmt_Prefix_StateValidator = (byte)Role.StateValidator;
@@ -51,6 +53,7 @@ namespace Neo.BlockchainToolkit.Persistence
             { NativeContract.ContractManagement.Id, new [] { ContractMgmt_Prefix_Contract, ContractMgmt_Prefix_ContractHash } },
             { NativeContract.NEO.Id, new [] { NEO_Prefix_Candidate, NEO_Prefix_GasPerBlock } },
             { NativeContract.Oracle.Id, new [] { Oracle_Prefix_Request } },
+            { NativeContract.Policy.Id, new [] { Policy_Prefix_BlockedAccount, Policy_Prefix_WhitelistedFeeContracts } },
             { NativeContract.RoleManagement.Id, new [] { RoleMgmt_Prefix_NeoFSAlphabetNode, RoleMgmt_Prefix_Oracle, RoleMgmt_Prefix_StateValidator } }
         };
 
@@ -289,34 +292,8 @@ namespace Neo.BlockchainToolkit.Persistence
                 return null;
             }
 
-            if (contractId < 0)
-            {
-                // contractSeekMap contains info on which native contract ids / prefixes can use seek methods
-                // For prefixes that need seek capability, ensure all records with that prefix are cached locally
-                // then retrieve the specifically keyed value from cache.
-                if (contractSeekMap.TryGetValue(contractId, out var prefixes))
-                {
-                    var prefix = key.Span[0];
-                    if (prefixes.Contains(prefix))
-                    {
-                        return GetFromStates(contractHash, prefix, key);
-                    }
-                }
-
-                // otherwise, retrieve and cache the keyed value
-                return GetStorage(contractHash, key,
-                    () => rpcClient.GetProvenState(branchInfo.RootHash, contractHash, key.Span));
-            }
-
-            // since there is no way to know the data usage patterns for deployed contracts download
-            // and cache all records for that contract then retrieve the keyed value from cache
-            return GetFromStates(contractHash, null, key);
-
-            byte[]? GetFromStates(UInt160 contractHash, byte? prefix, ReadOnlyMemory<byte> key)
-            {
-                return FindStates(contractHash, prefix)
-                    .FirstOrDefault(kvp => MemorySequenceComparer.Equals(kvp.key.Span, key.Span)).value;
-            }
+            return GetStorage(contractHash, key,
+                () => rpcClient.GetProvenState(branchInfo.RootHash, contractHash, key.Span));
         }
 
         byte[]? GetStorage(UInt160 contractHash, ReadOnlyMemory<byte> key, Func<byte[]?> getStorageFromService)

--- a/src/bctklib/smart-contract/TraceApplicationEngine.cs
+++ b/src/bctklib/smart-contract/TraceApplicationEngine.cs
@@ -22,15 +22,22 @@ namespace Neo.BlockchainToolkit.SmartContract
     public class TraceApplicationEngine : ApplicationEngine
     {
         readonly ITraceDebugSink traceDebugSink;
+        readonly ImmutableDictionary<UInt160, (int Id, string Name)> knownContracts;
+        readonly bool includeStorageSnapshots;
         ImmutableDictionary<UInt160, string> contractNameMap = ImmutableDictionary<UInt160, string>.Empty;
 
         public TraceApplicationEngine(ITraceDebugSink traceDebugSink, TriggerType trigger, IVerifiable container,
                                       DataCache snapshot, Block? persistingBlock, ProtocolSettings settings, long gas,
-                                      IDiagnostic? diagnostic = null, JumpTable? jumpTable = null)
+                                      IDiagnostic? diagnostic = null, JumpTable? jumpTable = null,
+                                      IReadOnlyDictionary<UInt160, (int Id, string Name)>? knownContracts = null,
+                                      bool includeStorageSnapshots = true)
             : base(trigger, container, snapshot, persistingBlock, settings, gas, diagnostic,
                   jumpTable ?? SelectJumpTable(snapshot, persistingBlock, settings))
         {
             this.traceDebugSink = traceDebugSink;
+            this.knownContracts = knownContracts?.ToImmutableDictionary()
+                ?? ImmutableDictionary<UInt160, (int Id, string Name)>.Empty;
+            this.includeStorageSnapshots = includeStorageSnapshots;
 
             Log += OnLog;
             Notify += OnNotify;
@@ -60,6 +67,12 @@ namespace Neo.BlockchainToolkit.SmartContract
 
         private string GetContractName(UInt160 scriptId)
         {
+            if (knownContracts.TryGetValue(scriptId, out var contract))
+                return contract.Name;
+
+            if (knownContracts.Count > 0)
+                return string.Empty;
+
             return ImmutableInterlocked.GetOrAdd(ref contractNameMap, scriptId,
                 k => NativeContract.ContractManagement.GetContract(SnapshotCache, k)?.Manifest.Name ?? string.Empty);
         }
@@ -103,16 +116,26 @@ namespace Neo.BlockchainToolkit.SmartContract
             traceDebugSink.Trace(State, FeeConsumed, InvocationStack);
         }
 
-        private void WriteStorages(UInt160 scriptHash)
+        private void WriteStorages(UInt160? scriptHash)
         {
-            if (scriptHash != null)
+            if (!includeStorageSnapshots || scriptHash is null)
+                return;
+
+            if (knownContracts.Count > 0)
             {
-                var contractState = NativeContract.ContractManagement.GetContract(SnapshotCache, scriptHash);
-                if (contractState != null)
-                {
-                    var storages = SnapshotCache.Find(StorageKey.CreateSearchPrefix(contractState.Id, default));
-                    traceDebugSink.Storages(scriptHash, storages);
-                }
+                if (!knownContracts.TryGetValue(scriptHash, out var contract))
+                    return;
+
+                var knownContractStorages = SnapshotCache.Find(StorageKey.CreateSearchPrefix(contract.Id, default));
+                traceDebugSink.Storages(scriptHash, knownContractStorages);
+                return;
+            }
+
+            var contractState = NativeContract.ContractManagement.GetContract(SnapshotCache, scriptHash);
+            if (contractState != null)
+            {
+                var storages = SnapshotCache.Find(StorageKey.CreateSearchPrefix(contractState.Id, default));
+                traceDebugSink.Storages(scriptHash, storages);
             }
         }
     }

--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -72,6 +72,7 @@ namespace NeoTrace
         static async Task TraceBlockAsync(RpcClient rpcClient, Block block, ProtocolSettings settings, IConsole console, UInt256? txHash = null)
         {
             IReadOnlyStore<byte[], byte[]> roStore;
+            IReadOnlyDictionary<UInt160, (int Id, string Name)>? knownContracts = null;
             if (block.Index == 0)
             {
                 roStore = NullStore.Instance;
@@ -80,6 +81,7 @@ namespace NeoTrace
             {
                 var branchInfo = await StateServiceStore.GetBranchInfoAsync(rpcClient, block.Index - 1).ConfigureAwait(false);
                 roStore = new StateServiceStore(rpcClient, branchInfo);
+                knownContracts = branchInfo.Contracts.ToDictionary(c => c.Hash, c => (c.Id, c.Name));
             }
 
             using var store = new MemoryTrackingStore(roStore);
@@ -137,7 +139,16 @@ namespace NeoTrace
                 {
                     var path = SysIO.Path.Combine(Environment.CurrentDirectory, $"{tx.Hash}.neo-trace");
                     var sink = new TraceDebugStream(SysIO.File.OpenWrite(path));
-                    return new TraceApplicationEngine(sink, TriggerType.Application, tx, snapshot, block, settings, tx.SystemFee);
+                    return new TraceApplicationEngine(
+                        sink,
+                        TriggerType.Application,
+                        tx,
+                        snapshot,
+                        block,
+                        settings,
+                        tx.SystemFee,
+                        knownContracts: knownContracts,
+                        includeStorageSnapshots: false);
                 }
                 else
                 {

--- a/test/test.bctklib/StateServiceStoreExactReadTests.cs
+++ b/test/test.bctklib/StateServiceStoreExactReadTests.cs
@@ -1,0 +1,141 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StateServiceStoreExactReadTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.Persistence;
+using Neo.Json;
+using Neo.Network.RPC;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace test.bctklib;
+
+public class StateServiceStoreExactReadTests
+{
+    [Fact]
+    public void TryGet_for_deployed_contract_uses_proven_state_without_prefetching_all_states()
+    {
+        var contractId = 1;
+        var contractHash = UInt160.Parse("0x1111111111111111111111111111111111111111");
+        var contractKey = new byte[] { 0x01, 0x02 };
+        var expected = new byte[] { 0x03, 0x04 };
+
+        var store = CreateStateServiceStore(contractId, contractHash, "SampleContract", contractKey, expected, out var rpcClient);
+        var fullKey = new StorageKey { Id = contractId, Key = contractKey }.ToArray();
+
+        store.TryGet(fullKey, out var actual).Should().BeTrue();
+
+        actual.Should().Equal(expected);
+        rpcClient.Methods.Should().ContainSingle("getproof");
+    }
+
+    [Fact]
+    public void TryGet_for_seekable_native_contract_uses_proven_state_without_prefetching_all_states()
+    {
+        var contractId = NativeContract.ContractManagement.Id;
+        var contractHash = NativeContract.ContractManagement.Hash;
+        var contractKey = new byte[] { 0x08, 0x01 };
+        var expected = new byte[] { 0x05, 0x06 };
+
+        var store = CreateStateServiceStore(contractId, contractHash, "ContractManagement", contractKey, expected, out var rpcClient);
+        var fullKey = new StorageKey { Id = contractId, Key = contractKey }.ToArray();
+
+        store.TryGet(fullKey, out var actual).Should().BeTrue();
+
+        actual.Should().Equal(expected);
+        rpcClient.Methods.Should().ContainSingle("getproof");
+    }
+
+    [Fact]
+    public void Find_supports_policy_blocked_account_prefix()
+    {
+        var rpcClient = new RecordingRpcClient((method, _) =>
+            method == "findstates"
+                ? new JObject
+                {
+                    ["firstProof"] = null,
+                    ["lastProof"] = null,
+                    ["truncated"] = false,
+                    ["results"] = new JArray()
+                }
+                : throw new InvalidOperationException($"{method} should not be called for PolicyContract seek"));
+        var branchInfo = new BranchInfo(
+            ProtocolSettings.Default.Network,
+            ProtocolSettings.Default.AddressVersion,
+            1,
+            UInt256.Zero,
+            UInt256.Zero,
+            new[] { new ContractInfo(NativeContract.Policy.Id, NativeContract.Policy.Hash, "PolicyContract") });
+        using var store = new StateServiceStore(rpcClient, branchInfo);
+        var blockedAccountPrefix = StorageKey.CreateSearchPrefix(NativeContract.Policy.Id, new byte[] { 0x0F });
+
+        store.Find(blockedAccountPrefix).Should().BeEmpty();
+
+        rpcClient.Methods.Should().ContainSingle("findstates");
+    }
+
+    static StateServiceStore CreateStateServiceStore(
+        int contractId,
+        UInt160 contractHash,
+        string contractName,
+        byte[] contractKey,
+        byte[] value,
+        out RecordingRpcClient rpcClient)
+    {
+        using var proofStore = new MemoryStore();
+        using var snapshot = proofStore.GetSnapshot();
+        var trie = new Neo.Cryptography.MPTTrie.Trie(snapshot, null);
+        var fullKey = new StorageKey { Id = contractId, Key = contractKey }.ToArray();
+        trie.Put(fullKey, value);
+        trie.Commit();
+        snapshot.Commit();
+
+        var proof = Convert.ToBase64String(trie.GetSerializedProof(fullKey));
+        rpcClient = new RecordingRpcClient((method, _) =>
+            method == "getproof"
+                ? new JString(proof)
+                : throw new InvalidOperationException($"{method} should not be called for exact reads"));
+
+        var branchInfo = new BranchInfo(
+            ProtocolSettings.Default.Network,
+            ProtocolSettings.Default.AddressVersion,
+            1,
+            UInt256.Zero,
+            trie.Root.Hash,
+            new[] { new ContractInfo(contractId, contractHash, contractName) });
+
+        return new StateServiceStore(rpcClient, branchInfo);
+    }
+
+    sealed class RecordingRpcClient : RpcClient
+    {
+        readonly Func<string, JToken[], JToken> handler;
+
+        public RecordingRpcClient(Func<string, JToken[], JToken> handler) : base(null!)
+        {
+            this.handler = handler;
+        }
+
+        public List<string> Methods { get; } = new();
+
+        public override JToken RpcSend(string method, params JToken[] paraArgs)
+        {
+            Methods.Add(method);
+            return handler(method, paraArgs);
+        }
+    }
+}

--- a/test/test.bctklib/TestApplicationEngineHardforkTests.cs
+++ b/test/test.bctklib/TestApplicationEngineHardforkTests.cs
@@ -67,6 +67,62 @@ public class TestApplicationEngineHardforkTests
         gorgon.FaultException.Should().BeOfType<InvalidCastException>();
     }
 
+    [Fact]
+    public void Trace_engine_skips_storage_snapshot_for_unknown_entry_script()
+    {
+        using var store = new MemoryStore();
+        store.EnsureLedgerInitialized(DeployedContractFixture.Default);
+        using var snapshot = new StoreCache(store.GetSnapshot());
+        var block = CreateBlock(1);
+        var sink = new CountingTraceDebugSink();
+        var knownContracts = ImmutableDictionary<UInt160, (int Id, string Name)>.Empty
+            .Add(UInt160.Zero, (1, "KnownContract"));
+        using var engine = new TraceApplicationEngine(
+            sink,
+            TriggerType.Application,
+            TestApplicationEngine.CreateTestTransaction(),
+            snapshot,
+            block,
+            DeployedContractFixture.Default,
+            ApplicationEngine.TestModeGas,
+            knownContracts: knownContracts);
+
+        engine.LoadScript(new byte[] { 0x40 });
+        engine.Execute();
+
+        engine.State.Should().Be(VMState.HALT);
+        sink.StorageSnapshots.Should().Be(0);
+    }
+
+    [Fact]
+    public void Trace_engine_can_skip_storage_snapshots()
+    {
+        using var store = new MemoryStore();
+        store.EnsureLedgerInitialized(DeployedContractFixture.Default);
+        using var snapshot = new StoreCache(store.GetSnapshot());
+        var block = CreateBlock(1);
+        var sink = new CountingTraceDebugSink();
+        var script = new byte[] { 0x40 };
+        var knownContracts = ImmutableDictionary<UInt160, (int Id, string Name)>.Empty
+            .Add(Neo.SmartContract.Helper.ToScriptHash(script), (1, "KnownContract"));
+        using var engine = new TraceApplicationEngine(
+            sink,
+            TriggerType.Application,
+            TestApplicationEngine.CreateTestTransaction(),
+            snapshot,
+            block,
+            DeployedContractFixture.Default,
+            ApplicationEngine.TestModeGas,
+            knownContracts: knownContracts,
+            includeStorageSnapshots: false);
+
+        engine.LoadScript(script);
+        engine.Execute();
+
+        engine.State.Should().Be(VMState.HALT);
+        sink.StorageSnapshots.Should().Be(0);
+    }
+
     static byte[] CreateGorgonSensitiveScript()
     {
         using var sb = new ScriptBuilder();
@@ -120,42 +176,52 @@ public class TestApplicationEngineHardforkTests
         Transactions = []
     };
 
-    sealed class NullTraceDebugSink : ITraceDebugSink
+    class NullTraceDebugSink : ITraceDebugSink
     {
-        public void Dispose()
+        public virtual void Dispose()
         {
         }
 
-        public void Fault(Exception exception)
+        public virtual void Fault(Exception exception)
         {
         }
 
-        public void Log(LogEventArgs args, string scriptName)
+        public virtual void Log(LogEventArgs args, string scriptName)
         {
         }
 
-        public void Notify(NotifyEventArgs args, string scriptName)
+        public virtual void Notify(NotifyEventArgs args, string scriptName)
         {
         }
 
-        public void ProtocolSettings(uint network, byte addressVersion)
+        public virtual void ProtocolSettings(uint network, byte addressVersion)
         {
         }
 
-        public void Results(VMState vmState, long gasConsumed, IReadOnlyCollection<Neo.VM.Types.StackItem> results)
+        public virtual void Results(VMState vmState, long gasConsumed, IReadOnlyCollection<Neo.VM.Types.StackItem> results)
         {
         }
 
-        public void Script(Script script)
+        public virtual void Script(Script script)
         {
         }
 
-        public void Storages(UInt160 scriptHash, IEnumerable<(StorageKey key, StorageItem item)> storages)
+        public virtual void Storages(UInt160 scriptHash, IEnumerable<(StorageKey key, StorageItem item)> storages)
         {
         }
 
-        public void Trace(VMState vmState, long gasConsumed, IReadOnlyCollection<ExecutionContext> executionContexts)
+        public virtual void Trace(VMState vmState, long gasConsumed, IReadOnlyCollection<ExecutionContext> executionContexts)
         {
+        }
+    }
+
+    sealed class CountingTraceDebugSink : NullTraceDebugSink
+    {
+        public int StorageSnapshots { get; private set; }
+
+        public override void Storages(UInt160 scriptHash, IEnumerable<(StorageKey key, StorageItem item)> storages)
+        {
+            StorageSnapshots++;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Use proven state lookups for exact StateService reads instead of prefetching whole contract storage.
- Add PolicyContract seek prefixes required by v3.10 native contract replay.
- Avoid public-chain per-instruction storage snapshots during NeoTrace replay.
- Document the public-chain storage snapshot limitation.

## Root cause
Exact reads from StateService were routed through `findstates`, so a single contract storage read could download the entire contract state. On public TestNet this made large contracts impractical to replay. v3.10 PolicyContract also seeks blocked-account storage during Faun initialization, but those prefixes were not registered in the StateService seek map.

## Testing
- `dotnet test test/test.bctklib/test.bctklib.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~StateServiceStoreExactReadTests|FullyQualifiedName~Trace_engine_skips_storage_snapshot_for_unknown_entry_script|FullyQualifiedName~Trace_engine_can_skip_storage_snapshots' --verbosity minimal`
- `dotnet test test/test.bctklib/test.bctklib.csproj --configuration Release --no-restore --verbosity minimal`
- `dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal`
- `dotnet restore neo-express.sln --verbosity minimal`
- `dotnet build neo-express.sln --configuration Release --no-restore --verbosity minimal`
- `dotnet test neo-express.sln --configuration Release --no-build --verbosity minimal`
- `neotrace transaction 0xb54c47d89fb9378c92e8d3d6c87d93e1688ea1394b7551113a84e074f93627c0 -r http://seed1t5.neo.org:20332`
- `neotrace block 12960000 -r http://seed1t5.neo.org:20332`
