### PR TITLE
Fix Visual Tracker workspace typos

### DIFF
--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
@@ -82,14 +82,14 @@ export default class NeoExpressCommands {
     if (!nodeCount) {
       return;
     }
-    const worksapcePath = (vscode.workspace.workspaceFolders || [])[0]?.uri
+    const workspacePath = (vscode.workspace.workspaceFolders || [])[0]?.uri
       .fsPath;
     const configSavePath = await IoHelpers.pickSaveFile(
       "Create",
       "Neo Express Configurations",
       "neo-express",
-      worksapcePath
-        ? vscode.Uri.file(posixPath(worksapcePath, "default.neo-express"))
+      workspacePath
+        ? vscode.Uri.file(posixPath(workspacePath, "default.neo-express"))
         : undefined
     );
     if (!configSavePath) {

--- a/extentions/neo3-visual-tracker/src/panel/components/quickStart/CreateContract.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/quickStart/CreateContract.tsx
@@ -11,7 +11,7 @@ export default function CreateContract({ onCreate }: Props) {
     <>
       <div style={{ margin: 10, textAlign: "left" }}>
         You don't appear to have any smart contracts in the current Visual
-        Studio Code worskspace. Would you like to create a new smart contract?
+        Studio Code workspace. Would you like to create a new smart contract?
         You can write your smart contract's code in a programming language of
         your choice and then deploy and test it locally using Neo Express.
       </div>


### PR DESCRIPTION
## Summary
- fix a Quick Start workspace typo
- clean up the matching workspace path variable name

## Validation
- npm test
- npm run compile-prod
