### PR TITLE
Update Neo dependencies to 3.10.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,14 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fix releases, but
 may not exactly match a publicly released version.
 
+## [3.10.1] - 2026-07-09
+
+### Changed
+
+* Updated to Neo 3.10.1
+* Updated Neo module dependencies to 3.10.1 where matching packages are available
+* Kept Neo.Consensus.DBFT at 3.10.0 because its 3.10.1 package depends on an unpublished Neo.ConsoleService 3.10.1 package
+
 ## [3.10.0] - 2026-06-15
 
 ### Changed

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-enable -->
 # Neo-Express N3 Command Reference
 
-> Note: This is the command reference for Neo-Express 3.10.0, targeting N3.
+> Note: This is the command reference for Neo-Express 3.10.1, targeting N3.
 >
 > You can pass -?|-h|--help to show a list of supported commands or to show
 > help information about a specific command.

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -31,7 +31,7 @@ compile and drops `<name>.nef`, `<name>.manifest.json` and `<name>.nefdbgnfo` un
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
-    <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>
 ```
@@ -77,9 +77,9 @@ project ([`samples/test/contract-test.csproj`](../samples/test/contract-test.csp
 </ItemGroup>
 <ItemGroup>
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-  <PackageReference Include="Neo.Assertions" Version="3.10.0" />
-  <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
-  <PackageReference Include="Neo.Test.Harness" Version="3.10.0" />
+  <PackageReference Include="Neo.Assertions" Version="3.10.1" />
+  <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
+  <PackageReference Include="Neo.Test.Harness" Version="3.10.1" />
   <PackageReference Include="xunit" Version="2.4.2" />
   <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
 </ItemGroup>

--- a/extensions/neodebug-vscode/package.json
+++ b/extensions/neodebug-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "neo-contract-debug",
   "displayName": "Neo Smart Contract Debugger",
   "description": "Source-level, time-travel debugger for Neo N3 smart contracts, powered by the neodebug (Neo.Debug) tool.",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "publisher": "neo-project",
   "license": "MIT",
   "repository": {

--- a/extentions/neo3-visual-tracker/CHANGELOG.md
+++ b/extentions/neo3-visual-tracker/CHANGELOG.md
@@ -6,6 +6,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [3.10.1] - 2026-07-09
+
+### Changed
+
+* Update Neo Express to 3.10.1 for Neo 3.10.1 compatibility
+* Align extension version with Neo 3.10.1 release
+
 ## [3.10.0] - 2026-06-15
 
 ### Changed

--- a/extentions/neo3-visual-tracker/package-lock.json
+++ b/extentions/neo3-visual-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neo3-visual-tracker",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neo3-visual-tracker",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "dependencies": {
         "@vscode/vsce": "^3.6.2"
       },

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -3,7 +3,7 @@
   "publisher": "ngd-seattle",
   "displayName": "Neo N3 Visual DevTracker",
   "description": "A Neo N3 blockchain explorer that is directly available within Visual Studio Code",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "icon": "resources/neo-logo.png",
   "galleryBanner": {
     "color": "#242424",

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/dotnet-tools.json
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "neo.express": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "commands": [
         "neoxp"
       ]

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
-    <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
@@ -18,9 +18,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Neo.Assertions" Version="3.10.0" />
-    <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
-    <PackageReference Include="Neo.Test.Harness" Version="3.10.0" />
+    <PackageReference Include="Neo.Assertions" Version="3.10.1" />
+    <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
+    <PackageReference Include="Neo.Test.Harness" Version="3.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/extentions/neo3-visual-tracker/version.json
+++ b/extentions/neo3-visual-tracker/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"

--- a/samples/src/contract.csproj
+++ b/samples/src/contract.csproj
@@ -4,7 +4,7 @@
     <NeoExpressBatchFile>../express.batch</NeoExpressBatchFile>
     <Nullable>enable</Nullable>
     <TargetFramework>net10.0</TargetFramework>
-    <NeoTestVersion>3.10.0</NeoTestVersion>
+    <NeoTestVersion>3.10.1</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />

--- a/samples/test/contract-test.csproj
+++ b/samples/test/contract-test.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>ContractTests</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
-    <NeoTestVersion>3.10.0</NeoTestVersion>
+    <NeoTestVersion>3.10.1</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
     <NeoContractReference Include="..\src\contract.csproj" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,8 +17,8 @@
         <ApplicationIcon>../neo-cli.ico</ApplicationIcon>
     </PropertyGroup>
     <PropertyGroup>
-        <NeoVersion>3.10.0</NeoVersion>
-        <NeoModuleVersion>3.10.0</NeoModuleVersion>
+        <NeoVersion>3.10.1</NeoVersion>
+        <NeoModuleVersion>3.10.1</NeoModuleVersion>
         <NeoConsensusDbftVersion>3.10.0</NeoConsensusDbftVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/neoxp/Extensions/PolicyExecutionFeeExtensions.cs
+++ b/src/neoxp/Extensions/PolicyExecutionFeeExtensions.cs
@@ -18,7 +18,7 @@ namespace NeoExpress
         internal static ulong GetScaledExecFeeFactorArgument(uint logicalFactor, bool isFaunEnabled)
         {
             return isFaunEnabled
-                ? (ulong)logicalFactor * ApplicationEngine.FeeFactor
+                ? (ulong)(logicalFactor * ApplicationEngine.FeeFactor)
                 : (ulong)logicalFactor;
         }
 

--- a/test/test.bctklib/test.bctklib.csproj
+++ b/test/test.bctklib/test.bctklib.csproj
@@ -16,7 +16,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="Neo.Plugins.Storage.RocksDBStore" Version="3.10.0" />
+        <PackageReference Include="Neo.Plugins.Storage.RocksDBStore" Version="3.10.1" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
         <PackageReference Include="Xunit.Combinatorial" Version="2.0.24" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/test/test.workflowvalidation/PolicyExecutionFeeScalingTests.cs
+++ b/test/test.workflowvalidation/PolicyExecutionFeeScalingTests.cs
@@ -34,7 +34,7 @@ public class PolicyExecutionFeeScalingTests
         PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(logical, faun).Should().Be(expected);
         logical.Should().BeLessOrEqualTo(100u, "Neo Policy MaxExecFeeFactor is 100 for the logical factor");
         if (faun)
-            expected.Should().Be((ulong)logical * ApplicationEngine.FeeFactor);
+            expected.Should().Be((ulong)(logical * ApplicationEngine.FeeFactor));
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class PolicyExecutionFeeScalingTests
         var policy = CreatePolicyValues(executionFeeFactor: 42);
         PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(policy, isFaunEnabled: false).Should().Be(42u);
         PolicyExecutionFeeExtensions.GetScaledExecFeeFactorArgument(policy, isFaunEnabled: true)
-            .Should().Be(42u * ApplicationEngine.FeeFactor);
+            .Should().Be((ulong)(42u * ApplicationEngine.FeeFactor));
     }
 
     /// <summary>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+(?:\\.\\d+)?)$"


### PR DESCRIPTION
## Summary

- Update Neo-Express version metadata to 3.10.1.
- Update Neo core, module, RpcServer, RocksDBStore, samples, docs, and VS Code extension templates for Neo 3.10.1 compatibility.
- Adapt execution fee scaling code to Neo 3.10.1 where `ApplicationEngine.FeeFactor` is now a `BigInteger`.

`Neo.Consensus.DBFT` is intentionally kept at 3.10.0. The 3.10.1 package currently depends on `Neo.ConsoleService` 3.10.1, but that package version is not available on NuGet.org, so using DBFT 3.10.1 makes the solution fail restore.

`Neo.SmartContract.Framework` and `neo.compiler.csharp` remain at 3.10.0 because matching 3.10.1 packages are not currently published.

## Validation

- `dotnet restore neo-express.sln --verbosity minimal`
- `dotnet build neo-express.sln --configuration Release --no-restore --verbosity minimal`
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter "FullyQualifiedName~PolicyExecutionFeeScalingTests" --no-restore --verbosity normal`
- `dotnet test test/test.bctklib/test.bctklib.csproj --configuration Release --no-restore --verbosity minimal`
- `dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-restore --verbosity minimal`
- `dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity diagnostic`
- `git diff --check`
