### PR TITLE
Hide unsupported Visual Tracker checkpoint action

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts
@@ -98,6 +98,26 @@ export default class BlockchainIdentifier {
     }
   }
 
+  async isSingleNodeExpress(): Promise<boolean> {
+    if (this.blockchainType !== "express" || !this.configPath) {
+      return false;
+    }
+    try {
+      const neoExpressConfig = JSONC.parse(
+        (await fs.promises.readFile(this.configPath)).toString()
+      );
+      return neoExpressConfig["consensus-nodes"]?.length === 1;
+    } catch (e : any) {
+      Log.log(
+        LOG_PREFIX,
+        "Error parsing neo-express node count",
+        this.configPath,
+        e.message
+      );
+      return false;
+    }
+  }
+
   async getWalletAddresses(): Promise<{ [walletName: string]: string }> {
     if (this.blockchainType !== "express") {
       return {};

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
@@ -137,6 +137,12 @@ export default class NeoExpressCommands {
     if (!identifier) {
       return;
     }
+    if (!(await identifier.isSingleNodeExpress())) {
+      vscode.window.showErrorMessage(
+        "Checkpoints can only be created for single-node Neo Express instances."
+      );
+      return;
+    }
     const rootFolder = workspaceFolder();
     if (!rootFolder) {
       vscode.window.showErrorMessage(

--- a/extentions/neo3-visual-tracker/src/extension/panelControllers/quickStartPanelController.ts
+++ b/extentions/neo3-visual-tracker/src/extension/panelControllers/quickStartPanelController.ts
@@ -36,6 +36,7 @@ export default class QuickStartPanelController extends PanelControllerBase<
         hasNeoExpressInstance: false,
         hasWallets: false,
         hasCheckpoints: false,
+        hasCheckpointCompatibleNeoExpressInstance: false,
         neoDeploymentRequired: false,
         neoExpressDeploymentRequired: false,
         neoExpressIsRunning: false,
@@ -85,10 +86,15 @@ export default class QuickStartPanelController extends PanelControllerBase<
       Object.values(this.contractDetector.contracts).filter((_) => _.deployed)
         .length > 0;
 
-    const hasNeoExpressInstance =
-      this.blockchainsTreeDataProvider
-        .getChildren()
-        .filter((_) => _.blockchainType === "express").length > 0;
+    const neoExpressInstances = this.blockchainsTreeDataProvider
+      .getChildren()
+      .filter((_) => _.blockchainType === "express");
+
+    const hasNeoExpressInstance = neoExpressInstances.length > 0;
+
+    const hasCheckpointCompatibleNeoExpressInstance = (
+      await Promise.all(neoExpressInstances.map((_) => _.isSingleNodeExpress()))
+    ).some(Boolean);
 
     const hasWallets = this.walletDetector.wallets.length > 0;
 
@@ -108,6 +114,7 @@ export default class QuickStartPanelController extends PanelControllerBase<
       hasNeoExpressInstance,
       hasWallets,
       hasCheckpoints,
+      hasCheckpointCompatibleNeoExpressInstance,
       neoDeploymentRequired,
       neoExpressDeploymentRequired,
       neoExpressIsRunning,

--- a/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.test.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.test.ts
@@ -13,6 +13,7 @@ const baseState: QuickStartViewState = {
   hasNeoExpressInstance: false,
   hasWallets: false,
   hasCheckpoints: false,
+  hasCheckpointCompatibleNeoExpressInstance: false,
   neoDeploymentRequired: false,
   neoExpressDeploymentRequired: false,
   neoExpressIsRunning: false,
@@ -41,10 +42,21 @@ test("offers transfer when Express and wallets are available", () => {
   assert(actions.includes("transfer"));
 });
 
-test("offers checkpoint actions when Express is present", () => {
+test("does not offer checkpoint actions when no single-node Express instance is present", () => {
   const actions = getQuickStartActions({
     ...baseState,
     hasNeoExpressInstance: true,
+    hasCheckpoints: true,
+  });
+  assert(!actions.includes("createCheckpoint"));
+  assert(!actions.includes("restoreCheckpoint"));
+});
+
+test("offers checkpoint actions when a single-node Express instance is present", () => {
+  const actions = getQuickStartActions({
+    ...baseState,
+    hasNeoExpressInstance: true,
+    hasCheckpointCompatibleNeoExpressInstance: true,
     hasCheckpoints: true,
   });
   assert(actions.includes("createCheckpoint"));

--- a/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.ts
@@ -53,7 +53,7 @@ export function getQuickStartActions(
       actions.push("transfer");
     }
 
-    if (viewState.hasNeoExpressInstance) {
+    if (viewState.hasCheckpointCompatibleNeoExpressInstance) {
       actions.push("createCheckpoint");
       if (viewState.hasCheckpoints) {
         actions.push("restoreCheckpoint");

--- a/extentions/neo3-visual-tracker/src/shared/viewState/quickStartViewState.ts
+++ b/extentions/neo3-visual-tracker/src/shared/viewState/quickStartViewState.ts
@@ -7,6 +7,7 @@ type QuickStartViewState = {
   hasNeoExpressInstance: boolean;
   hasWallets: boolean;
   hasCheckpoints: boolean;
+  hasCheckpointCompatibleNeoExpressInstance: boolean;
   neoDeploymentRequired: boolean;
   neoExpressDeploymentRequired: boolean;
   neoExpressIsRunning: boolean;


### PR DESCRIPTION
## Summary
- hide Quick Start checkpoint actions unless a single-node Neo Express instance is available
- guard the checkpoint command itself so context-menu use gives a clear message instead of surfacing a raw exception
- update Quick Start action tests for the unsupported multi-node case

## Validation
- `npm test`
- `npm run compile`

This was found while validating the Visual Tracker flow with a 4-node Neo Express 3.10.0 instance. `neoxp checkpoint create` only supports single-node instances, so the extension should not offer that action for multi-node private chains.
