### PR TITLE
Avoid plugin list mutation during run shutdown

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -370,18 +370,25 @@ namespace NeoExpress
                         expressStorage, multiSigAccount.ScriptHash);
                     using var neoSystem = new Neo.NeoSystem(ProtocolSettings, storeProvider.Name);
 
-                    neoSystem.StartNode(new Neo.Network.P2P.ChannelsConfig
+                    try
                     {
-                        Tcp = new IPEndPoint(IPAddress.Loopback, node.TcpPort)
-                    });
-                    dbftPlugin.Start(wallet);
+                        neoSystem.StartNode(new Neo.Network.P2P.ChannelsConfig
+                        {
+                            Tcp = new IPEndPoint(IPAddress.Loopback, node.TcpPort)
+                        });
+                        dbftPlugin.Start(wallet);
 
-                    // DevTracker looks for a string that starts with "Neo express is running" to confirm that the instance has started
-                    // Do not remove or re-word this console output:
-                    console.Out.WriteLine($"Neo express is running ({expressStorage.Name})");
+                        // DevTracker looks for a string that starts with "Neo express is running" to confirm that the instance has started
+                        // Do not remove or re-word this console output:
+                        console.Out.WriteLine($"Neo express is running ({expressStorage.Name})");
 
-                    var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(token, rpcServerPlugin.CancellationToken);
-                    linkedToken.Token.WaitHandle.WaitOne();
+                        var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(token, rpcServerPlugin.CancellationToken);
+                        linkedToken.Token.WaitHandle.WaitOne();
+                    }
+                    finally
+                    {
+                        _ = Plugin.Plugins.Remove(persistencePlugin);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
@@ -271,18 +271,13 @@ public class NeoxpAdvancedIntegrationTests : IDisposable
             await _runCommand.RunNeoxpCommand("transfer", "10000", "gas", "genesis", "bob");
 
             // Equivalent to: neoxp stop --all
-            await _runCommand.RunNeoxpCommand("stop", "--all");
-            // Note: Stop command may fail if no blockchain is running, which is expected
+            var (stopExitCode, _, stopError) = await _runCommand.RunNeoxpCommand("stop", "--all");
+            stopExitCode.Should().Be(0, stopError);
 
             // Wait for the run task to complete
-            try
-            {
-                await runTask;
-            }
-            catch (TimeoutException)
-            {
-                _output.WriteLine("Run command timed out as expected");
-            }
+            var (runExitCode, _, runError) = await runTask;
+            runExitCode.Should().Be(0, runError);
+            runError.Should().NotContain("Collection was modified");
 
             _output.WriteLine("✅ neoxp run command with timeout test completed");
         }


### PR DESCRIPTION
Summary:
- remove the express persistence plugin from the global plugin list before NeoSystem disposal during run shutdown
- assert that neoxp run exits cleanly after stop --all

Tests:
- dotnet build src/neoxp/neoxp.csproj --configuration Release --no-restore --verbosity minimal
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter "FullyQualifiedName~NeoxpAdvancedIntegrationTests.Test03_RunCommandWithTimeout" --verbosity minimal
- manual create/run/stop validation with neoxp --stack-trace