### PR TITLE
Fix Visual Tracker create output argument

### DIFF
--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
@@ -30,10 +30,10 @@
 
   <Target Name="ExecuteCreateNeoExpressInstance" Condition="!Exists($(NeoExpressBatchInputFile))"
           AfterTargets="Build" BeforeTargets="ExecuteNeoExpressBatch">
-    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp create" />
-    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp wallet create owner" />
-    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp wallet create alice" />
-    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp wallet create bob" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp create -o &quot;$(NeoExpressBatchInputFile)&quot;" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp wallet create -i &quot;$(NeoExpressBatchInputFile)&quot; owner" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp wallet create -i &quot;$(NeoExpressBatchInputFile)&quot; alice" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="neoxp wallet create -i &quot;$(NeoExpressBatchInputFile)&quot; bob" />
   </Target>
 
 </Project>

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
@@ -100,6 +100,7 @@ export default class NeoExpressCommands {
       "-f",
       "-c",
       nodeCount,
+      "-o",
       configSavePath
     );
     NeoExpressCommands.showResult(output);

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCreateCommand.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCreateCommand.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const packageRoot = join(__dirname, "../../..");
+
+test("Visual Tracker create commands pass Neo Express output explicitly", () => {
+  const neoExpressCommands = readFileSync(
+    join(__dirname, "neoExpressCommands.ts"),
+    "utf8"
+  );
+  assert.match(
+    neoExpressCommands,
+    /"create",\s+"-f",\s+"-c",\s+nodeCount,\s+"-o",\s+configSavePath/s
+  );
+
+  const languages = readFileSync(
+    join(__dirname, "../templates/languages.ts"),
+    "utf8"
+  );
+  assert.match(
+    languages,
+    /\["create",\s+"-f",\s+"-o",\s+"test\/\$_CONTRACTNAME_\$Tests\.neo-express"\]/
+  );
+
+  const csharpTemplate = readFileSync(
+    join(
+      packageRoot,
+      "resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt"
+    ),
+    "utf8"
+  );
+  assert.match(csharpTemplate, /neoxp create -o &quot;\$\(NeoExpressBatchInputFile\)&quot;/);
+  assert.match(csharpTemplate, /neoxp wallet create -i &quot;\$\(NeoExpressBatchInputFile\)&quot; owner/);
+});

--- a/extentions/neo3-visual-tracker/src/extension/templates/languages.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/languages.ts
@@ -160,7 +160,7 @@ const languages: { [code: string]: Language } = {
         group: "set-private-chain",
         type: "shell",
         command: "neoxp",
-        args: ["create", "-f", "test/$_CONTRACTNAME_$Tests.neo-express"],
+        args: ["create", "-f", "-o", "test/$_CONTRACTNAME_$Tests.neo-express"],
         problemMatcher: [],
       },
       {


### PR DESCRIPTION
## Summary
- pass `-o` when Visual Tracker creates a Neo Express instance
- update generated contract tasks/templates to create and update wallets against the intended `.neo-express` file
- add a regression test for the create command arguments

## Validation
- `npm test`
- `npm run compile`

This was found while validating the Visual Tracker Quick Start flow with Neo Express 3.10.0: the old positional output path is rejected by `neoxp create`, which now requires `-o|--output`.
