### PR TITLE
Use two-parameter contract update without data

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -214,7 +214,7 @@ namespace NeoExpress.Commands
                             }
                         case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:
                             {
-                                var data = txExec.ContractParameterParser(cmd.Model.Data);
+                                var data = ContractCommand.Update.ParseUpdateData(cmd.Model.Data, txExec.ContractParameterParser);
                                 await txExec.ContractUpdateAsync(
                                     cmd.Model.Contract,
                                     root.Resolve(cmd.Model.NefFile),

--- a/src/neoxp/Commands/ContractCommand.Update.cs
+++ b/src/neoxp/Commands/ContractCommand.Update.cs
@@ -67,7 +67,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    var data = txExec.ContractParameterParser(Data);
+                    var data = ParseUpdateData(Data, txExec.ContractParameterParser);
                     await txExec.ContractUpdateAsync(Contract, NefFile, Account, password, WitnessScope, data).ConfigureAwait(false);
                     return 0;
                 }
@@ -78,6 +78,8 @@ namespace NeoExpress.Commands
                 }
             }
 
+            internal static object? ParseUpdateData(string data, Func<string, object> parseData)
+                => string.IsNullOrEmpty(data) ? null : parseData(data);
         }
     }
 }

--- a/test/test.workflowvalidation/ContractUpdateCommandTests.cs
+++ b/test/test.workflowvalidation/ContractUpdateCommandTests.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractUpdateCommandTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractUpdateCommandTests
+{
+    [Fact]
+    public void ParseUpdateData_returns_null_when_data_is_omitted()
+    {
+        var data = ContractCommand.Update.ParseUpdateData(string.Empty, _ => throw new InvalidOperationException());
+
+        data.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseUpdateData_parses_explicit_data()
+    {
+        var data = ContractCommand.Update.ParseUpdateData("42", value => value.Length);
+
+        data.Should().Be(2);
+    }
+}


### PR DESCRIPTION
Summary:
- treat omitted contract update data as null so two-parameter update methods are used
- apply the same behavior to batch contract update commands
- add unit coverage for update data parsing

Tests:
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter "FullyQualifiedName~ContractUpdateCommandTests|FullyQualifiedName~BatchCommandParserTests" --verbosity minimal
- dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity minimal
- manual deploy/update/run validation with a two-parameter update contract
- manual batch update validation without --data