### PR TITLE
Fix Visual Tracker run node index argument

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressInstanceManager.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressInstanceManager.ts
@@ -75,6 +75,7 @@ export default class NeoExpressInstanceManager {
           child.configPath,
           "-s",
           `${secondsPerBlock}`,
+          "--node-index",
           `${child.index}`
         );
         if (terminal) {
@@ -89,6 +90,7 @@ export default class NeoExpressInstanceManager {
         identifier.configPath,
         "-s",
         `${secondsPerBlock}`,
+        "--node-index",
         `${identifier.index}`
       );
       if (terminal) {


### PR DESCRIPTION
## Summary
- pass the selected Neo Express node index with --node-index
- avoid sending the index as an unsupported positional argument

## Validation
- npm run compile
- npm test
