### PR TITLE
Polish v3.10 developer paths

### DIFF
--- a/docs/worknet-command-reference.md
+++ b/docs/worknet-command-reference.md
@@ -52,8 +52,8 @@ Updating this field requires adding an *unsigned* block to the local blockchain 
 transition block is unsigned, the blockchain history can not be validated across this transition block. 
 
 Unlike Neo-Express, Neo-Worknet doesn't provide an option for creating a multiple consensus nodes for
-the branched chain. Based on understanding of Neo-Express usage patterns, multiple conesnsus nodes are
-not typically used. If four or seven conesnsus node support in Neo-WorkNet is important to you, please
+the branched chain. Based on understanding of Neo-Express usage patterns, multiple consensus nodes are
+not typically used. If four- or seven-consensus-node support in Neo-WorkNet is important to you, please
 file an issue in our [GitHub repo](https://github.com/neo-project/neo-express/issues)
 
 ## neo-worknet fastfwd
@@ -121,7 +121,7 @@ Options:
 This command resets all the locally generated blocks in the chain. The unsigned branch transition block
 (described in the `create` command section) is deleted and regenerated as part of this process.
 
-Any contract data from the public chain that has been cached locally - either via `prefetch` or thru
+Any contract data from the public chain that has been cached locally - either via `prefetch` or through
 the normal process of executing transactions on the branched chain - are not affected. Even after a
 `reset`, contract storage does not need to be `prefetch`ed again.
 

--- a/extentions/neo3-visual-tracker/package-lock.json
+++ b/extentions/neo3-visual-tracker/package-lock.json
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1527,9 +1527,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1815,9 +1815,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3708,9 +3708,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/neoxp/Commands/ContractCommand.Update.cs
+++ b/src/neoxp/Commands/ContractCommand.Update.cs
@@ -17,7 +17,7 @@ namespace NeoExpress.Commands
 
     partial class ContractCommand
     {
-        [Command("update", Description = "update a contract that has been deployed to a neo-express instance")]
+        [Command("update", Description = "Update a contract that has been deployed to a neo-express instance")]
         internal class Update
         {
             readonly ExpressChainManagerFactory chainManagerFactory;

--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -30,7 +30,7 @@ using SysIO = System.IO;
 
 namespace NeoTrace
 {
-    [Command("neotrace", Description = "Generates .neo-trace files for transactions on a public Neo N3 blockchains", UsePagerForHelpText = false)]
+    [Command("neotrace", Description = "Generates .neo-trace files for transactions on public Neo N3 blockchains", UsePagerForHelpText = false)]
     [VersionOption(ThisAssembly.AssemblyInformationalVersion)]
     [Subcommand(typeof(BlockCommand), typeof(TransactionCommand))]
     class Program

--- a/test/test.bctklib/ToolkitPersistencePluginTests.cs
+++ b/test/test.bctklib/ToolkitPersistencePluginTests.cs
@@ -33,6 +33,8 @@ namespace test.bctklib
 
     public class ToolkitPersistencePluginTests
     {
+        const int RocksDbTimeout = 30000;
+
         static readonly UInt160 ContractA = UInt160.Parse("0x0101010101010101010101010101010101010101");
         static readonly UInt160 ContractB = UInt160.Parse("0x0202020202020202020202020202020202020202");
 
@@ -73,7 +75,7 @@ namespace test.bctklib
         // A contract+event filter must KEEP matching notifications and must terminate.
         // The pre-fix code inverted the filter and never advanced the iterator on a
         // filtered record, so this would return the wrong record or loop forever.
-        [Fact(Timeout = 10000)]
+        [Fact(Timeout = RocksDbTimeout)]
         public void GetNotifications_returns_only_records_matching_the_filter()
         {
             using var path = new CleanupPath();
@@ -89,7 +91,7 @@ namespace test.bctklib
             result[0].Notification.ScriptHash.Should().Be(ContractA);
         }
 
-        [Fact(Timeout = 10000)]
+        [Fact(Timeout = RocksDbTimeout)]
         public void GetNotifications_returns_every_record_when_unfiltered()
         {
             using var path = new CleanupPath();
@@ -105,7 +107,7 @@ namespace test.bctklib
 
         // The event-name filter is compared case-insensitively so a caller-supplied
         // "transfer" still matches a stored "Transfer", matching ExpressPersistencePlugin.
-        [Fact(Timeout = 10000)]
+        [Fact(Timeout = RocksDbTimeout)]
         public void GetNotifications_matches_event_names_case_insensitively()
         {
             using var path = new CleanupPath();
@@ -122,7 +124,7 @@ namespace test.bctklib
 
         // The backward direction walks the iterator with Prev() rather than Next();
         // pin that path so the reverse advance cannot regress.
-        [Fact(Timeout = 10000)]
+        [Fact(Timeout = RocksDbTimeout)]
         public void GetNotifications_walks_records_in_reverse_when_backward()
         {
             using var path = new CleanupPath();


### PR DESCRIPTION
Summary:
- relax RocksDB notification test timeout to avoid load-sensitive failures
- fix neoxp and neotrace help text plus WorkNet documentation typos
- update the Visual Tracker lockfile to clear the brace-expansion advisory

Tests:
- dotnet test test/test.bctklib/test.bctklib.csproj -c Release --filter FullyQualifiedName~ToolkitPersistencePluginTests
- dotnet build src/neoxp/neoxp.csproj -c Release --no-restore
- dotnet build src/trace/neotrace.csproj -c Release --no-restore
- npm audit --audit-level=moderate
- npm test -- --runInBand
