### PR TITLE
Fix Visual Tracker checkpoint restore while running

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCheckpointCommand.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCheckpointCommand.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+test("Visual Tracker stops a running Neo Express instance before offline checkpoint operations", () => {
+  const neoExpressCommands = readFileSync(
+    join(__dirname, "neoExpressCommands.ts"),
+    "utf8"
+  );
+  assert.match(
+    neoExpressCommands,
+    /const wasRunning = neoExpressInstanceManager\.isRunning\(blockchainIdentifier\);\s+await neoExpressInstanceManager\.stopAll\(blockchainIdentifier\);/s
+  );
+  assert.match(
+    neoExpressCommands,
+    /const wasRunning = neoExpressInstanceManager\.isRunning\(identifier\);\s+await neoExpressInstanceManager\.stopAll\(identifier\);/s
+  );
+
+  const neoExpressInstanceManager = readFileSync(
+    join(__dirname, "../neoExpress/neoExpressInstanceManager.ts"),
+    "utf8"
+  );
+  assert.match(
+    neoExpressInstanceManager,
+    /"stop",\s+"--all",\s+"-i",\s+target\.configPath/s
+  );
+});

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
@@ -230,12 +230,8 @@ export default class NeoExpressCommands {
     if (!confirmed) {
       return;
     }
-    const wasRunning =
-      neoExpressInstanceManager.runningInstance?.configPath ===
-      blockchainIdentifier.configPath;
-    if (wasRunning) {
-      await neoExpressInstanceManager.stopAll();
-    }
+    const wasRunning = neoExpressInstanceManager.isRunning(blockchainIdentifier);
+    await neoExpressInstanceManager.stopAll(blockchainIdentifier);
     try {
       const output = await neoExpress.run(
         "reset",
@@ -255,6 +251,7 @@ export default class NeoExpressCommands {
 
   static async restoreCheckpoint(
     neoExpress: NeoExpress,
+    neoExpressInstanceManager: NeoExpressInstanceManager,
     blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
     checkpointDetector: CheckpointDetector,
     commandArguments?: CommandArguments
@@ -278,15 +275,25 @@ export default class NeoExpressCommands {
     if (!confirmed) {
       return;
     }
-    const output = await neoExpress.run(
-      "checkpoint",
-      "restore",
-      "-f",
-      "-i",
-      identifier.configPath,
-      filename
-    );
-    NeoExpressCommands.showResult(output);
+    const wasRunning = neoExpressInstanceManager.isRunning(identifier);
+    await neoExpressInstanceManager.stopAll(identifier);
+    try {
+      const output = await neoExpress.run(
+        "checkpoint",
+        "restore",
+        "-f",
+        "-i",
+        identifier.configPath,
+        filename
+      );
+      NeoExpressCommands.showResult(output);
+    } finally {
+      if (wasRunning) {
+        await neoExpressInstanceManager.run(blockchainsTreeDataProvider, {
+          blockchainIdentifier: identifier,
+        });
+      }
+    }
   }
 
   static async transfer(

--- a/extentions/neo3-visual-tracker/src/extension/index.ts
+++ b/extentions/neo3-visual-tracker/src/extension/index.ts
@@ -251,6 +251,7 @@ export async function activate(context: vscode.ExtensionContext) {
     (commandArguments) =>
       NeoExpressCommands.restoreCheckpoint(
         neoExpress,
+        neoExpressInstanceManager,
         blockchainsTreeDataProvider,
         checkpointDetector,
         commandArguments

--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpress.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpress.ts
@@ -14,6 +14,7 @@ type Command =
   | "reset"
   | "run"
   | "show"
+  | "stop"
   | "transfer"
   | "wallet"
   | "-v";

--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressInstanceManager.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressInstanceManager.ts
@@ -19,6 +19,14 @@ export default class NeoExpressInstanceManager {
     return this.running;
   }
 
+  isRunning(identifier: BlockchainIdentifier) {
+    return (
+      this.running?.configPath === identifier.configPath ||
+      this.activeConnection.connection?.blockchainIdentifier.configPath ===
+        identifier.configPath
+    );
+  }
+
   private readonly onChangeEmitter: vscode.EventEmitter<void>;
 
   private disposed: boolean;
@@ -141,7 +149,25 @@ export default class NeoExpressInstanceManager {
     }
   }
 
-  async stopAll() {
+  async stopAll(identifier?: BlockchainIdentifier) {
+    const target = identifier || this.running;
+    if (target?.blockchainType === "express") {
+      const output = await this.neoExpress.run(
+        "stop",
+        "--all",
+        "-i",
+        target.configPath
+      );
+      if (output.isError) {
+        Log.warn(
+          LOG_PREFIX,
+          "Could not stop",
+          target.name,
+          output.message.trim()
+        );
+      }
+    }
+
     try {
       for (const terminal of this.terminals) {
         if (!terminal.exitStatus) {


### PR DESCRIPTION
## Summary
- stop the selected Neo Express instance before Visual Tracker reset and checkpoint restore operations
- restart the instance after restore/reset when it was running before the operation
- add a regression check for the offline checkpoint flow

## Validation
- npm test
- npm run compile
- npm run typecheck
- manually verified in VS Code with the packaged Visual Tracker extension: create a single-node Neo Express instance, create a checkpoint, fast-forward 3 blocks, restore the checkpoint while the node is running, and confirm the RPC block count returns from 4 to 1 with Neo Express restarted

Targets v3.10.0 validation.