### PR TITLE
Make Neo settings configurable

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -105,11 +105,13 @@ Supported native policy settings:
 - `policy.MillisecondsPerBlock`
 - `policy.MaxValidUntilBlockIncrement`
 - `policy.MaxTraceableBlocks`
+- `policy.AttributeFee.<TransactionAttributeType>`
 
 GAS-denominated policy values are specified in datoshi. One GAS is `100000000` datoshi.
 `policy.StorageFeeFactor`, `policy.ExecutionFeeFactor`, `policy.MillisecondsPerBlock`,
 `policy.MaxValidUntilBlockIncrement` and `policy.MaxTraceableBlocks` are whole-number factors or
-counts.
+counts. Attribute fee keys use Neo `TransactionAttributeType` enum names, such as `HighPriority`,
+`NotValidBefore`, `Conflicts` or `NotaryAssisted`.
 
 When `HF_Echidna` is active at genesis height, Neo stores block time, max valid-until-block
 increment and max traceable blocks in the native Policy contract. In that case Neo-Express uses
@@ -118,6 +120,9 @@ increment and max traceable blocks in the native Policy contract. In that case N
 from `protocol.MillisecondsPerBlock`, `protocol.MaxValidUntilBlockIncrement` and
 `protocol.MaxTraceableBlocks`.
 
+`policy.AttributeFee.NotaryAssisted` only takes effect when `HF_Echidna` is active at genesis
+height.
+
 Example usage:
 
 ``` json
@@ -125,7 +130,30 @@ Example usage:
     "policy.NetworkFeePerByte": "2000",
     "policy.StorageFeeFactor": "200000",
     "policy.ExecutionFeeFactor": "40",
-    "policy.MinimumDeploymentFee": "2000000000"
+    "policy.MinimumDeploymentFee": "2000000000",
+    "policy.AttributeFee.HighPriority": "1000"
+  }
+```
+
+## `notary.*`
+
+Neo-Express can initialize native Notary values from the `settings` object when the Notary contract
+is active at genesis height. These values are written only while the chain is still at genesis
+height.
+
+Supported native Notary settings:
+
+- `notary.MaxNotValidBeforeDelta`
+
+`notary.MaxNotValidBeforeDelta` must be at least the validator count and no more than half of the
+current max valid-until-block increment.
+
+Example usage:
+
+``` json
+  "settings": {
+    "protocol.Hardforks.HF_Echidna": "0",
+    "notary.MaxNotValidBeforeDelta": "40"
   }
 ```
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -48,6 +48,87 @@ Example usage:
   }
 ```
 
+## `protocol.*`
+
+Neo-Express can read Neo protocol configuration values from the `settings` object. These values
+override the defaults used to build the `ProtocolSettings` passed to the Neo node. The network
+magic, address version, consensus committee, validators count and seed list continue to come from
+the top-level `.neo-express` chain definition.
+
+Supported protocol settings:
+
+- `protocol.MillisecondsPerBlock`
+- `protocol.MaxTransactionsPerBlock`
+- `protocol.MemoryPoolMaxTransactions`
+- `protocol.MaxTraceableBlocks`
+- `protocol.MaxValidUntilBlockIncrement`
+- `protocol.InitialGasDistribution`
+- `protocol.Hardforks.<HardforkName>`
+
+The `chain.SecondsPerBlock` setting and the `run --seconds-per-block` option still override
+`protocol.MillisecondsPerBlock`.
+
+Protocol values are specified as unsigned integers, except `protocol.MemoryPoolMaxTransactions`,
+which is a positive integer. Hardfork names use the Neo `Hardfork` enum names, such as
+`HF_Echidna` or `HF_Faun`, and values are activation block heights.
+
+Example usage:
+
+``` json
+  "settings": {
+    "protocol.MillisecondsPerBlock": "3000",
+    "protocol.MaxTransactionsPerBlock": "1024",
+    "protocol.MemoryPoolMaxTransactions": "100000",
+    "protocol.MaxTraceableBlocks": "2102400",
+    "protocol.MaxValidUntilBlockIncrement": "86400",
+    "protocol.InitialGasDistribution": "5200000000000000",
+    "protocol.Hardforks.HF_Echidna": "0",
+    "protocol.Hardforks.HF_Faun": "0"
+  }
+```
+
+## `policy.*`
+
+Neo-Express can also initialize native policy values from the `settings` object. These values are
+written to the chain state only while the chain is still at genesis height. If the chain has already
+produced blocks, use the `policy set` command to change policy values through a transaction.
+
+Supported native policy settings:
+
+- `policy.GasPerBlock`
+- `policy.MinimumDeploymentFee`
+- `policy.CandidateRegistrationFee`
+- `policy.OracleRequestFee`
+- `policy.NetworkFeePerByte`
+- `policy.StorageFeeFactor`
+- `policy.ExecutionFeeFactor`
+- `policy.MillisecondsPerBlock`
+- `policy.MaxValidUntilBlockIncrement`
+- `policy.MaxTraceableBlocks`
+
+GAS-denominated policy values are specified in datoshi. One GAS is `100000000` datoshi.
+`policy.StorageFeeFactor`, `policy.ExecutionFeeFactor`, `policy.MillisecondsPerBlock`,
+`policy.MaxValidUntilBlockIncrement` and `policy.MaxTraceableBlocks` are whole-number factors or
+counts.
+
+When `HF_Echidna` is active at genesis height, Neo stores block time, max valid-until-block
+increment and max traceable blocks in the native Policy contract. In that case Neo-Express uses
+`policy.MillisecondsPerBlock`, `policy.MaxValidUntilBlockIncrement` and
+`policy.MaxTraceableBlocks` if they are present; otherwise it initializes those native policy values
+from `protocol.MillisecondsPerBlock`, `protocol.MaxValidUntilBlockIncrement` and
+`protocol.MaxTraceableBlocks`.
+
+Example usage:
+
+``` json
+  "settings": {
+    "policy.NetworkFeePerByte": "2000",
+    "policy.StorageFeeFactor": "200000",
+    "policy.ExecutionFeeFactor": "40",
+    "policy.MinimumDeploymentFee": "2000000000"
+  }
+```
+
 ## `dbft.MaxBlockSystemFee`
 
 The `dbft.MaxBlockSystemFee` Neo-Express setting corresponds to the `MaxBlockSystemFee`

--- a/src/bctklib/ExpressChainExtensions.cs
+++ b/src/bctklib/ExpressChainExtensions.cs
@@ -17,8 +17,8 @@ using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.Wallets;
-using System.Diagnostics.CodeAnalysis;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
 
@@ -44,6 +44,8 @@ namespace Neo.BlockchainToolkit
         const string PolicyMillisecondsPerBlockSetting = "policy.MillisecondsPerBlock";
         const string PolicyMaxValidUntilBlockIncrementSetting = "policy.MaxValidUntilBlockIncrement";
         const string PolicyMaxTraceableBlocksSetting = "policy.MaxTraceableBlocks";
+        const string PolicyAttributeFeePrefix = "policy.AttributeFee.";
+        const string NotaryMaxNotValidBeforeDeltaSetting = "notary.MaxNotValidBeforeDelta";
 
         const byte NeoGasPerBlockPrefix = 29;
         const byte NeoRegisterPricePrefix = 13;
@@ -52,9 +54,11 @@ namespace Neo.BlockchainToolkit
         const byte PolicyFeePerBytePrefix = 10;
         const byte PolicyExecFeeFactorPrefix = 18;
         const byte PolicyStoragePricePrefix = 19;
+        const byte PolicyAttributeFeeStoragePrefix = 20;
         const byte PolicyMillisecondsPerBlockPrefix = 21;
         const byte PolicyMaxValidUntilBlockIncrementPrefix = 22;
         const byte PolicyMaxTraceableBlocksPrefix = 23;
+        const byte NotaryMaxNotValidBeforeDeltaPrefix = 10;
 
         public static ProtocolSettings GetProtocolSettings(this ExpressChain? chain, uint secondsPerBlock = 0)
         {
@@ -181,12 +185,14 @@ namespace Neo.BlockchainToolkit
                         : value;
                     SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyExecFeeFactorPrefix, storageValue);
                 });
+            changed |= ApplyAttributeFeeSettings(chain, snapshot, settings, currentIndex);
             if (settings.IsHardforkEnabled(Hardfork.HF_Echidna, currentIndex))
             {
                 changed |= ApplyUIntSettingOrProtocolValue(chain, PolicyMillisecondsPerBlockSetting, ProtocolMillisecondsPerBlockSetting,
                     settings.MillisecondsPerBlock, ProtocolSettings.Default.MillisecondsPerBlock, 1, PolicyContract.MaxMillisecondsPerBlock,
                     value => SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyMillisecondsPerBlockPrefix, value));
                 changed |= ApplyTraceableBlockSettings(chain, snapshot, settings);
+                changed |= ApplyNotarySettings(chain, snapshot, settings);
             }
 
             if (changed)
@@ -230,6 +236,38 @@ namespace Neo.BlockchainToolkit
 
             static void SetIndexedStorage(DataCache snapshot, int contractId, byte prefix, uint index, BigInteger value)
                 => snapshot.GetAndChange(StorageKey.Create(contractId, prefix, index), () => new StorageItem())!.Set(value);
+
+            static void SetByteIndexedStorage(DataCache snapshot, int contractId, byte prefix, byte index, BigInteger value)
+                => snapshot.GetAndChange(StorageKey.Create(contractId, prefix, index), () => new StorageItem())!.Set(value);
+
+            static bool ApplyAttributeFeeSettings(ExpressChain chain, DataCache snapshot, ProtocolSettings settings, uint currentIndex)
+            {
+                var changed = false;
+                var echidnaEnabled = settings.IsHardforkEnabled(Hardfork.HF_Echidna, currentIndex);
+                foreach (var (key, value) in chain.Settings)
+                {
+                    if (!key.StartsWith(PolicyAttributeFeePrefix, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var attributeName = key[PolicyAttributeFeePrefix.Length..];
+                    if (!Enum.TryParse<TransactionAttributeType>(attributeName, ignoreCase: true, out var attributeType)
+                        || !Enum.IsDefined(typeof(TransactionAttributeType), attributeType)
+                        || (attributeType == TransactionAttributeType.NotaryAssisted && !echidnaEnabled)
+                        || !uint.TryParse(value, out var attributeFee)
+                        || attributeFee > PolicyContract.MaxAttributeFee)
+                    {
+                        continue;
+                    }
+
+                    SetByteIndexedStorage(snapshot, NativeContract.Policy.Id, PolicyAttributeFeeStoragePrefix,
+                        (byte)attributeType, attributeFee);
+                    changed = true;
+                }
+
+                return changed;
+            }
 
             static bool ApplyUIntSettingOrProtocolValue(
                 ExpressChain chain,
@@ -304,6 +342,24 @@ namespace Neo.BlockchainToolkit
                     changed = true;
                 }
                 return changed;
+            }
+
+            static bool ApplyNotarySettings(ExpressChain chain, DataCache snapshot, ProtocolSettings settings)
+            {
+                if (!TryReadSetting<uint>(chain, NotaryMaxNotValidBeforeDeltaSetting, uint.TryParse, out var maxNotValidBeforeDelta))
+                {
+                    return false;
+                }
+
+                var maxValidUntilBlockIncrement = NativeContract.Policy.GetMaxValidUntilBlockIncrement(snapshot);
+                if (maxNotValidBeforeDelta < settings.ValidatorsCount
+                    || maxNotValidBeforeDelta > maxValidUntilBlockIncrement / 2)
+                {
+                    return false;
+                }
+
+                SetStorageValue(snapshot, NativeContract.Notary.Id, NotaryMaxNotValidBeforeDeltaPrefix, maxNotValidBeforeDelta);
+                return true;
             }
 
             static uint? GetUIntPolicyOrProtocolValue(

--- a/src/bctklib/ExpressChainExtensions.cs
+++ b/src/bctklib/ExpressChainExtensions.cs
@@ -325,6 +325,12 @@ namespace Neo.BlockchainToolkit
                     ?? NativeContract.Policy.GetMaxTraceableBlocks(snapshot);
                 if (resultingMaxValidUntilBlockIncrement >= resultingMaxTraceableBlocks)
                 {
+                    Logs.GetLogger(nameof(ExpressChainExtensions)).Warning(
+                        "Ignoring traceable block settings because {MaxValidUntilBlockIncrementSetting} ({MaxValidUntilBlockIncrement}) must be less than {MaxTraceableBlocksSetting} ({MaxTraceableBlocks})",
+                        PolicyMaxValidUntilBlockIncrementSetting,
+                        resultingMaxValidUntilBlockIncrement,
+                        PolicyMaxTraceableBlocksSetting,
+                        resultingMaxTraceableBlocks);
                     return false;
                 }
 

--- a/src/bctklib/ExpressChainExtensions.cs
+++ b/src/bctklib/ExpressChainExtensions.cs
@@ -15,31 +15,336 @@ using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.SmartContract;
+using Neo.SmartContract.Native;
 using Neo.Wallets;
 using System.Diagnostics.CodeAnalysis;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Numerics;
 
 namespace Neo.BlockchainToolkit
 {
     public static class ExpressChainExtensions
     {
+        const string ChainSecondsPerBlockSetting = "chain.SecondsPerBlock";
+        const string ProtocolMillisecondsPerBlockSetting = "protocol.MillisecondsPerBlock";
+        const string ProtocolMaxTransactionsPerBlockSetting = "protocol.MaxTransactionsPerBlock";
+        const string ProtocolMemoryPoolMaxTransactionsSetting = "protocol.MemoryPoolMaxTransactions";
+        const string ProtocolMaxTraceableBlocksSetting = "protocol.MaxTraceableBlocks";
+        const string ProtocolMaxValidUntilBlockIncrementSetting = "protocol.MaxValidUntilBlockIncrement";
+        const string ProtocolInitialGasDistributionSetting = "protocol.InitialGasDistribution";
+        const string ProtocolHardforksPrefix = "protocol.Hardforks.";
+        const string PolicyGasPerBlockSetting = "policy.GasPerBlock";
+        const string PolicyMinimumDeploymentFeeSetting = "policy.MinimumDeploymentFee";
+        const string PolicyCandidateRegistrationFeeSetting = "policy.CandidateRegistrationFee";
+        const string PolicyOracleRequestFeeSetting = "policy.OracleRequestFee";
+        const string PolicyNetworkFeePerByteSetting = "policy.NetworkFeePerByte";
+        const string PolicyStorageFeeFactorSetting = "policy.StorageFeeFactor";
+        const string PolicyExecutionFeeFactorSetting = "policy.ExecutionFeeFactor";
+        const string PolicyMillisecondsPerBlockSetting = "policy.MillisecondsPerBlock";
+        const string PolicyMaxValidUntilBlockIncrementSetting = "policy.MaxValidUntilBlockIncrement";
+        const string PolicyMaxTraceableBlocksSetting = "policy.MaxTraceableBlocks";
+
+        const byte NeoGasPerBlockPrefix = 29;
+        const byte NeoRegisterPricePrefix = 13;
+        const byte ContractMinimumDeploymentFeePrefix = 20;
+        const byte OraclePricePrefix = 5;
+        const byte PolicyFeePerBytePrefix = 10;
+        const byte PolicyExecFeeFactorPrefix = 18;
+        const byte PolicyStoragePricePrefix = 19;
+        const byte PolicyMillisecondsPerBlockPrefix = 21;
+        const byte PolicyMaxValidUntilBlockIncrementPrefix = 22;
+        const byte PolicyMaxTraceableBlocksPrefix = 23;
+
         public static ProtocolSettings GetProtocolSettings(this ExpressChain? chain, uint secondsPerBlock = 0)
         {
-            return chain == null
-                ? ProtocolSettings.Default
-                : ProtocolSettings.Default with
-                {
-                    Network = chain.Network,
-                    AddressVersion = chain.AddressVersion,
-                    MillisecondsPerBlock = secondsPerBlock == 0 ? 15000 : secondsPerBlock * 1000,
-                    ValidatorsCount = chain.ConsensusNodes.Count,
-                    StandbyCommittee = chain.ConsensusNodes.Select(GetPublicKey).ToArray(),
-                    SeedList = chain.ConsensusNodes
-                        .Select(n => $"{System.Net.IPAddress.Loopback}:{n.TcpPort}")
-                        .ToArray(),
-                };
+            if (chain is null)
+            {
+                return ProtocolSettings.Default;
+            }
+
+            var settings = ProtocolSettings.Default with
+            {
+                Network = chain.Network,
+                AddressVersion = chain.AddressVersion,
+                ValidatorsCount = chain.ConsensusNodes.Count,
+                StandbyCommittee = chain.ConsensusNodes.Select(GetPublicKey).ToArray(),
+                SeedList = chain.ConsensusNodes
+                    .Select(n => $"{System.Net.IPAddress.Loopback}:{n.TcpPort}")
+                    .ToArray(),
+            };
+
+            settings = ApplyProtocolSettings(chain, settings);
+
+            if (secondsPerBlock > 0)
+            {
+                settings = settings with { MillisecondsPerBlock = secondsPerBlock * 1000 };
+            }
+            else if (TryReadSetting<uint>(chain, ChainSecondsPerBlockSetting, uint.TryParse, out var chainSecondsPerBlock)
+                && chainSecondsPerBlock > 0)
+            {
+                settings = settings with { MillisecondsPerBlock = chainSecondsPerBlock * 1000 };
+            }
+
+            return settings;
 
             static ECPoint GetPublicKey(ExpressConsensusNode node)
                 => new KeyPair(node.Wallet.Accounts.Select(a => a.PrivateKey).Distinct().Single().HexToBytes()).PublicKey;
+        }
+
+        static ProtocolSettings ApplyProtocolSettings(ExpressChain chain, ProtocolSettings settings)
+        {
+            if (TryReadSetting<uint>(chain, ProtocolMillisecondsPerBlockSetting, uint.TryParse, out var millisecondsPerBlock)
+                && millisecondsPerBlock > 0)
+            {
+                settings = settings with { MillisecondsPerBlock = millisecondsPerBlock };
+            }
+
+            if (TryReadSetting<uint>(chain, ProtocolMaxTransactionsPerBlockSetting, uint.TryParse, out var maxTransactionsPerBlock)
+                && maxTransactionsPerBlock > 0)
+            {
+                settings = settings with { MaxTransactionsPerBlock = maxTransactionsPerBlock };
+            }
+
+            if (TryReadSetting<int>(chain, ProtocolMemoryPoolMaxTransactionsSetting, int.TryParse, out var memoryPoolMaxTransactions)
+                && memoryPoolMaxTransactions > 0)
+            {
+                settings = settings with { MemoryPoolMaxTransactions = memoryPoolMaxTransactions };
+            }
+
+            if (TryReadSetting<uint>(chain, ProtocolMaxTraceableBlocksSetting, uint.TryParse, out var maxTraceableBlocks)
+                && maxTraceableBlocks > 0)
+            {
+                settings = settings with { MaxTraceableBlocks = maxTraceableBlocks };
+            }
+
+            if (TryReadSetting<uint>(chain, ProtocolMaxValidUntilBlockIncrementSetting, uint.TryParse, out var maxValidUntilBlockIncrement)
+                && maxValidUntilBlockIncrement > 0)
+            {
+                settings = settings with { MaxValidUntilBlockIncrement = maxValidUntilBlockIncrement };
+            }
+
+            if (TryReadSetting<ulong>(chain, ProtocolInitialGasDistributionSetting, ulong.TryParse, out var initialGasDistribution))
+            {
+                settings = settings with { InitialGasDistribution = initialGasDistribution };
+            }
+
+            var hardforks = settings.Hardforks.ToBuilder();
+            var hardforkChanged = false;
+            foreach (var (key, value) in chain.Settings)
+            {
+                if (!key.StartsWith(ProtocolHardforksPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var hardforkName = key[ProtocolHardforksPrefix.Length..];
+                if (Enum.TryParse<Hardfork>(hardforkName, ignoreCase: true, out var hardfork)
+                    && uint.TryParse(value, out var height))
+                {
+                    hardforks[hardfork] = height;
+                    hardforkChanged = true;
+                }
+            }
+
+            return hardforkChanged
+                ? settings with { Hardforks = hardforks.ToImmutableDictionary() }
+                : settings;
+        }
+
+        public static bool ApplyNativePolicySettings(this ExpressChain? chain, DataCache snapshot, ProtocolSettings settings)
+        {
+            var currentIndex = NativeContract.Ledger.CurrentIndex(snapshot);
+            if (chain is null || currentIndex != 0)
+            {
+                return false;
+            }
+
+            var changed = false;
+            changed |= ApplyBigIntegerSetting(chain, PolicyGasPerBlockSetting, 0, 10 * NativeContract.GAS.Factor,
+                value => SetIndexedStorage(snapshot, NativeContract.NEO.Id, NeoGasPerBlockPrefix, 0u, value));
+            changed |= ApplyBigIntegerSetting(chain, PolicyMinimumDeploymentFeeSetting, 0, null,
+                value => SetStorageValue(snapshot, NativeContract.ContractManagement.Id, ContractMinimumDeploymentFeePrefix, value));
+            changed |= ApplyBigIntegerSetting(chain, PolicyCandidateRegistrationFeeSetting, 1, null,
+                value => SetStorageValue(snapshot, NativeContract.NEO.Id, NeoRegisterPricePrefix, value));
+            changed |= ApplyBigIntegerSetting(chain, PolicyOracleRequestFeeSetting, 1, null,
+                value => SetStorageValue(snapshot, NativeContract.Oracle.Id, OraclePricePrefix, value));
+            changed |= ApplyBigIntegerSetting(chain, PolicyNetworkFeePerByteSetting, 0, 1_00000000,
+                value => SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyFeePerBytePrefix, value));
+            changed |= ApplyUIntSetting(chain, PolicyStorageFeeFactorSetting, 1, PolicyContract.MaxStoragePrice,
+                value => SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyStoragePricePrefix, value));
+            changed |= ApplyUIntSetting(chain, PolicyExecutionFeeFactorSetting, 1, (uint)PolicyContract.MaxExecFeeFactor,
+                value =>
+                {
+                    var storageValue = settings.IsHardforkEnabled(Hardfork.HF_Faun, currentIndex)
+                        ? (BigInteger)value * ApplicationEngine.FeeFactor
+                        : value;
+                    SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyExecFeeFactorPrefix, storageValue);
+                });
+            if (settings.IsHardforkEnabled(Hardfork.HF_Echidna, currentIndex))
+            {
+                changed |= ApplyUIntSettingOrProtocolValue(chain, PolicyMillisecondsPerBlockSetting, ProtocolMillisecondsPerBlockSetting,
+                    settings.MillisecondsPerBlock, ProtocolSettings.Default.MillisecondsPerBlock, 1, PolicyContract.MaxMillisecondsPerBlock,
+                    value => SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyMillisecondsPerBlockPrefix, value));
+                changed |= ApplyTraceableBlockSettings(chain, snapshot, settings);
+            }
+
+            if (changed)
+            {
+                snapshot.Commit();
+            }
+
+            return changed;
+
+            static bool ApplyBigIntegerSetting(ExpressChain chain, string setting, BigInteger min, BigInteger? max, Action<BigInteger> apply)
+            {
+                if (!TryReadSetting<BigInteger>(chain, setting, TryParseBigInteger, out var value)
+                    || value < min
+                    || (max.HasValue && value > max.Value))
+                {
+                    return false;
+                }
+
+                apply(value);
+                return true;
+            }
+
+            static bool ApplyUIntSetting(ExpressChain chain, string setting, uint min, uint max, Action<uint> apply)
+            {
+                if (!TryReadSetting<uint>(chain, setting, uint.TryParse, out var value)
+                    || value < min
+                    || value > max)
+                {
+                    return false;
+                }
+
+                apply(value);
+                return true;
+            }
+
+            static bool TryParseBigInteger(string value, [MaybeNullWhen(false)] out BigInteger parsedValue)
+                => BigInteger.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedValue);
+
+            static void SetStorageValue(DataCache snapshot, int contractId, byte prefix, BigInteger value)
+                => snapshot.GetAndChange(StorageKey.Create(contractId, prefix), () => new StorageItem())!.Set(value);
+
+            static void SetIndexedStorage(DataCache snapshot, int contractId, byte prefix, uint index, BigInteger value)
+                => snapshot.GetAndChange(StorageKey.Create(contractId, prefix, index), () => new StorageItem())!.Set(value);
+
+            static bool ApplyUIntSettingOrProtocolValue(
+                ExpressChain chain,
+                string policySetting,
+                string protocolSetting,
+                uint protocolValue,
+                uint defaultProtocolValue,
+                uint min,
+                uint max,
+                Action<uint> apply)
+            {
+                if (chain.Settings.ContainsKey(policySetting))
+                {
+                    return ApplyUIntSetting(chain, policySetting, min, max, apply);
+                }
+
+                if ((chain.Settings.ContainsKey(protocolSetting) || protocolValue != defaultProtocolValue)
+                    && protocolValue >= min
+                    && protocolValue <= max)
+                {
+                    apply(protocolValue);
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool ApplyTraceableBlockSettings(ExpressChain chain, DataCache snapshot, ProtocolSettings settings)
+            {
+                var maxValidUntilBlockIncrement = GetUIntPolicyOrProtocolValue(
+                    chain,
+                    PolicyMaxValidUntilBlockIncrementSetting,
+                    ProtocolMaxValidUntilBlockIncrementSetting,
+                    settings.MaxValidUntilBlockIncrement,
+                    ProtocolSettings.Default.MaxValidUntilBlockIncrement,
+                    1,
+                    PolicyContract.MaxMaxValidUntilBlockIncrement);
+                var maxTraceableBlocks = GetUIntPolicyOrProtocolValue(
+                    chain,
+                    PolicyMaxTraceableBlocksSetting,
+                    ProtocolMaxTraceableBlocksSetting,
+                    settings.MaxTraceableBlocks,
+                    ProtocolSettings.Default.MaxTraceableBlocks,
+                    1,
+                    PolicyContract.MaxMaxTraceableBlocks);
+
+                if (maxValidUntilBlockIncrement is null && maxTraceableBlocks is null)
+                {
+                    return false;
+                }
+
+                var resultingMaxValidUntilBlockIncrement = maxValidUntilBlockIncrement
+                    ?? NativeContract.Policy.GetMaxValidUntilBlockIncrement(snapshot);
+                var resultingMaxTraceableBlocks = maxTraceableBlocks
+                    ?? NativeContract.Policy.GetMaxTraceableBlocks(snapshot);
+                if (resultingMaxValidUntilBlockIncrement >= resultingMaxTraceableBlocks)
+                {
+                    return false;
+                }
+
+                var changed = false;
+                if (maxValidUntilBlockIncrement is not null)
+                {
+                    SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyMaxValidUntilBlockIncrementPrefix,
+                        maxValidUntilBlockIncrement.Value);
+                    changed = true;
+                }
+                if (maxTraceableBlocks is not null)
+                {
+                    SetStorageValue(snapshot, NativeContract.Policy.Id, PolicyMaxTraceableBlocksPrefix,
+                        maxTraceableBlocks.Value);
+                    changed = true;
+                }
+                return changed;
+            }
+
+            static uint? GetUIntPolicyOrProtocolValue(
+                ExpressChain chain,
+                string policySetting,
+                string protocolSetting,
+                uint protocolValue,
+                uint defaultProtocolValue,
+                uint min,
+                uint max)
+            {
+                if (chain.Settings.ContainsKey(policySetting))
+                {
+                    return TryReadSetting<uint>(chain, policySetting, uint.TryParse, out var policyValue)
+                        && policyValue >= min
+                        && policyValue <= max
+                        ? policyValue
+                        : null;
+                }
+
+                return (chain.Settings.ContainsKey(protocolSetting) || protocolValue != defaultProtocolValue)
+                    && protocolValue >= min
+                    && protocolValue <= max
+                    ? protocolValue
+                    : null;
+            }
+        }
+
+        delegate bool TryParse<T>(string value, [MaybeNullWhen(false)] out T parsedValue);
+
+        static bool TryReadSetting<T>(ExpressChain chain, string setting, TryParse<T> tryParse, [MaybeNullWhen(false)] out T value)
+        {
+            if (chain.Settings.TryGetValue(setting, out var stringValue)
+                && tryParse(stringValue, out var result))
+            {
+                value = result;
+                return true;
+            }
+
+            value = default;
+            return false;
         }
 
         public static ExpressWallet GetWallet(this ExpressChain chain, string name)

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -373,6 +373,10 @@ namespace NeoExpress
                         using var rpcServerPlugin = new ExpressRpcServerPlugin(CreateRpcServerSettings(chain, node),
                             expressStorage, multiSigAccount.ScriptHash);
                         using var neoSystem = new Neo.NeoSystem(ProtocolSettings, storeProvider.Name);
+                        using (var snapshot = neoSystem.GetSnapshotCache())
+                        {
+                            chain.ApplyNativePolicySettings(snapshot, ProtocolSettings);
+                        }
 
                         neoSystem.StartNode(new Neo.Network.P2P.ChannelsConfig
                         {

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -72,6 +72,10 @@ namespace NeoExpress.Node
 
             persistencePlugin = new ExpressPersistencePlugin();
             neoSystem = new NeoSystem(settings, storeProvider, null);
+            using (var snapshot = neoSystem.GetSnapshotCache())
+            {
+                chain.ApplyNativePolicySettings(snapshot, settings);
+            }
 
             ApplicationEngine.InstanceHandler += OnApplicationEngineCreated;
         }

--- a/test/test.bctklib/ExpressChainSettingsTests.cs
+++ b/test/test.bctklib/ExpressChainSettingsTests.cs
@@ -15,6 +15,7 @@ using Neo.BlockchainToolkit.Models;
 using Neo.BlockchainToolkit.Persistence;
 using Neo.BlockchainToolkit.SmartContract;
 using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.Persistence.Providers;
 using Neo.SmartContract;
@@ -149,6 +150,34 @@ namespace test.bctklib
             snapshot.GetTimePerBlock(settings).Should().Be(TimeSpan.FromSeconds(7));
             snapshot.GetMaxValidUntilBlockIncrement(settings).Should().Be(100);
             snapshot.GetMaxTraceableBlocks(settings).Should().Be(1000);
+        }
+
+        [Fact]
+        public void apply_native_policy_settings_updates_echidna_policy_values_from_policy_settings()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["protocol.Hardforks.HF_Echidna"] = "0";
+            chain.Settings["protocol.MillisecondsPerBlock"] = "7000";
+            chain.Settings["policy.MillisecondsPerBlock"] = "6000";
+            chain.Settings["policy.MaxValidUntilBlockIncrement"] = "100";
+            chain.Settings["policy.MaxTraceableBlocks"] = "1000";
+            chain.Settings["policy.AttributeFee.HighPriority"] = "1234";
+            chain.Settings["policy.AttributeFee.NotaryAssisted"] = "5678";
+            chain.Settings["notary.MaxNotValidBeforeDelta"] = "40";
+            var settings = chain.GetProtocolSettings();
+
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            chain.ApplyNativePolicySettings(snapshot, settings).Should().BeTrue();
+
+            NativeContract.Policy.GetMillisecondsPerBlock(snapshot).Should().Be(6000);
+            NativeContract.Policy.GetMaxValidUntilBlockIncrement(snapshot).Should().Be(100);
+            NativeContract.Policy.GetMaxTraceableBlocks(snapshot).Should().Be(1000);
+            NativeContract.Policy.GetAttributeFeeV1(snapshot, (byte)TransactionAttributeType.HighPriority).Should().Be(1234);
+            NativeContract.Policy.GetAttributeFeeV1(snapshot, (byte)TransactionAttributeType.NotaryAssisted).Should().Be(5678);
+            NativeContract.Notary.GetMaxNotValidBeforeDelta(snapshot).Should().Be(40);
         }
 
         static BigInteger InvokeInteger(ProtocolSettings settings, DataCache snapshot, UInt160 contractHash, string operation)

--- a/test/test.bctklib/ExpressChainSettingsTests.cs
+++ b/test/test.bctklib/ExpressChainSettingsTests.cs
@@ -1,0 +1,198 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExpressChainSettingsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.Persistence;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.Extensions;
+using Neo.Persistence;
+using Neo.Persistence.Providers;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using Neo.Wallets;
+using System;
+using System.Numerics;
+using Xunit;
+
+namespace test.bctklib
+{
+    public class ExpressChainSettingsTests
+    {
+        [Fact]
+        public void get_protocol_settings_reads_protocol_settings()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["protocol.MillisecondsPerBlock"] = "7000";
+            chain.Settings["protocol.MaxTransactionsPerBlock"] = "64";
+            chain.Settings["protocol.MemoryPoolMaxTransactions"] = "500";
+            chain.Settings["protocol.MaxTraceableBlocks"] = "1000";
+            chain.Settings["protocol.MaxValidUntilBlockIncrement"] = "100";
+            chain.Settings["protocol.InitialGasDistribution"] = "123456789";
+            chain.Settings["protocol.Hardforks.HF_Faun"] = "42";
+
+            var settings = chain.GetProtocolSettings();
+
+            settings.MillisecondsPerBlock.Should().Be(7000);
+            settings.MaxTransactionsPerBlock.Should().Be(64);
+            settings.MemoryPoolMaxTransactions.Should().Be(500);
+            settings.MaxTraceableBlocks.Should().Be(1000);
+            settings.MaxValidUntilBlockIncrement.Should().Be(100);
+            settings.InitialGasDistribution.Should().Be(123456789);
+            settings.Hardforks[Hardfork.HF_Faun].Should().Be(42);
+        }
+
+        [Fact]
+        public void chain_seconds_per_block_overrides_protocol_milliseconds_per_block()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["protocol.MillisecondsPerBlock"] = "7000";
+            chain.Settings["chain.SecondsPerBlock"] = "9";
+
+            var settings = chain.GetProtocolSettings();
+
+            settings.MillisecondsPerBlock.Should().Be(9000);
+        }
+
+        [Fact]
+        public void seconds_per_block_argument_overrides_chain_settings()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["protocol.MillisecondsPerBlock"] = "7000";
+            chain.Settings["chain.SecondsPerBlock"] = "9";
+
+            var settings = chain.GetProtocolSettings(secondsPerBlock: 3);
+
+            settings.MillisecondsPerBlock.Should().Be(3000);
+        }
+
+        [Fact]
+        public void apply_native_policy_settings_updates_initial_policy_values()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["policy.GasPerBlock"] = "400000000";
+            chain.Settings["policy.MinimumDeploymentFee"] = "2000000000";
+            chain.Settings["policy.CandidateRegistrationFee"] = "200000000000";
+            chain.Settings["policy.OracleRequestFee"] = "60000000";
+            chain.Settings["policy.NetworkFeePerByte"] = "2000";
+            chain.Settings["policy.StorageFeeFactor"] = "200000";
+            chain.Settings["policy.ExecutionFeeFactor"] = "40";
+            var settings = chain.GetProtocolSettings();
+
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            chain.ApplyNativePolicySettings(snapshot, settings).Should().BeTrue();
+
+            NativeContract.NEO.GetGasPerBlock(snapshot).Should().Be(400000000);
+            InvokeInteger(settings, snapshot, NativeContract.ContractManagement.Hash, "getMinimumDeploymentFee")
+                .Should().Be(2000000000);
+            NativeContract.NEO.GetRegisterPrice(snapshot).Should().Be(200000000000);
+            NativeContract.Oracle.GetPrice(snapshot).Should().Be(60000000);
+            NativeContract.Policy.GetFeePerByte(snapshot).Should().Be(2000);
+            NativeContract.Policy.GetStoragePrice(snapshot).Should().Be(200000);
+            using var engine = new TestApplicationEngine(snapshot, settings);
+            NativeContract.Policy.GetExecFeeFactor(engine).Should().Be(40);
+        }
+
+        [Fact]
+        public void apply_native_policy_settings_ignores_invalid_policy_values()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["policy.NetworkFeePerByte"] = "-1";
+            chain.Settings["policy.StorageFeeFactor"] = "0";
+            chain.Settings["policy.ExecutionFeeFactor"] = "101";
+            var settings = chain.GetProtocolSettings();
+
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            chain.ApplyNativePolicySettings(snapshot, settings).Should().BeFalse();
+
+            NativeContract.Policy.GetFeePerByte(snapshot).Should().Be(PolicyContract.DefaultFeePerByte);
+            NativeContract.Policy.GetStoragePrice(snapshot).Should().Be(PolicyContract.DefaultStoragePrice);
+            using var engine = new TestApplicationEngine(snapshot, settings);
+            NativeContract.Policy.GetExecFeeFactor(engine).Should().Be(PolicyContract.DefaultExecFeeFactor);
+        }
+
+        [Fact]
+        public void apply_native_policy_settings_updates_echidna_policy_values_from_protocol_settings()
+        {
+            var chain = CreateExpressChain();
+            chain.Settings["protocol.Hardforks.HF_Echidna"] = "0";
+            chain.Settings["protocol.MillisecondsPerBlock"] = "7000";
+            chain.Settings["protocol.MaxValidUntilBlockIncrement"] = "100";
+            chain.Settings["protocol.MaxTraceableBlocks"] = "1000";
+            var settings = chain.GetProtocolSettings();
+
+            using var store = new MemoryStore();
+            store.EnsureLedgerInitialized(settings);
+            using var snapshot = new StoreCache(store.GetSnapshot());
+
+            chain.ApplyNativePolicySettings(snapshot, settings).Should().BeTrue();
+
+            NativeContract.Policy.GetMillisecondsPerBlock(snapshot).Should().Be(7000);
+            NativeContract.Policy.GetMaxValidUntilBlockIncrement(snapshot).Should().Be(100);
+            NativeContract.Policy.GetMaxTraceableBlocks(snapshot).Should().Be(1000);
+            snapshot.GetTimePerBlock(settings).Should().Be(TimeSpan.FromSeconds(7));
+            snapshot.GetMaxValidUntilBlockIncrement(settings).Should().Be(100);
+            snapshot.GetMaxTraceableBlocks(settings).Should().Be(1000);
+        }
+
+        static BigInteger InvokeInteger(ProtocolSettings settings, DataCache snapshot, UInt160 contractHash, string operation)
+        {
+            using var builder = new ScriptBuilder();
+            builder.EmitDynamicCall(contractHash, operation);
+            using var engine = ApplicationEngine.Run(
+                script: builder.ToArray(),
+                snapshot: snapshot,
+                settings: settings);
+
+            engine.State.Should().Be(VMState.HALT);
+            engine.ResultStack.Should().HaveCount(1);
+            return engine.ResultStack.Pop().GetInteger();
+        }
+
+        static ExpressChain CreateExpressChain()
+        {
+            var key = new KeyPair(Convert.FromHexString("2A79CFA210832EB7139C36168E415DC78E2649EA7735060BF1DAE04C05050A98"));
+            return new ExpressChain
+            {
+                Network = 0x334F454Eu,
+                AddressVersion = ProtocolSettings.Default.AddressVersion,
+                ConsensusNodes =
+                [
+                    new ExpressConsensusNode
+                    {
+                        TcpPort = 50013,
+                        RpcPort = 50012,
+                        Wallet = new ExpressWallet
+                        {
+                            Name = "node1",
+                            Accounts =
+                            [
+                                new ExpressWalletAccount
+                                {
+                                    PrivateKey = key.PrivateKey.ToHexString(),
+                                    IsDefault = true,
+                                },
+                            ],
+                        },
+                    },
+                ],
+            };
+        }
+    }
+}

--- a/test/test.workflowvalidation/OfflineNodeSettingsTests.cs
+++ b/test/test.workflowvalidation/OfflineNodeSettingsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OfflineNodeSettingsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using NeoExpress;
+using NeoExpress.Node;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+// mutates global Neo plugin state, so keep it isolated with the other OfflineNode tests
+[Collection("OfflineNodeDispose")]
+public class OfflineNodeSettingsTests
+{
+    [Fact]
+    public async Task offline_node_applies_initial_policy_settings()
+    {
+        var chain = ExpressChainManagerFactory.CreateChain(1, null);
+        chain.Settings["policy.MinimumDeploymentFee"] = "2000000000";
+        chain.Settings["policy.NetworkFeePerByte"] = "2000";
+        chain.Settings["policy.StorageFeeFactor"] = "200000";
+        chain.Settings["policy.ExecutionFeeFactor"] = "40";
+        var settings = chain.GetProtocolSettings();
+        var nodePath = Path.Combine(Path.GetTempPath(), $"neo-express-offline-node-settings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(nodePath);
+        try
+        {
+            using var node = new OfflineNode(
+                settings,
+                new RocksDbExpressStorage(nodePath),
+                chain.ConsensusNodes[0].Wallet,
+                chain,
+                enableTrace: false);
+
+            var policy = await node.GetPolicyAsync();
+
+            policy.MinimumDeploymentFee.Value.Should().Be(2000000000);
+            policy.NetworkFeePerByte.Value.Should().Be(2000);
+            policy.StorageFeeFactor.Should().Be(200000);
+            policy.ExecutionFeeFactor.Should().Be(40);
+        }
+        finally
+        {
+            if (Directory.Exists(nodePath))
+                Directory.Delete(nodePath, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `.neo-express` settings for Neo `ProtocolSettings` scalar values.
- Add genesis-time native policy initialization for policy values such as network fee per byte, storage fee factor, execution fee factor, minimum deployment fee, and related policy parameters.
- Apply initial policy values during online and offline node creation before the node starts, and document the supported settings.

## Validation
- `dotnet test test/test.bctklib/test.bctklib.csproj --filter "FullyQualifiedName~ExpressChainSettingsTests" --no-restore`
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --filter "FullyQualifiedName~ExpressChainManagerSettingsTests|FullyQualifiedName~OfflineNodeDisposeTests|FullyQualifiedName~OfflineNodeSettingsTests" --no-restore`
- `dotnet build src/neoxp/neoxp.csproj --no-restore`
- `dotnet build src/bctklib/bctklib.csproj --no-restore`
- `git diff --check`