### PR TITLE
Explain PolicyFail transaction rejections

### DIFF
--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -31,6 +31,9 @@ namespace NeoExpress.Node
 {
     class OnlineNode : IExpressNode
     {
+        internal const int RpcPolicyFailedCode = -505;
+        internal const long DefaultMaxBlockSystemFee = 20_00000000;
+
         readonly ExpressChain chain;
         readonly RpcClient rpcClient;
         readonly Lazy<KeyPair[]> consensusNodesKeys;
@@ -125,7 +128,7 @@ namespace NeoExpress.Node
                 return await SubmitAutoMinedBlockAsync(tx).ConfigureAwait(false);
             }
 
-            return await rpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
+            return await SendRawTransactionAsync(tx).ConfigureAwait(false);
         }
 
         // Instant transaction confirmation is opt-in via the chain.AutoMine setting and only
@@ -164,7 +167,7 @@ namespace NeoExpress.Node
                 }
             }
 
-            return await rpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
+            return await SendRawTransactionAsync(tx).ConfigureAwait(false);
         }
 
         public async Task<UInt256> SubmitOracleResponseAsync(OracleResponse response, IReadOnlyList<ECPoint> oracleNodes)
@@ -173,8 +176,42 @@ namespace NeoExpress.Node
             var tx = Convert.FromBase64String(jsonTx.AsString()).AsSerializable<Transaction>();
             NodeUtility.SignOracleResponseTransaction(ProtocolSettings, chain, tx, oracleNodes);
 
-            return await rpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
+            return await SendRawTransactionAsync(tx).ConfigureAwait(false);
         }
+
+        async Task<UInt256> SendRawTransactionAsync(Transaction tx)
+        {
+            try
+            {
+                return await rpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
+            }
+            catch (RpcException ex) when (IsPolicyFail(ex))
+            {
+                throw CreatePolicyFailException(ex, tx);
+            }
+        }
+
+        internal static bool IsPolicyFail(RpcException ex)
+            => ex.HResult == RpcPolicyFailedCode
+            || ex.Message.Contains("PolicyFail", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("Policy check failed", StringComparison.OrdinalIgnoreCase);
+
+        internal static Exception CreatePolicyFailException(RpcException ex, Transaction tx)
+        {
+            var systemFee = FormatGas(tx.SystemFee);
+            var maxBlockSystemFee = FormatGas(DefaultMaxBlockSystemFee);
+
+            var hint = tx.SystemFee > DefaultMaxBlockSystemFee
+                ? $" The transaction system fee exceeds the default DBFT MaxBlockSystemFee of {maxBlockSystemFee} GAS."
+                : $" The transaction system fee does not exceed the default DBFT MaxBlockSystemFee of {maxBlockSystemFee} GAS; check whether any signer or target contract is blocked by Policy or whether the node uses a lower MaxBlockSystemFee setting.";
+
+            return new Exception(
+                $"Transaction rejected by node policy (PolicyFail). System fee: {systemFee} GAS.{hint} Contract deployment and update transactions include storage fees based on NEF and manifest size. Increase the DBFT MaxBlockSystemFee setting or reduce the transaction system fee. Original RPC error: {ex.Message}",
+                ex);
+        }
+
+        internal static string FormatGas(long value)
+            => $"{new BigDecimal((BigInteger)value, NativeContract.GAS.Decimals)}";
 
         public async Task<Block> GetBlockAsync(UInt256 blockHash)
         {

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -12,6 +12,7 @@ using FluentAssertions;
 using Neo;
 using Neo.BlockchainToolkit.Models;
 using Neo.Json;
+using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC;
 using NeoExpress.Commands;
 using NeoExpress.Node;
@@ -101,5 +102,54 @@ public class OnlineNodeTests
         result.Should().Equal(
             Convert.ToBase64String(new byte[] { 0x31 }),
             Convert.ToBase64String(new byte[] { 0x0a, 0x0b }));
+    }
+
+    [Fact]
+    public void CreatePolicyFailException_explains_default_max_block_system_fee_when_system_fee_is_high()
+    {
+        var rpcException = new RpcException(OnlineNode.RpcPolicyFailedCode, "Policy check failed");
+        var tx = new Transaction
+        {
+            Signers = [],
+            Attributes = [],
+            Witnesses = [],
+            SystemFee = OnlineNode.DefaultMaxBlockSystemFee + 1
+        };
+
+        var exception = OnlineNode.CreatePolicyFailException(rpcException, tx);
+
+        exception.Message.Should().Contain("Transaction rejected by node policy (PolicyFail)");
+        exception.Message.Should().Contain("System fee:");
+        exception.Message.Should().Contain("default DBFT MaxBlockSystemFee");
+        exception.Message.Should().Contain("20 GAS");
+        exception.Message.Should().Contain("NEF and manifest size");
+        exception.InnerException.Should().BeSameAs(rpcException);
+    }
+
+    [Fact]
+    public void CreatePolicyFailException_keeps_policy_block_hint_when_system_fee_is_not_high()
+    {
+        var rpcException = new RpcException(OnlineNode.RpcPolicyFailedCode, "Policy check failed");
+        var tx = new Transaction
+        {
+            Signers = [],
+            Attributes = [],
+            Witnesses = [],
+            SystemFee = OnlineNode.DefaultMaxBlockSystemFee
+        };
+
+        var exception = OnlineNode.CreatePolicyFailException(rpcException, tx);
+
+        exception.Message.Should().Contain("does not exceed the default DBFT MaxBlockSystemFee");
+        exception.Message.Should().Contain("blocked by Policy");
+        exception.Message.Should().Contain("lower MaxBlockSystemFee");
+    }
+
+    [Fact]
+    public void IsPolicyFail_matches_rpc_policy_error_code()
+    {
+        var rpcException = new RpcException(OnlineNode.RpcPolicyFailedCode, "Policy check failed");
+
+        OnlineNode.IsPolicyFail(rpcException).Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Summary
- Wrap PolicyFail responses from online sendrawtransaction calls with a more actionable error.
- Include the transaction system fee, the default DBFT MaxBlockSystemFee limit, and deployment/update storage-fee context.
- Keep non-PolicyFail RPC errors unchanged.

## Testing
- git diff --check
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter "FullyQualifiedName~OnlineNodeTests" --no-restore
- End-to-end local validation: a temporary default chain rejected `neoxp execute 11 --account genesis --gas 21 --json` with the expanded PolicyFail message.