### PR TITLE
Fix clean shutdown race

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -363,25 +363,33 @@ namespace NeoExpress
                     if (enableTrace)
                     { Neo.SmartContract.ApplicationEngine.Provider = new ExpressApplicationEngineProvider(); }
 
-                    using var persistencePlugin = new ExpressPersistencePlugin();
-                    using var logPlugin = new ExpressLogPlugin(console);
-                    using var dbftPlugin = new DBFTPlugin(GetConsensusSettings(chain));
-                    using var rpcServerPlugin = new ExpressRpcServerPlugin(GetRpcServerSettings(chain, node),
-                        expressStorage, multiSigAccount.ScriptHash);
-                    using var neoSystem = new Neo.NeoSystem(ProtocolSettings, storeProvider.Name);
-
-                    neoSystem.StartNode(new Neo.Network.P2P.ChannelsConfig
+                    var persistencePlugin = new ExpressPersistencePlugin();
+                    try
                     {
-                        Tcp = new IPEndPoint(IPAddress.Loopback, node.TcpPort)
-                    });
-                    dbftPlugin.Start(wallet);
+                        using var logPlugin = new ExpressLogPlugin(console);
+                        using var dbftPlugin = new DBFTPlugin(GetConsensusSettings(chain));
+                        using var rpcServerPlugin = new ExpressRpcServerPlugin(GetRpcServerSettings(chain, node),
+                            expressStorage, multiSigAccount.ScriptHash);
+                        using var neoSystem = new Neo.NeoSystem(ProtocolSettings, storeProvider.Name);
 
-                    // DevTracker looks for a string that starts with "Neo express is running" to confirm that the instance has started
-                    // Do not remove or re-word this console output:
-                    console.Out.WriteLine($"Neo express is running ({expressStorage.Name})");
+                        neoSystem.StartNode(new Neo.Network.P2P.ChannelsConfig
+                        {
+                            Tcp = new IPEndPoint(IPAddress.Loopback, node.TcpPort)
+                        });
+                        dbftPlugin.Start(wallet);
 
-                    var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(token, rpcServerPlugin.CancellationToken);
-                    linkedToken.Token.WaitHandle.WaitOne();
+                        // DevTracker looks for a string that starts with "Neo express is running" to confirm that the instance has started
+                        // Do not remove or re-word this console output:
+                        console.Out.WriteLine($"Neo express is running ({expressStorage.Name})");
+
+                        var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(token, rpcServerPlugin.CancellationToken);
+                        linkedToken.Token.WaitHandle.WaitOne();
+                    }
+                    finally
+                    {
+                        persistencePlugin.Dispose();
+                        persistencePlugin.RemoveFromPluginList();
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/neoxp/Node/Modules/ExpressLogPlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressLogPlugin.cs
@@ -26,6 +26,7 @@ namespace NeoExpress.Node
         readonly List<WeakReference<ApplicationEngine>> engineRefs = new();
         NeoSystem? neoSystem;
         readonly IConsole console;
+        bool disposedValue;
 
         public ExpressLogPlugin(IConsole console)
         {
@@ -40,16 +41,19 @@ namespace NeoExpress.Node
         {
             Neo.Utility.Logging -= OnNeoUtilityLog;
             ApplicationEngine.InstanceHandler -= OnApplicationEngineCreated;
+            List<WeakReference<ApplicationEngine>> refs;
             lock (engineLock)
             {
-                foreach (var engineRef in engineRefs)
-                {
-                    if (engineRef.TryGetTarget(out var engine))
-                    {
-                        engine.Log -= OnAppEngineLog;
-                    }
-                }
+                disposedValue = true;
+                refs = engineRefs.ToList();
                 engineRefs.Clear();
+            }
+            foreach (var engineRef in refs)
+            {
+                if (engineRef.TryGetTarget(out var engine))
+                {
+                    engine.Log -= OnAppEngineLog;
+                }
             }
             Blockchain.Committing -= OnCommitting;
         }
@@ -58,9 +62,12 @@ namespace NeoExpress.Node
         {
             lock (engineLock)
             {
+                if (disposedValue)
+                    return;
+
                 engineRefs.Add(new WeakReference<ApplicationEngine>(engine));
+                engine.Log += OnAppEngineLog;
             }
-            engine.Log += OnAppEngineLog;
         }
 
         protected override void OnSystemLoaded(NeoSystem system)

--- a/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
+++ b/src/neoxp/Node/Modules/ExpressPersistencePlugin.cs
@@ -32,6 +32,7 @@ namespace NeoExpress.Node
         IStore? notificationsStore;
         IStoreSnapshot? appLogsSnapshot;
         IStoreSnapshot? notificationsSnapshot;
+        bool disposedValue;
 
         public ExpressPersistencePlugin()
         {
@@ -41,14 +42,24 @@ namespace NeoExpress.Node
 
         public override void Dispose()
         {
+            if (disposedValue)
+                return;
+
+            disposedValue = true;
             Blockchain.Committing -= OnCommitting;
             Blockchain.Committed -= OnCommitted;
             appLogsSnapshot?.Dispose();
             appLogsStore?.Dispose();
             notificationsSnapshot?.Dispose();
             notificationsStore?.Dispose();
-            // the Plugin constructor adds this instance to the global plugin list; remove it
-            // so a NeoSystem created later does not call into this disposed instance
+        }
+
+        internal void RemoveFromPluginList()
+        {
+            // The Plugin constructor adds this instance to the global plugin list. Remove it
+            // after NeoSystem.Dispose finishes so a later NeoSystem does not load this
+            // disposed instance, without mutating the plugin list while NeoSystem is
+            // enumerating it during shutdown.
             _ = Plugins.Remove(this);
         }
 

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -80,25 +80,28 @@ namespace NeoExpress.Node
             if (!disposedValue)
             {
                 ApplicationEngine.InstanceHandler -= OnApplicationEngineCreated;
+                List<WeakReference<ApplicationEngine>> refs;
                 lock (engineLock)
                 {
-                    foreach (var engineRef in engineRefs)
-                    {
-                        if (engineRef.TryGetTarget(out var engine))
-                        {
-                            engine.Log -= OnLog;
-                        }
-                    }
+                    disposedValue = true;
+                    refs = engineRefs.ToList();
                     engineRefs.Clear();
+                }
+                foreach (var engineRef in refs)
+                {
+                    if (engineRef.TryGetTarget(out var engine))
+                    {
+                        engine.Log -= OnLog;
+                    }
                 }
                 persistencePlugin.Dispose();
                 neoSystem.Dispose();
+                persistencePlugin.RemoveFromPluginList();
                 if (engineProviderSet)
                 {
                     ApplicationEngine.Provider = priorEngineProvider;
                 }
                 expressStorage.Dispose();
-                disposedValue = true;
             }
         }
 
@@ -106,9 +109,12 @@ namespace NeoExpress.Node
         {
             lock (engineLock)
             {
+                if (disposedValue)
+                    return;
+
                 engineRefs.Add(new WeakReference<ApplicationEngine>(engine));
+                engine.Log += OnLog;
             }
-            engine.Log += OnLog;
         }
 
         private void OnLog(ApplicationEngine engine, LogEventArgs args)

--- a/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
+++ b/test/test.workflowvalidation/NeoxpAdvancedIntegrationTests.cs
@@ -271,18 +271,13 @@ public class NeoxpAdvancedIntegrationTests : IDisposable
             await _runCommand.RunNeoxpCommand("transfer", "10000", "gas", "genesis", "bob");
 
             // Equivalent to: neoxp stop --all
-            await _runCommand.RunNeoxpCommand("stop", "--all");
-            // Note: Stop command may fail if no blockchain is running, which is expected
+            var (stopExitCode, _, stopError) = await _runCommand.RunNeoxpCommand("stop", "--all");
+            stopExitCode.Should().Be(0, stopError);
 
             // Wait for the run task to complete
-            try
-            {
-                await runTask;
-            }
-            catch (TimeoutException)
-            {
-                _output.WriteLine("Run command timed out as expected");
-            }
+            var (runExitCode, _, runError) = await runTask;
+            runExitCode.Should().Be(0, runError);
+            runError.Should().NotContain("Collection was modified");
 
             _output.WriteLine("✅ neoxp run command with timeout test completed");
         }


### PR DESCRIPTION
## Summary
- avoid mutating the global plugin list while NeoSystem is disposing plugins
- make ExpressPersistencePlugin disposal idempotent and remove it after NeoSystem shutdown
- guard application engine log subscriptions during shutdown
- assert run/stop exits cleanly without the collection-modified shutdown error

## Validation
- `dotnet build src/neoxp/neoxp.csproj --no-restore`
- `dotnet build src/neoxp/neoxp.csproj --configuration Release --no-restore -v:minimal`
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --no-restore --filter "OfflineNodeDisposeTests|StopCommandTests"`
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --no-restore --filter "FullyQualifiedName~NeoxpAdvancedIntegrationTests.Test03_RunCommandWithTimeout"`
- verified `neoxp run` exits cleanly after `neoxp stop --all`