### PR TITLE
Improve NeoTrace public chain state loading

### DIFF
--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -152,12 +152,17 @@ namespace Neo.BlockchainToolkit.Persistence
         internal static async Task<UInt256> ParseBlockHashAsync(RpcClient rpcClient, uint index)
             => UInt256.Parse(await rpcClient.GetBlockHashAsync(index).ConfigureAwait(false));
 
-        public static async Task<BranchInfo> GetBranchInfoAsync(RpcClient rpcClient, uint index)
+        public static Task<BranchInfo> GetBranchInfoAsync(RpcClient rpcClient, uint index)
+            => GetBranchInfoAsync(rpcClient, index, includeContractNames: true);
+
+        public static async Task<BranchInfo> GetBranchInfoAsync(RpcClient rpcClient, uint index, bool includeContractNames)
         {
             var versionTask = rpcClient.GetVersionAsync();
             var blockHashTask = ParseBlockHashAsync(rpcClient, index);
             var stateRoot = await rpcClient.GetStateRootAsync(index).ConfigureAwait(false);
-            var contractsTask = GetContractsAsync(rpcClient, stateRoot.RootHash);
+            var contractsTask = includeContractNames
+                ? GetContractsAsync(rpcClient, stateRoot.RootHash)
+                : GetContractHashesAsync(rpcClient, stateRoot.RootHash);
 
             await Task.WhenAll(versionTask, blockHashTask, contractsTask).ConfigureAwait(false);
 
@@ -173,44 +178,78 @@ namespace Neo.BlockchainToolkit.Persistence
                 stateRoot.RootHash,
                 contracts,
                 version.Protocol.Hardforks);
+        }
 
-            static async Task<IReadOnlyList<ContractInfo>> GetContractsAsync(RpcClient rpcClient, UInt256 rootHash)
+        internal static async Task<IReadOnlyList<ContractInfo>> GetContractHashesAsync(RpcClient rpcClient, UInt256 rootHash)
+        {
+            using var memoryOwner = MemoryPool<byte>.Shared.Rent(1);
+            memoryOwner.Memory.Span[0] = ContractMgmt_Prefix_ContractHash;
+            var prefix = memoryOwner.Memory[..1];
+
+            var contracts = NativeContract.Contracts
+                .Select(static c => new ContractInfo(c.Id, c.Hash, c.Name))
+                .ToList();
+            var contractIds = contracts.Select(static c => c.Id).ToHashSet();
+
+            var from = Array.Empty<byte>();
+            while (true)
             {
-                const byte ContractManagement_Prefix_Contract = 8;
-
-                using var memoryOwner = MemoryPool<byte>.Shared.Rent(1);
-                memoryOwner.Memory.Span[0] = ContractManagement_Prefix_Contract;
-                var prefix = memoryOwner.Memory[..1];
-
-                var contracts = new List<ContractInfo>();
-                var from = Array.Empty<byte>();
-                while (true)
+                var found = await rpcClient.FindStatesAsync(rootHash, NativeContract.ContractManagement.Hash, prefix, from.AsMemory()).ConfigureAwait(false);
+                ValidateFoundStates(rootHash, found);
+                for (var i = 0; i < found.Results.Length; i++)
                 {
-                    var found = await rpcClient.FindStatesAsync(rootHash, NativeContract.ContractManagement.Hash, prefix, from.AsMemory()).ConfigureAwait(false);
-                    ValidateFoundStates(rootHash, found);
-                    for (var i = 0; i < found.Results.Length; i++)
+                    var (key, value) = found.Results[i];
+                    if (key.Length == 5 && key.AsSpan().StartsWith(prefix.Span) && value.Length == UInt160.Length)
                     {
-                        var (key, value) = found.Results[i];
-                        if (key.AsSpan().StartsWith(prefix.Span))
+                        var id = BinaryPrimitives.ReadInt32BigEndian(key.AsSpan(1));
+                        if (contractIds.Add(id))
                         {
-                            // Temporary fix --> https://github.com/neo-project/neo/issues/2829
-                            try
-                            {
-                                var state = new StorageItem(value).GetInteroperable<ContractState>();
-                                contracts.Add(new ContractInfo(state.Id, state.Hash, state.Manifest.Name));
-                            }
-                            catch
-                            {
-
-                            }
+                            var hash = new UInt160(value);
+                            contracts.Add(new ContractInfo(id, hash, hash.ToString()));
                         }
                     }
-                    if (!found.Truncated || found.Results.Length == 0)
-                        break;
-                    from = EnsureCursorAdvanced(from, found.Results[^1].key);
                 }
-                return contracts;
+                if (!found.Truncated || found.Results.Length == 0)
+                    break;
+                from = EnsureCursorAdvanced(from, found.Results[^1].key);
             }
+            return contracts;
+        }
+
+        static async Task<IReadOnlyList<ContractInfo>> GetContractsAsync(RpcClient rpcClient, UInt256 rootHash)
+        {
+            using var memoryOwner = MemoryPool<byte>.Shared.Rent(1);
+            memoryOwner.Memory.Span[0] = ContractMgmt_Prefix_Contract;
+            var prefix = memoryOwner.Memory[..1];
+
+            var contracts = new List<ContractInfo>();
+            var from = Array.Empty<byte>();
+            while (true)
+            {
+                var found = await rpcClient.FindStatesAsync(rootHash, NativeContract.ContractManagement.Hash, prefix, from.AsMemory()).ConfigureAwait(false);
+                ValidateFoundStates(rootHash, found);
+                for (var i = 0; i < found.Results.Length; i++)
+                {
+                    var (key, value) = found.Results[i];
+                    if (key.AsSpan().StartsWith(prefix.Span))
+                    {
+                        // Temporary fix --> https://github.com/neo-project/neo/issues/2829
+                        try
+                        {
+                            var state = new StorageItem(value).GetInteroperable<ContractState>();
+                            contracts.Add(new ContractInfo(state.Id, state.Hash, state.Manifest.Name));
+                        }
+                        catch
+                        {
+
+                        }
+                    }
+                }
+                if (!found.Truncated || found.Results.Length == 0)
+                    break;
+                from = EnsureCursorAdvanced(from, found.Results[^1].key);
+            }
+            return contracts;
         }
 
         static void ValidateFoundStates(UInt256 rootHash, RpcFoundStates foundStates)

--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -79,7 +79,9 @@ namespace NeoTrace
             }
             else
             {
-                var branchInfo = await StateServiceStore.GetBranchInfoAsync(rpcClient, block.Index - 1).ConfigureAwait(false);
+                await console.Out.WriteLineAsync($"Loading state for block {block.Index - 1}").ConfigureAwait(false);
+                var branchInfo = await StateServiceStore.GetBranchInfoAsync(rpcClient, block.Index - 1, includeContractNames: false).ConfigureAwait(false);
+                await console.Out.WriteLineAsync($"Loaded {branchInfo.Contracts.Count} contracts").ConfigureAwait(false);
                 roStore = new StateServiceStore(rpcClient, branchInfo);
                 knownContracts = branchInfo.Contracts.ToDictionary(c => c.Hash, c => (c.Id, c.Name));
             }

--- a/test/test.bctklib/StateServiceStoreBranchInfoTests.cs
+++ b/test/test.bctklib/StateServiceStoreBranchInfoTests.cs
@@ -1,0 +1,116 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StateServiceStoreBranchInfoTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Persistence;
+using Neo.Extensions;
+using Neo.Json;
+using Neo.Network.RPC;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace test.bctklib;
+
+public class StateServiceStoreBranchInfoTests
+{
+    [Fact]
+    public async Task GetContractHashesAsync_reads_the_lightweight_contract_hash_index()
+    {
+        const int contractId = 42;
+        var contractHash = UInt160.Parse("0x1111111111111111111111111111111111111111");
+        var contractKey = CreateContractHashKey(contractId);
+        var contractValue = contractHash.ToArray();
+        var nativeKey = CreateContractHashKey(NativeContract.ContractManagement.Id);
+        var nativeValue = NativeContract.ContractManagement.Hash.ToArray();
+
+        using var proofStore = new MemoryStore();
+        using var snapshot = proofStore.GetSnapshot();
+        var trie = new Neo.Cryptography.MPTTrie.Trie(snapshot, null);
+        var storageKey = new StorageKey { Id = NativeContract.ContractManagement.Id, Key = contractKey }.ToArray();
+        var nativeStorageKey = new StorageKey { Id = NativeContract.ContractManagement.Id, Key = nativeKey }.ToArray();
+        trie.Put(storageKey, contractValue);
+        trie.Put(nativeStorageKey, nativeValue);
+        trie.Commit();
+        snapshot.Commit();
+
+        var proof = Convert.ToBase64String(trie.GetSerializedProof(storageKey));
+        var nativeProof = Convert.ToBase64String(trie.GetSerializedProof(nativeStorageKey));
+        var rpcClient = new RecordingRpcClient((method, _) =>
+            method == "findstates"
+                ? new JObject
+                {
+                    ["firstProof"] = proof,
+                    ["lastProof"] = nativeProof,
+                    ["truncated"] = false,
+                    ["results"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["key"] = Convert.ToBase64String(contractKey),
+                            ["value"] = Convert.ToBase64String(contractValue)
+                        },
+                        new JObject
+                        {
+                            ["key"] = Convert.ToBase64String(nativeKey),
+                            ["value"] = Convert.ToBase64String(nativeValue)
+                        }
+                    }
+                }
+                : throw new InvalidOperationException($"{method} should not be called"));
+
+        var contracts = await StateServiceStore.GetContractHashesAsync(rpcClient, trie.Root.Hash);
+
+        contracts.Should().Contain(c =>
+            c.Id == NativeContract.ContractManagement.Id
+            && c.Hash == NativeContract.ContractManagement.Hash
+            && c.Name == NativeContract.ContractManagement.Name);
+        contracts.Should().Contain(c =>
+            c.Id == contractId
+            && c.Hash == contractHash
+            && c.Name == contractHash.ToString());
+        contracts.Count(c => c.Id == NativeContract.ContractManagement.Id).Should().Be(1);
+        rpcClient.Methods.Should().ContainSingle("findstates");
+    }
+
+    static byte[] CreateContractHashKey(int contractId)
+    {
+        var key = new byte[5];
+        key[0] = 0x0C;
+        BinaryPrimitives.WriteInt32BigEndian(key.AsSpan(1), contractId);
+        return key;
+    }
+
+    sealed class RecordingRpcClient : RpcClient
+    {
+        readonly Func<string, JToken[], JToken> handler;
+
+        public RecordingRpcClient(Func<string, JToken[], JToken> handler) : base(null!)
+        {
+            this.handler = handler;
+        }
+
+        public List<string> Methods { get; } = new();
+
+        public override Task<JToken> RpcSendAsync(string method, params JToken[] paraArgs)
+        {
+            Methods.Add(method);
+            return Task.FromResult(handler(method, paraArgs));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight branch-info path that loads contract id/hash mappings from the ContractManagement hash index
- use the lightweight path for NeoTrace public-chain replay while preserving the existing full contract-name loading behavior by default
- print state-loading progress before replay so long public-chain traces do not look stalled

## Validation
- `dotnet build src/trace/neotrace.csproj --configuration Release -v:minimal`
- `dotnet test test/test.bctklib/test.bctklib.csproj --configuration Release -v:minimal --no-build`
- `dotnet run --project src/trace/neotrace.csproj --configuration Release --no-build -- transaction --rpc-uri http://seed2t5.neo.org:20332 0x3748339125e4d9ec6d19e03408552ec1ec33c32c8d5bae577cc9edbd0e3923ee` generated a 56 KB `.neo-trace` file