### PR TITLE
Fix NEP-11 token listing

### DIFF
--- a/src/bctklib/plugins/ToolkitRpcServer.cs
+++ b/src/bctklib/plugins/ToolkitRpcServer.cs
@@ -363,7 +363,7 @@ namespace Neo.BlockchainToolkit.Plugins
                         ? (ByteString)value
                         : (ByteString)value.ConvertTo(StackItemType.ByteString);
 
-                    yield return (ReadOnlyMemory<byte>)byteString;
+                    yield return byteString.GetSpan().ToArray();
                 }
             }
         }
@@ -371,7 +371,7 @@ namespace Neo.BlockchainToolkit.Plugins
         public static BigInteger GetDivisibleNep11Balance(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, UInt160 address, ProtocolSettings settings)
         {
             using var builder = new ScriptBuilder();
-            builder.EmitDynamicCall(asset, "balanceOf", address.ToArray(), (ByteString)tokenId);
+            builder.EmitDynamicCall(asset, "balanceOf", address.ToArray(), tokenId.ToArray());
             return TryGetBalance(snapshot, builder, settings, out var balance)
                 ? balance
                 : BigInteger.Zero;
@@ -380,7 +380,7 @@ namespace Neo.BlockchainToolkit.Plugins
         public static UInt160 GetIndivisibleNep11Owner(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, ProtocolSettings settings)
         {
             using var builder = new ScriptBuilder();
-            builder.EmitDynamicCall(asset, "ownerOf", (ByteString)tokenId);
+            builder.EmitDynamicCall(asset, "ownerOf", tokenId.ToArray());
 
             using var engine = builder.Invoke(settings, snapshot);
             if (engine.State != VMState.FAULT

--- a/src/neoxp/Commands/ShowCommand.NFT.cs
+++ b/src/neoxp/Commands/ShowCommand.NFT.cs
@@ -66,7 +66,7 @@ namespace NeoExpress.Commands
                         : UInt160.TryParse(Contract, out var uint160)
                             ? uint160
                             : throw new InvalidOperationException($"contract \"{Contract}\" not found");
-                    var list = await expressNode.GetNFTAsync(accountHash, scriptHash).ConfigureAwait(false);
+                    var list = await expressNode.ListNftTokenIdsAsync(accountHash, scriptHash).ConfigureAwait(false);
                     if (Json)
                     {
                         using var writer = new JsonTextWriter(console.Out) { Formatting = Formatting.Indented };
@@ -75,7 +75,12 @@ namespace NeoExpress.Commands
                     else if (list.Count == 0)
                         await console.Out.WriteLineAsync($"No NFT yet. (Contract:{scriptHash}, Account:{accountHash.ToAddress(ProtocolSettings.Default.AddressVersion)})");
                     else
-                        list.ForEach(p => console.Out.WriteLine(FormatTokenId(p)));
+                    {
+                        foreach (var tokenId in list)
+                        {
+                            console.Out.WriteLine(FormatTokenId(tokenId));
+                        }
+                    }
                     return 0;
                 }
                 catch (Exception ex)

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -18,11 +18,9 @@ using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC;
 using Neo.Network.RPC.Models;
 using Neo.SmartContract;
-using Neo.SmartContract.Iterators;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Native;
 using Neo.VM;
-using Neo.VM.Types;
 using Neo.Wallets;
 using NeoExpress.Models;
 using NeoExpress.Utility;
@@ -452,34 +450,6 @@ namespace NeoExpress
             }
 
             throw new Exception("invalid script results");
-        }
-
-        public static async Task<List<string>> GetNFTAsync(this IExpressNode expressNode, UInt160 accountHash, UInt160 assetHash)
-        {
-            using var sb = new ScriptBuilder();
-            sb.EmitDynamicCall(assetHash, "tokensOf", accountHash);
-
-            var result = await expressNode.InvokeAsync(sb.ToArray()).ConfigureAwait(false);
-            var stack = result.Stack;
-            var list = new List<string>();
-            try
-            {
-                if (result.State != VMState.FAULT
-                        && result.Stack.Length >= 1
-                        && result.Stack[0] is InteropInterface interop
-                        && interop.GetInterface<object>() is IIterator iterator)
-                {
-                    while (iterator.Next())
-                    {
-                        list.Add(Convert.ToBase64String(iterator.Value().GetSpan()));
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                throw new Exception("invalid script results");
-            }
-            return list;
         }
 
         public static async Task<Block> GetBlockAsync(this IExpressNode expressNode, string blockHash)

--- a/src/neoxp/Extensions/SmartContractExtensions.cs
+++ b/src/neoxp/Extensions/SmartContractExtensions.cs
@@ -116,7 +116,7 @@ namespace NeoExpress
                         ? (ByteString)value
                         : (ByteString)(value.ConvertTo(StackItemType.ByteString));
 
-                    yield return (ReadOnlyMemory<byte>)byteString;
+                    yield return byteString.GetSpan().ToArray();
                 }
             }
         }
@@ -124,7 +124,7 @@ namespace NeoExpress
         public static BigInteger GetDivisibleNep11Balance(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, UInt160 address, ProtocolSettings settings)
         {
             using var builder = new ScriptBuilder();
-            builder.EmitDynamicCall(asset, "balanceOf", address.ToArray(), (ByteString)tokenId);
+            builder.EmitDynamicCall(asset, "balanceOf", address.ToArray(), tokenId.ToArray());
             return TryGetBalance(snapshot, builder, settings, out var balance)
                 ? balance
                 : BigInteger.Zero;
@@ -152,7 +152,7 @@ namespace NeoExpress
         public static bool TryGetIndivisibleNep11Owner(this DataCache snapshot, UInt160 asset, ReadOnlyMemory<byte> tokenId, ProtocolSettings settings, out UInt160 owner)
         {
             using var builder = new ScriptBuilder();
-            builder.EmitDynamicCall(asset, "ownerOf", (ByteString)tokenId);
+            builder.EmitDynamicCall(asset, "ownerOf", tokenId.ToArray());
 
             using var engine = builder.Invoke(settings, snapshot);
             if (engine.State != VMState.FAULT

--- a/src/neoxp/IExpressNode.cs
+++ b/src/neoxp/IExpressNode.cs
@@ -45,6 +45,7 @@ namespace NeoExpress
 
         Task<IReadOnlyList<(TokenContract contract, BigInteger balance)>> ListBalancesAsync(UInt160 address);
         Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync();
+        Task<IReadOnlyList<string>> ListNftTokenIdsAsync(UInt160 address, UInt160 assetHash);
         Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync();
         Task<IReadOnlyList<(string key, string value)>> ListStoragesAsync(UInt160 scriptHash);
         Task<IReadOnlyList<TokenContract>> ListTokenContractsAsync();

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -384,6 +384,17 @@ namespace NeoExpress.Node
         public Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync()
             => MakeAsync(ListContracts);
 
+        IReadOnlyList<string> ListNftTokenIds(UInt160 address, UInt160 assetHash)
+        {
+            using var snapshot = neoSystem.GetSnapshotCache();
+            return snapshot.GetNep11Tokens(assetHash, address, ProtocolSettings)
+                .Select(tokenId => Convert.ToBase64String(tokenId.Span))
+                .ToList();
+        }
+
+        public Task<IReadOnlyList<string>> ListNftTokenIdsAsync(UInt160 address, UInt160 assetHash)
+            => MakeAsync(() => ListNftTokenIds(address, assetHash));
+
         IReadOnlyList<(ulong requestId, OracleRequest request)> ListOracleRequests()
             => NativeContract.Oracle.GetRequests(neoSystem.StoreView).ToList();
 

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -210,6 +210,29 @@ namespace NeoExpress.Node
             return Array.Empty<TokenContract>();
         }
 
+        public async Task<IReadOnlyList<string>> ListNftTokenIdsAsync(UInt160 address, UInt160 assetHash)
+        {
+            var json = await rpcClient.RpcSendAsync("getnep11balances", address.ToAddress(ProtocolSettings.AddressVersion))
+                .ConfigureAwait(false);
+
+            return ParseNftTokenIds(json, assetHash);
+        }
+
+        internal static IReadOnlyList<string> ParseNftTokenIds(JToken? json, UInt160 assetHash)
+        {
+            if (json is JObject obj && obj["balance"] is JArray balances)
+            {
+                return balances
+                    .OfType<JObject>()
+                    .Where(balance => UInt160.Parse(balance["assethash"]!.AsString()) == assetHash)
+                    .SelectMany(balance => ((JArray?)balance["tokens"])?.OfType<JObject>() ?? Enumerable.Empty<JObject>())
+                    .Select(token => Convert.ToBase64String(token["tokenid"]!.AsString().HexToBytes()))
+                    .ToList();
+            }
+
+            return Array.Empty<string>();
+        }
+
         public async Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync()
         {
             var json = await rpcClient.RpcSendAsync("expresslistoraclerequests").ConfigureAwait(false);

--- a/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
+++ b/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
@@ -220,6 +220,9 @@ public class ExpressNodeExtensionsTests
         public Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync() =>
             Task.FromResult<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>>(Contracts);
 
+        public Task<IReadOnlyList<string>> ListNftTokenIdsAsync(UInt160 address, UInt160 assetHash) =>
+            Task.FromResult<IReadOnlyList<string>>(SysArray.Empty<string>());
+
         public Task<IReadOnlyList<(ulong requestId, OracleRequest request)>> ListOracleRequestsAsync() =>
             Task.FromResult<IReadOnlyList<(ulong requestId, OracleRequest request)>>(SysArray.Empty<(ulong requestId, OracleRequest request)>());
 

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -74,4 +74,32 @@ public class OnlineNodeTests
         payload["storage"]![0]!["key"]!.AsString().Should().Be("AQ==");
         payload["storage"]![0]!["value"]!.AsString().Should().Be("Ag==");
     }
+
+    [Fact]
+    public void ParseNftTokenIds_filters_by_asset_hash_and_returns_base64_token_ids()
+    {
+        var assetHash = UInt160.Parse("0xe94c5a1f5018fc34eabe84335f9690bd552780ba");
+        var otherAssetHash = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+        var tokens = new JArray
+        {
+            new JObject { ["tokenid"] = "31" },
+            new JObject { ["tokenid"] = "0a0b" },
+        };
+        var otherTokens = new JArray
+        {
+            new JObject { ["tokenid"] = "ff" },
+        };
+        var balances = new JArray
+        {
+            new JObject { ["assethash"] = otherAssetHash.ToString(), ["tokens"] = otherTokens },
+            new JObject { ["assethash"] = assetHash.ToString(), ["tokens"] = tokens },
+        };
+        var json = new JObject { ["balance"] = balances };
+
+        var result = OnlineNode.ParseNftTokenIds(json, assetHash);
+
+        result.Should().Equal(
+            Convert.ToBase64String(new byte[] { 0x31 }),
+            Convert.ToBase64String(new byte[] { 0x0a, 0x0b }));
+    }
 }


### PR DESCRIPTION
## Summary
- list NEP-11 token IDs through node-specific APIs instead of generic script invocation
- materialize NEP-11 token IDs as byte arrays before ownerOf/balanceOf calls
- add online token ID parsing coverage

## Validation
- dotnet build src/neoxp/neoxp.csproj --no-restore
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --no-restore --filter "OnlineNodeTests|ShowNftCommandTests|ExpressNodeExtensionsTests"
- verified `show nft SampleLootNFT alice` offline and against a running node
- verified `getnep11balances` returns the SampleLootNFT token via RPC