### PR TITLE
Allow configuring Neo-WorkNet run ports

### DIFF
--- a/docs/worknet-command-reference.md
+++ b/docs/worknet-command-reference.md
@@ -155,7 +155,7 @@ Runs the branched blockchain locally. New blocks will be added to the chain ever
 overridden with the `--seconds-per-block` option.
 
 The node listens on RPC port `30332` and TCP port `30333` by default. Use `--rpc-port` and `--tcp-port`
-when those ports are already in use by another local node.
+when those ports are already in use by another local node. The RPC and TCP ports must be different.
 
 These new blocks added to the chain have *no* correlation to the blocks added to the public chain that
 was branched from. From the point of the branch, the original source chain and the local branched chain

--- a/docs/worknet-command-reference.md
+++ b/docs/worknet-command-reference.md
@@ -144,6 +144,8 @@ Usage: neo-worknet run [options]
 
 Options:
   -s|--seconds-per-block <SECONDS_PER_BLOCK>  Time between blocks
+  --rpc-port <PORT>                           RPC server port
+  --tcp-port <PORT>                           TCP server port
   --disable-log                               Disable verbose data logging
   -?|-h|--help                                Show help information.
   --input                                     Path to .neo-worknet data file
@@ -151,6 +153,9 @@ Options:
 
 Runs the branched blockchain locally. New blocks will be added to the chain every 15 seconds unless
 overridden with the `--seconds-per-block` option.
+
+The node listens on RPC port `30332` and TCP port `30333` by default. Use `--rpc-port` and `--tcp-port`
+when those ports are already in use by another local node.
 
 These new blocks added to the chain have *no* correlation to the blocks added to the public chain that
 was branched from. From the point of the branch, the original source chain and the local branched chain

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -27,6 +27,9 @@ namespace NeoWorkNet.Commands;
 [Command("run", Description = "Run Neo-WorkNet instance node")]
 partial class RunCommand
 {
+    internal const ushort DEFAULT_RPC_PORT = 30332;
+    internal const ushort DEFAULT_TCP_PORT = 30333;
+
     readonly IFileSystem fs;
 
     public RunCommand(IFileSystem fs)
@@ -36,6 +39,12 @@ partial class RunCommand
 
     [Option(Description = "Time between blocks")]
     internal uint? SecondsPerBlock { get; }
+
+    [Option("--rpc-port <PORT>", Description = "RPC server port")]
+    internal ushort RpcPort { get; } = DEFAULT_RPC_PORT;
+
+    [Option("--tcp-port <PORT>", Description = "TCP server port")]
+    internal ushort TcpPort { get; } = DEFAULT_TCP_PORT;
 
     [Option("--disable-log", Description = "Disable verbose data logging")]
     internal bool DisableLog { get; set; }
@@ -49,8 +58,11 @@ partial class RunCommand
             if (!fs.Directory.Exists(dataDir))
                 throw new Exception($"Cannot locate data directory {dataDir}");
 
+            ValidatePort(RpcPort, nameof(RpcPort));
+            ValidatePort(TcpPort, nameof(TcpPort));
+
             var secondsPerBlock = SecondsPerBlock ?? 0;
-            await RunAsync(worknet, dataDir, secondsPerBlock, DisableLog, console, token).ConfigureAwait(false);
+            await RunAsync(worknet, dataDir, secondsPerBlock, RpcPort, TcpPort, DisableLog, console, token).ConfigureAwait(false);
             return 0;
         }
         catch (Exception ex)
@@ -60,7 +72,7 @@ partial class RunCommand
         }
     }
 
-    internal static ProtocolSettings GetProtocolSettings(WorknetFile worknetFile, uint secondsPerBlock = 0)
+    internal static ProtocolSettings GetProtocolSettings(WorknetFile worknetFile, uint secondsPerBlock = 0, ushort tcpPort = DEFAULT_TCP_PORT)
     {
         var account = worknetFile.ConsensusWallet.GetAccounts().Single();
         var key = account.GetKey() ?? throw new Exception();
@@ -69,11 +81,27 @@ partial class RunCommand
             MillisecondsPerBlock = secondsPerBlock == 0 ? 15000 : secondsPerBlock * 1000,
             ValidatorsCount = 1,
             StandbyCommittee = new ECPoint[] { key.PublicKey },
-            SeedList = new string[] { $"{System.Net.IPAddress.Loopback}:{30333}" }
+            SeedList = new string[] { $"{System.Net.IPAddress.Loopback}:{tcpPort}" }
         };
     }
 
-    static async Task RunAsync(WorknetFile worknet, string dataDir, uint secondsPerBlock, bool disableLog, IConsole console, CancellationToken token)
+    internal static RpcServersSettings GetRpcServerSettings(WorknetFile worknet, ushort rpcPort)
+    {
+        ValidatePort(rpcPort, nameof(rpcPort));
+
+        var settings = new Dictionary<string, string>()
+            {
+                { "PluginConfiguration:Network", $"{worknet.BranchInfo.Network}" },
+                { "PluginConfiguration:BindAddress", $"{IPAddress.Loopback}" },
+                { "PluginConfiguration:Port", $"{rpcPort}" },
+                { "PluginConfiguration:SessionEnabled", $"{true}"}
+            };
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        return RpcServersSettings.Load(config.GetSection("PluginConfiguration"));
+    }
+
+    static async Task RunAsync(WorknetFile worknet, string dataDir, uint secondsPerBlock, ushort rpcPort, ushort tcpPort, bool disableLog, IConsole console, CancellationToken token)
     {
         var tcs = new TaskCompletionSource<bool>();
         _ = Task.Run(() =>
@@ -84,7 +112,7 @@ partial class RunCommand
                 using var stateStore = new StateServiceStore(worknet.Uri, worknet.BranchInfo, db, true);
                 using var trackStore = new PersistentTrackingStore(db, stateStore, true);
 
-                var protocolSettings = GetProtocolSettings(worknet, secondsPerBlock);
+                var protocolSettings = GetProtocolSettings(worknet, secondsPerBlock, tcpPort);
 
                 var storeProvider = new WorknetStorageProvider(trackStore);
                 StoreFactory.RegisterProvider(storeProvider);
@@ -93,12 +121,12 @@ partial class RunCommand
                 using var logPlugin = new WorkNetLogPlugin(console,
                     disableLog ? null : Utility.GetDiagnosticWriter(console));
                 using var dbftPlugin = new DBFTPlugin(GetConsensusSettings(worknet));
-                using var rpcServerPlugin = new WorknetRpcServerPlugin(GetRpcServerSettings(worknet), persistencePlugin, worknet.Uri);
+                using var rpcServerPlugin = new WorknetRpcServerPlugin(GetRpcServerSettings(worknet, rpcPort), persistencePlugin, worknet.Uri);
                 using var neoSystem = new NeoSystem(protocolSettings, storeProvider.Name);
 
                 neoSystem.StartNode(new Neo.Network.P2P.ChannelsConfig
                 {
-                    Tcp = new IPEndPoint(IPAddress.Loopback, 30333)
+                    Tcp = new IPEndPoint(IPAddress.Loopback, tcpPort)
                 });
                 dbftPlugin.Start(worknet.ConsensusWallet);
 
@@ -132,19 +160,11 @@ partial class RunCommand
             var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
             return new DbftSettings(config.GetSection("PluginConfiguration"));
         }
+    }
 
-        static RpcServersSettings GetRpcServerSettings(WorknetFile worknet)
-        {
-            var settings = new Dictionary<string, string>()
-                {
-                    { "PluginConfiguration:Network", $"{worknet.BranchInfo.Network}" },
-                    { "PluginConfiguration:BindAddress", $"{IPAddress.Loopback}" },
-                    { "PluginConfiguration:Port", $"{30332}" },
-                    { "PluginConfiguration:SessionEnabled", $"{true}"}
-                };
-
-            var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
-            return RpcServersSettings.Load(config.GetSection("PluginConfiguration"));
-        }
+    static void ValidatePort(ushort port, string name)
+    {
+        if (port == 0)
+            throw new ArgumentOutOfRangeException(name, "Port must be greater than zero.");
     }
 }

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -58,8 +58,7 @@ partial class RunCommand
             if (!fs.Directory.Exists(dataDir))
                 throw new Exception($"Cannot locate data directory {dataDir}");
 
-            ValidatePort(RpcPort, nameof(RpcPort));
-            ValidatePort(TcpPort, nameof(TcpPort));
+            ValidatePorts(RpcPort, TcpPort);
 
             var secondsPerBlock = SecondsPerBlock ?? 0;
             await RunAsync(worknet, dataDir, secondsPerBlock, RpcPort, TcpPort, DisableLog, console, token).ConfigureAwait(false);
@@ -166,5 +165,13 @@ partial class RunCommand
     {
         if (port == 0)
             throw new ArgumentOutOfRangeException(name, "Port must be greater than zero.");
+    }
+
+    internal static void ValidatePorts(ushort rpcPort, ushort tcpPort)
+    {
+        ValidatePort(rpcPort, nameof(rpcPort));
+        ValidatePort(tcpPort, nameof(tcpPort));
+        if (rpcPort == tcpPort)
+            throw new ArgumentException("RPC and TCP ports must be different.");
     }
 }

--- a/test/test.worknet/RunCommandPortTests.cs
+++ b/test/test.worknet/RunCommandPortTests.cs
@@ -1,0 +1,78 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RunCommandPortTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using Neo.BlockchainToolkit.Models;
+using Neo.Wallets;
+using NeoWorkNet.Commands;
+using NeoWorkNet.Models;
+using System;
+using Xunit;
+
+namespace test.worknet;
+
+public class RunCommandPortTests
+{
+    static WorknetFile CreateWorknetFile()
+    {
+        var branchInfo = new BranchInfo(
+            Network: 0x746E7535,
+            AddressVersion: ProtocolSettings.Default.AddressVersion,
+            Index: 1,
+            IndexHash: UInt256.Zero,
+            RootHash: UInt256.Zero,
+            Contracts: Array.Empty<ContractInfo>());
+
+        var wallet = new ToolkitWallet("consensus", branchInfo.ProtocolSettings);
+        var account = wallet.CreateAccount();
+        account.IsDefault = true;
+
+        return new WorknetFile(new Uri("https://seed1t5.neo.org:20331"), branchInfo, wallet);
+    }
+
+    [Fact]
+    public void get_protocol_settings_uses_default_tcp_port()
+    {
+        var settings = RunCommand.GetProtocolSettings(CreateWorknetFile());
+
+        settings.SeedList.Should().ContainSingle()
+            .Which.Should().Be($"127.0.0.1:{RunCommand.DEFAULT_TCP_PORT}");
+    }
+
+    [Fact]
+    public void get_protocol_settings_uses_custom_tcp_port()
+    {
+        const ushort tcpPort = 40333;
+
+        var settings = RunCommand.GetProtocolSettings(CreateWorknetFile(), tcpPort: tcpPort);
+
+        settings.SeedList.Should().ContainSingle()
+            .Which.Should().Be($"127.0.0.1:{tcpPort}");
+    }
+
+    [Fact]
+    public void get_rpc_server_settings_rejects_zero_port()
+    {
+        Action act = () => RunCommand.GetRpcServerSettings(CreateWorknetFile(), 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void get_rpc_server_settings_uses_custom_rpc_port()
+    {
+        const ushort rpcPort = 40332;
+
+        var settings = RunCommand.GetRpcServerSettings(CreateWorknetFile(), rpcPort);
+
+        settings.Port.Should().Be(rpcPort);
+    }
+}

--- a/test/test.worknet/RunCommandPortTests.cs
+++ b/test/test.worknet/RunCommandPortTests.cs
@@ -75,4 +75,13 @@ public class RunCommandPortTests
 
         settings.Port.Should().Be(rpcPort);
     }
+
+    [Fact]
+    public void validate_ports_rejects_shared_port()
+    {
+        Action act = () => RunCommand.ValidatePorts(40332, 40332);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("RPC and TCP ports must be different.");
+    }
 }


### PR DESCRIPTION
## Summary
- add --rpc-port and --tcp-port options to neo-worknet run
- keep the existing 30332/30333 defaults
- update the WorkNet command reference

## Validation
- dotnet test test/test.worknet/test.worknet.csproj --configuration Release --verbosity minimal
- dotnet run --project src/worknet/neoworknet.csproj --configuration Release --no-build -- run --help