### PR TITLE
Fix Visual Tracker Neo Express package bundling

### DIFF
--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -29,9 +29,17 @@ jobs:
         cache: npm
         cache-dependency-path: extentions/neo3-visual-tracker/package-lock.json
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5.2.0
+      with:
+        dotnet-version: '10.0.x'
+
     - name: Install dependencies
       working-directory: extentions/neo3-visual-tracker
       run: npm ci
+
+    - name: Pack Neo Express
+      run: dotnet pack src/neoxp/neoxp.csproj --configuration Release --output ./out --verbosity normal
 
     - name: Typecheck
       working-directory: extentions/neo3-visual-tracker
@@ -48,3 +56,11 @@ jobs:
     - name: Run unit tests
       working-directory: extentions/neo3-visual-tracker
       run: npm test
+
+    - name: Package extension
+      working-directory: extentions/neo3-visual-tracker
+      shell: bash
+      run: |
+        nupkg="$(find "${GITHUB_WORKSPACE}/out" -maxdepth 1 -name 'Neo.Express.*.nupkg' -print -quit)"
+        test -n "$nupkg"
+        NEO_EXPRESS_NUPKG="$nupkg" npx vsce package --no-git-tag-version

--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
 
     - name: Setup Node
       uses: actions/setup-node@v6.4.0

--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -66,3 +66,10 @@ jobs:
         nupkg="$(find "${GITHUB_WORKSPACE}/out" -maxdepth 1 -name 'Neo.Express.*.nupkg' -print -quit)"
         test -n "$nupkg"
         NEO_EXPRESS_NUPKG="$nupkg" npx vsce package --no-git-tag-version
+        vsix="$(find . -maxdepth 1 -name 'neo3-visual-tracker-*.vsix' -print -quit)"
+        test -n "$vsix"
+        unzip -l "$vsix" | grep -q 'extension/deps/nxp/tools/net10.0/any/neoxp.dll'
+        if unzip -l "$vsix" | grep -q 'nxp\.nupkg'; then
+          echo "The VSIX should not include the source Neo Express nupkg."
+          exit 1
+        fi

--- a/.github/workflows/vse-release.yml
+++ b/.github/workflows/vse-release.yml
@@ -30,12 +30,21 @@ jobs:
       with:
         node-version: '22'
 
+    - name: Restore .NET dependencies
+      working-directory: .
+      run: dotnet restore neo-express.sln
+
+    - name: Pack Neo Express
+      working-directory: .
+      run: dotnet pack neo-express.sln --output ./dist --configuration Release --no-restore --verbosity normal
+
     - name: Build + Package extension
       run: |
         npm ci
         npx vsce package --no-git-tag-version ${{ steps.nbgv.outputs.NpmPackageVersion }}
       env:
         EXTENSION_VERSION: ${{ steps.nbgv.outputs.NpmPackageVersion }}
+        NEO_EXPRESS_NUPKG: ${{ format('{0}/dist/Neo.Express.{1}.nupkg', github.workspace, steps.nbgv.outputs.NuGetPackageVersion) }}
 
     - name: Create Release
       uses: softprops/action-gh-release@v3

--- a/extentions/neo3-visual-tracker/.vscodeignore
+++ b/extentions/neo3-visual-tracker/.vscodeignore
@@ -8,4 +8,4 @@ node_modules/**
 **/tsconfig.json
 **/*.map
 **/*.ts
-*.nupkg
+**/*.nupkg

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -327,7 +327,7 @@
   "scripts": {
     "vscode:prepublish": "npm run compile-prod && npm run bundle-nxp",
     "bundle-nxp": "npm run bundle-nxp-download && npm run bundle-nxp-extract",
-    "bundle-nxp-download": "shx rm -rf deps/nxp && shx mkdir -p deps/nxp && curl -fL \"https://www.nuget.org/api/v2/package/Neo.Express/%npm_package_version%\" -o deps/nxp/nxp.nupkg",
+    "bundle-nxp-download": "node scripts/download-nxp.js",
     "bundle-nxp-extract": "cd deps/nxp && extract-zip nxp.nupkg",
     "compile": "npm run compile-ext && npm run compile-panel",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/extentions/neo3-visual-tracker/scripts/download-nxp.js
+++ b/extentions/neo3-visual-tracker/scripts/download-nxp.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// This file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+"use strict";
+
+const fs = require("fs");
+const http = require("http");
+const https = require("https");
+const path = require("path");
+
+const version = process.env.npm_package_version;
+if (!version) {
+  console.error("npm_package_version is not set.");
+  process.exit(1);
+}
+
+const outputDir = path.join(__dirname, "..", "deps", "nxp");
+const outputPath = path.join(outputDir, "nxp.nupkg");
+const packageUrl = `https://www.nuget.org/api/v2/package/Neo.Express/${version}`;
+const localPackagePath = process.env.NEO_EXPRESS_NUPKG;
+
+fs.rmSync(outputDir, { recursive: true, force: true });
+fs.mkdirSync(outputDir, { recursive: true });
+
+if (localPackagePath) {
+  fs.copyFileSync(path.resolve(localPackagePath), outputPath);
+  process.exit(0);
+}
+
+function download(url, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith("https:") ? https : http;
+    const request = client.get(
+      url,
+      { headers: { "User-Agent": "neo3-visual-tracker-package" } },
+      (response) => {
+        const { statusCode, headers } = response;
+        const redirect =
+          statusCode &&
+          [301, 302, 303, 307, 308].includes(statusCode) &&
+          headers.location;
+
+        if (redirect) {
+          response.resume();
+          if (redirectsLeft === 0) {
+            reject(new Error(`Too many redirects while downloading ${packageUrl}`));
+            return;
+          }
+          resolve(download(new URL(redirect, url).toString(), redirectsLeft - 1));
+          return;
+        }
+
+        if (statusCode !== 200) {
+          response.resume();
+          reject(new Error(`Download failed with HTTP ${statusCode}: ${url}`));
+          return;
+        }
+
+        const file = fs.createWriteStream(outputPath);
+        response.pipe(file);
+        file.on("finish", () => file.close(resolve));
+        file.on("error", reject);
+      }
+    );
+
+    request.on("error", reject);
+  });
+}
+
+download(packageUrl).catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- replace the Visual Tracker NuGet download shell command with a cross-platform Node script
- support NEO_EXPRESS_NUPKG for packaging with a local Neo.Express nupkg before NuGet.org publication

## Validation
- npm test
- NEO_EXPRESS_NUPKG=/tmp/neo-express-v310-pack-postfix/Neo.Express.3.10.0-g0ca4ec6a48.nupkg npm run package
