### PR TITLE
Fix online automine Release build

### DIFF
--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -149,7 +149,7 @@ namespace NeoExpress.Node
                 var prevHeaderHex = await rpcClient.GetBlockHeaderHexAsync($"{prevHash}").ConfigureAwait(false);
                 var prevHeader = Convert.FromBase64String(prevHeaderHex).AsSerializable<Header>();
 
-                var block = NodeUtility.CreateSignedBlock(prevHeader,
+                var block = BlockProducer.CreateSignedBlock(prevHeader,
                     consensusNodesKeys.Value,
                     ProtocolSettings.Network,
                     new[] { tx });


### PR DESCRIPTION
## Summary
- Use `BlockProducer.CreateSignedBlock` for online automine block creation.

## Why
`NodeUtility.CreateSignedBlock` no longer exists, so the online automine path breaks Release builds after #783. Offline block production already uses `BlockProducer.CreateSignedBlock`; this aligns the online path with it.

## Validation
- `dotnet build neo-express.sln --configuration Release --verbosity minimal`
- `dotnet format neo-express.sln --verify-no-changes --verbosity minimal`
