### PR TITLE
Validate typed public key parameters

### DIFF
--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -70,11 +70,10 @@ namespace Neo.BlockchainToolkit
                 return LoadInvocationScript(document);
             }
             catch (Exception ex) when (ex is JsonException or FormatException or InvalidCastException or IOException
-                or ArgumentException or IndexOutOfRangeException)
+                or ArgumentException)
             {
-                // ArgumentException covers an unsupported parameter token type; IndexOutOfRangeException
-                // covers an empty or null public key reaching ECPoint.Parse. Both mean the file is
-                // malformed, so report it as such instead of surfacing a raw low-level exception.
+                // ArgumentException covers an unsupported parameter token type. All caught errors
+                // mean the file is malformed, so report it without surfacing low-level parser details.
                 throw new Exception($"Invocation file {path} is invalid: {ex.Message}");
             }
         }
@@ -511,7 +510,7 @@ namespace Neo.BlockchainToolkit
                 ContractParameterType.Integer => BigInteger.Parse(valueProp.Value<string>() ?? ""),
                 ContractParameterType.Hash160 => UInt160.Parse(valueProp.Value<string>()),
                 ContractParameterType.Hash256 => UInt256.Parse(valueProp.Value<string>()),
-                ContractParameterType.PublicKey => ECPoint.Parse(valueProp.Value<string>(), ECCurve.Secp256r1),
+                ContractParameterType.PublicKey => ParsePublicKey(valueProp),
                 ContractParameterType.String => valueProp.Value<string>() ?? throw new JsonException(),
                 ContractParameterType.Array => valueProp.Select(ParseParameter).ToList(),
                 ContractParameterType.Map => valueProp.Select(ParseMapElement).ToList(),
@@ -543,6 +542,22 @@ namespace Neo.BlockchainToolkit
                 }
 
                 throw new ArgumentException($"ContractParameterParser could not parse \"{value}\" as binary", nameof(json));
+            }
+
+            static ECPoint ParsePublicKey(JToken json)
+            {
+                var value = json.Value<string>();
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new FormatException("PublicKey parameter value must be a non-empty string");
+
+                try
+                {
+                    return ECPoint.Parse(value, ECCurve.Secp256r1);
+                }
+                catch (Exception ex) when (ex is ArgumentException or FormatException)
+                {
+                    throw new FormatException($"Invalid PublicKey parameter value: {ex.Message}", ex);
+                }
             }
         }
     }

--- a/test/test.bctklib/ContractParameterParserTest.cs
+++ b/test/test.bctklib/ContractParameterParserTest.cs
@@ -11,6 +11,7 @@
 using FluentAssertions;
 using Neo;
 using Neo.BlockchainToolkit;
+using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.SmartContract;
 using Newtonsoft.Json.Linq;
@@ -99,6 +100,44 @@ namespace test.bctklib
             param.Type.Should().Be(ContractParameterType.ByteArray);
             param.Value.Should().BeOfType<byte[]>();
             ((byte[])param.Value).AsSpan().SequenceEqual(expected).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ParseObjectParameter_publickey()
+        {
+            const string value = "0233DE3496D32B8EA6AB5FB925D16009D05E41C109A129AA5B0BE3DB2809946BA8";
+            var json = new JObject()
+            {
+                ["type"] = "PublicKey",
+                ["value"] = value
+            };
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION);
+            var param = parser.ParseObjectParameter(json);
+
+            param.Type.Should().Be(ContractParameterType.PublicKey);
+            param.Value.Should().BeOfType<ECPoint>();
+            param.Value.Should().Be(ECPoint.Parse(value, ECCurve.Secp256r1));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("not-a-public-key")]
+        public void ParseObjectParameter_publickey_reports_malformed_values(string? value)
+        {
+            var json = new JObject()
+            {
+                ["type"] = "PublicKey",
+                ["value"] = value == null ? JValue.CreateNull() : new JValue(value)
+            };
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION);
+
+            var action = () => parser.ParseObjectParameter(json);
+
+            action.Should().Throw<FormatException>()
+                .WithMessage("*PublicKey*");
         }
 
         [Fact]


### PR DESCRIPTION
Summary:
- validate typed PublicKey invocation arguments before parsing
- return a clear FormatException for empty or malformed values
- add regression coverage for valid and malformed PublicKey parameters

Tests:
- dotnet build test/test.bctklib/test.bctklib.csproj -c Release --no-restore
- dotnet test test/test.bctklib/test.bctklib.csproj -c Release --no-build --filter FullyQualifiedName~ContractParameterParserTest
- dotnet format test/test.bctklib/test.bctklib.csproj --verify-no-changes --no-restore
