### PR TITLE
Fix test runner without checkpoint

### DIFF
--- a/src/bctklib/persistence/NullCheckpointStore.cs
+++ b/src/bctklib/persistence/NullCheckpointStore.cs
@@ -11,16 +11,17 @@
 using Neo.BlockchainToolkit.Models;
 using Neo.Persistence;
 using Neo.SmartContract;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Neo.BlockchainToolkit.Persistence
 {
-    public class NullCheckpointStore : ICheckpointStore
+    public class NullCheckpointStore : ICheckpointStore, IReadOnlyStore<byte[], byte[]>
     {
         public ProtocolSettings Settings { get; }
 
         public NullCheckpointStore(ExpressChain? chain)
-            : this(chain?.Network, chain?.AddressVersion)
         {
+            Settings = chain.GetProtocolSettings();
         }
 
         public NullCheckpointStore(uint? network = null, byte? addressVersion = null)
@@ -32,10 +33,17 @@ namespace Neo.BlockchainToolkit.Persistence
             };
         }
 
-        public IEnumerable<(byte[] Key, byte[]? Value)> Seek(byte[] key, SeekDirection direction)
-            => Enumerable.Empty<(byte[], byte[]?)>();
+        public IEnumerable<(byte[] Key, byte[] Value)> Seek(byte[] key, SeekDirection direction)
+            => Enumerable.Empty<(byte[], byte[])>();
         public byte[]? TryGet(byte[] key) => null;
+        public bool TryGet(byte[] key, [NotNullWhen(true)] out byte[]? value)
+        {
+            value = null;
+            return false;
+        }
         public bool Contains(byte[] key) => false;
+        public IEnumerable<(byte[] Key, byte[] Value)> Find(byte[]? key_prefix = null, SeekDirection direction = SeekDirection.Forward)
+            => Enumerable.Empty<(byte[], byte[])>();
 
         // IReadOnlyStore<StorageKey, StorageItem> implementation
         public StorageItem this[StorageKey key]
@@ -46,7 +54,7 @@ namespace Neo.BlockchainToolkit.Persistence
         [Obsolete("use TryGet(StorageKey key, out StorageItem? value) instead.")]
         public StorageItem? TryGet(StorageKey key) => null;
 
-        public bool TryGet(StorageKey key, out StorageItem? value)
+        public bool TryGet(StorageKey key, [NotNullWhen(true)] out StorageItem? value)
         {
             value = null;
             return false;

--- a/test/test.bctklib/EnsureLedgerInitializedTests.cs
+++ b/test/test.bctklib/EnsureLedgerInitializedTests.cs
@@ -8,11 +8,17 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo;
 using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.Persistence;
 using Neo.BlockchainToolkit.SmartContract;
+using Neo.Extensions;
 using Neo.Persistence;
 using Neo.Persistence.Providers;
 using Neo.SmartContract.Native;
+using Neo.Wallets;
+using System;
 using Xunit;
 
 namespace test.bctklib
@@ -44,6 +50,55 @@ namespace test.bctklib
 
             using var snapshot = new StoreCache(store.GetSnapshot());
             Assert.Equal(0u, NativeContract.Ledger.CurrentIndex(snapshot));
+        }
+
+        [Fact]
+        public void null_checkpoint_store_can_seed_memory_tracking_store()
+        {
+            var chain = CreateExpressChain();
+            ICheckpointStore checkpoint = new NullCheckpointStore(chain);
+            var readOnlyStore = Assert.IsAssignableFrom<IReadOnlyStore<byte[], byte[]>>(checkpoint);
+            using var store = new MemoryTrackingStore(readOnlyStore);
+
+            Assert.Equal(chain.Network, checkpoint.Settings.Network);
+            Assert.Equal(chain.AddressVersion, checkpoint.Settings.AddressVersion);
+            Assert.Equal(chain.ConsensusNodes.Count, checkpoint.Settings.ValidatorsCount);
+            Assert.Equal(chain.GetProtocolSettings().StandbyCommittee, checkpoint.Settings.StandbyCommittee);
+
+            store.EnsureLedgerInitialized(checkpoint.Settings);
+
+            using var snapshot = new StoreCache(store.GetSnapshot());
+            Assert.Equal(0u, NativeContract.Ledger.CurrentIndex(snapshot));
+        }
+
+        private static ExpressChain CreateExpressChain()
+        {
+            var key = new KeyPair(Convert.FromHexString("2A79CFA210832EB7139C36168E415DC78E2649EA7735060BF1DAE04C05050A98"));
+            return new ExpressChain
+            {
+                Network = 0x334F454Eu,
+                AddressVersion = ProtocolSettings.Default.AddressVersion,
+                ConsensusNodes =
+                [
+                    new ExpressConsensusNode
+                    {
+                        TcpPort = 50013,
+                        RpcPort = 50012,
+                        Wallet = new ExpressWallet
+                        {
+                            Name = "node1",
+                            Accounts =
+                            [
+                                new ExpressWalletAccount
+                                {
+                                    PrivateKey = key.PrivateKey.ToHexString(),
+                                    IsDefault = true,
+                                },
+                            ],
+                        },
+                    },
+                ],
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- Let `NullCheckpointStore` expose the byte-addressed read-only store interface used by `MemoryTrackingStore`.
- Derive no-checkpoint protocol settings from the loaded express chain so genesis initialization has validators and committee data.
- Add regression coverage for no-checkpoint ledger initialization.

## Validation
- `dotnet test test/test.bctklib/test.bctklib.csproj --no-restore --filter "FullyQualifiedName~ReadOnlyStoreTests|FullyQualifiedName~EnsureLedgerInitializedTests"`
- `dotnet test test/test-runner/test-runner.csproj`
- `dotnet build src/runner/runner.csproj --no-restore -v:minimal`
- `dotnet run --no-build --project src/runner/runner.csproj -- /tmp/neo-express-v310-real-validation/gas-symbol.neo-invoke.json --express /tmp/neo-express-v310-real-validation/full.neo-express`
- `dotnet run --no-build --project src/runner/runner.csproj -- /tmp/neo-express-v310-real-validation/gas-symbol.neo-invoke.json --express /tmp/neo-express-v310-real-validation/full.neo-express --checkpoint /tmp/neo-express-v310-real-validation/full-checkpoint.neoxp-checkpoint`