### PR TITLE
Make DBFT max block system fee configurable

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -48,6 +48,24 @@ Example usage:
   }
 ```
 
+## `dbft.MaxBlockSystemFee`
+
+The `dbft.MaxBlockSystemFee` Neo-Express setting corresponds to the `MaxBlockSystemFee`
+DBFT plugin setting. This setting specifies the maximum transaction system fee, in
+datoshi, accepted by the consensus service.
+
+This setting defaults to `2000000000` datoshi, or 20 GAS. If you specify an invalid or
+negative integer value for this setting, Neo-Express reverts to the default. One GAS is
+`100000000` datoshi.
+
+Example usage:
+
+``` json
+  "settings": {
+    "dbft.MaxBlockSystemFee": "4000000000" // support transaction system fees up to 40 GAS
+  }
+```
+
 ## `rpc.BindAddress`
 
 The `rpc.BindAddress` Neo-Express setting corresponds to the `BindAddress`

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -30,6 +30,7 @@ namespace NeoExpress
     {
         private const string GLOBAL_PREFIX = "Global\\";
         private const string CHECKPOINT_EXTENSION = ".neoxp-checkpoint";
+        internal const string MaxBlockSystemFeeSetting = "dbft.MaxBlockSystemFee";
 
         private readonly IFileSystem fileSystem;
         private readonly ExpressChain chain;
@@ -368,8 +369,8 @@ namespace NeoExpress
                     try
                     {
                         using var logPlugin = new ExpressLogPlugin(console);
-                        using var dbftPlugin = new DBFTPlugin(GetConsensusSettings(chain));
-                        using var rpcServerPlugin = new ExpressRpcServerPlugin(GetRpcServerSettings(chain, node),
+                        using var dbftPlugin = new DBFTPlugin(CreateConsensusSettings(chain));
+                        using var rpcServerPlugin = new ExpressRpcServerPlugin(CreateRpcServerSettings(chain, node),
                             expressStorage, multiSigAccount.ScriptHash);
                         using var neoSystem = new Neo.NeoSystem(ProtocolSettings, storeProvider.Name);
 
@@ -403,52 +404,59 @@ namespace NeoExpress
             });
             await tcs.Task.ConfigureAwait(false);
 
-            static DbftSettings GetConsensusSettings(ExpressChain chain)
-            {
-                var settings = new Dictionary<string, string>()
-                {
-                    { "PluginConfiguration:Network", $"{chain.Network}" },
-                    { "IgnoreRecoveryLogs", "true" }
-                };
+        }
 
-                var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
-                return new DbftSettings(config.GetSection("PluginConfiguration"));
+        internal static DbftSettings CreateConsensusSettings(ExpressChain chain)
+        {
+            var settings = new Dictionary<string, string>()
+            {
+                { "PluginConfiguration:Network", $"{chain.Network}" },
+                { "IgnoreRecoveryLogs", "true" }
+            };
+
+            if (chain.TryReadSetting<long>(MaxBlockSystemFeeSetting, long.TryParse, out var maxBlockSystemFee)
+                && maxBlockSystemFee >= 0)
+            {
+                settings.Add("PluginConfiguration:MaxBlockSystemFee", $"{maxBlockSystemFee}");
             }
 
-            static RpcServersSettings GetRpcServerSettings(ExpressChain chain, ExpressConsensusNode node)
+            var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+            return new DbftSettings(config.GetSection("PluginConfiguration"));
+        }
+
+        internal static RpcServersSettings CreateRpcServerSettings(ExpressChain chain, ExpressConsensusNode node)
+        {
+            var ipAddress = chain.TryReadSetting<IPAddress>("rpc.BindAddress", IPAddress.TryParse, out var bindAddress)
+                ? bindAddress : IPAddress.Loopback;
+
+            var settings = new Dictionary<string, string>()
             {
-                var ipAddress = chain.TryReadSetting<IPAddress>("rpc.BindAddress", IPAddress.TryParse, out var bindAddress)
-                    ? bindAddress : IPAddress.Loopback;
+                { "PluginConfiguration:Network", $"{chain.Network}" },
+                { "PluginConfiguration:BindAddress", $"{ipAddress}" },
+                { "PluginConfiguration:Port", $"{node.RpcPort}" },
+            };
 
-                var settings = new Dictionary<string, string>()
-                {
-                    { "PluginConfiguration:Network", $"{chain.Network}" },
-                    { "PluginConfiguration:BindAddress", $"{ipAddress}" },
-                    { "PluginConfiguration:Port", $"{node.RpcPort}" },
-                };
-
-                if (chain.TryReadSetting<decimal>("rpc.MaxGasInvoke", decimal.TryParse, out var maxGasInvoke))
-                {
-                    settings.Add("PluginConfiguration:MaxGasInvoke", $"{maxGasInvoke}");
-                }
-
-                if (chain.TryReadSetting<decimal>("rpc.MaxFee", decimal.TryParse, out var maxFee))
-                {
-                    settings.Add("PluginConfiguration:MaxFee", $"{maxFee}");
-                }
-
-                if (chain.TryReadSetting<int>("rpc.MaxIteratorResultItems", int.TryParse, out var maxIteratorResultItems)
-                    && maxIteratorResultItems > 0)
-                {
-                    settings.Add("PluginConfiguration:MaxIteratorResultItems", $"{maxIteratorResultItems}");
-                }
-
-                var sessionEnabled = !chain.TryReadSetting<bool>("rpc.SessionEnabled", bool.TryParse, out var value) || value;
-                settings.Add("PluginConfiguration:SessionEnabled", $"{sessionEnabled}");
-
-                var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
-                return RpcServersSettings.Load(config.GetSection("PluginConfiguration"));
+            if (chain.TryReadSetting<decimal>("rpc.MaxGasInvoke", decimal.TryParse, out var maxGasInvoke))
+            {
+                settings.Add("PluginConfiguration:MaxGasInvoke", $"{maxGasInvoke}");
             }
+
+            if (chain.TryReadSetting<decimal>("rpc.MaxFee", decimal.TryParse, out var maxFee))
+            {
+                settings.Add("PluginConfiguration:MaxFee", $"{maxFee}");
+            }
+
+            if (chain.TryReadSetting<int>("rpc.MaxIteratorResultItems", int.TryParse, out var maxIteratorResultItems)
+                && maxIteratorResultItems > 0)
+            {
+                settings.Add("PluginConfiguration:MaxIteratorResultItems", $"{maxIteratorResultItems}");
+            }
+
+            var sessionEnabled = !chain.TryReadSetting<bool>("rpc.SessionEnabled", bool.TryParse, out var value) || value;
+            settings.Add("PluginConfiguration:SessionEnabled", $"{sessionEnabled}");
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+            return RpcServersSettings.Load(config.GetSection("PluginConfiguration"));
         }
 
         public IExpressStorage GetNodeStorageProvider(ExpressConsensusNode node, bool discard)

--- a/test/test.workflowvalidation/ExpressChainManagerSettingsTests.cs
+++ b/test/test.workflowvalidation/ExpressChainManagerSettingsTests.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExpressChainManagerSettingsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.Models;
+using NeoExpress;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ExpressChainManagerSettingsTests
+{
+    [Fact]
+    public void CreateConsensusSettings_reads_dbft_max_block_system_fee()
+    {
+        var chain = CreateChain();
+        chain.Settings[ExpressChainManager.MaxBlockSystemFeeSetting] = "4000000000";
+
+        var settings = ExpressChainManager.CreateConsensusSettings(chain);
+
+        settings.MaxBlockSystemFee.Should().Be(40_00000000L);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("-1")]
+    public void CreateConsensusSettings_ignores_invalid_dbft_max_block_system_fee(string value)
+    {
+        var defaultSettings = ExpressChainManager.CreateConsensusSettings(CreateChain());
+        var chain = CreateChain();
+        chain.Settings[ExpressChainManager.MaxBlockSystemFeeSetting] = value;
+
+        var settings = ExpressChainManager.CreateConsensusSettings(chain);
+
+        settings.MaxBlockSystemFee.Should().Be(defaultSettings.MaxBlockSystemFee);
+    }
+
+    static ExpressChain CreateChain()
+        => new()
+        {
+            Network = 12345
+        };
+}


### PR DESCRIPTION
## Summary
- Add dbft.MaxBlockSystemFee support when Neo-Express builds DBFT settings.
- Document the setting and the 40 GAS datoshi example.
- Add focused tests for valid and invalid dbft.MaxBlockSystemFee values.

## Testing
- git diff --check
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter "FullyQualifiedName~ExpressChainManagerSettingsTests" --no-restore
- End-to-end local validation: a temporary default chain rejected a 21 GAS invocation with PolicyFail; a temporary chain configured with `"dbft.MaxBlockSystemFee": "4000000000"` accepted the same 21 GAS invocation and returned a transaction hash, transaction payload, and application log.