### PR TITLE
Add NeoTrace timeout option

### DIFF
--- a/docs/trace-command-reference.md
+++ b/docs/trace-command-reference.md
@@ -33,6 +33,8 @@ Arguments:
 Options:
   --rpc-uri <RPC_URI>  URL of a Neo JSON-RPC node. Specify MainNet (the default),
                        TestNet, or a JSON-RPC URL.
+  --timeout <SECONDS>  Maximum tracing time in seconds. Defaults to 300. Use 0
+                       to disable the timeout.
 ```
 
 Traces every transaction in the specified block. The block can be identified by index or
@@ -55,6 +57,8 @@ Arguments:
 Options:
   --rpc-uri <RPC_URI>  URL of a Neo JSON-RPC node. Specify MainNet (the default),
                        TestNet, or a JSON-RPC URL.
+  --timeout <SECONDS>  Maximum tracing time in seconds. Defaults to 300. Use 0
+                       to disable the timeout.
 ```
 
 Traces the specified transaction. `tx` is an alias for `transaction`.

--- a/src/trace/Commands/BlockCommand.cs
+++ b/src/trace/Commands/BlockCommand.cs
@@ -55,9 +55,9 @@ namespace NeoTrace.Commands
             }
             catch (Exception ex)
             {
-                 await app.Error.WriteLineAsync(ex.Message);
+                await app.Error.WriteLineAsync(ex.Message);
             }
-            return  1;
+            return 1;
         }
 
         OneOf<uint, UInt256> ParseBlockIdentifier()

--- a/src/trace/Commands/BlockCommand.cs
+++ b/src/trace/Commands/BlockCommand.cs
@@ -59,7 +59,19 @@ namespace NeoTrace.Commands
             {
                 await app.Error.WriteLineAsync(ex.Message);
                 return 1;
+            catch (TimeoutException ex)
+            {
+                await app.Error.WriteLineAsync(ex.Message);
             }
+            catch (OperationCanceledException)
+            {
+                await app.Error.WriteLineAsync("Operation canceled");
+            }
+            catch (Exception ex)
+            {
+                 await app.Error.WriteLineAsync(ex.Message);
+            }
+            return  1;
         }
 
         OneOf<uint, UInt256> ParseBlockIdentifier()

--- a/src/trace/Commands/BlockCommand.cs
+++ b/src/trace/Commands/BlockCommand.cs
@@ -48,20 +48,6 @@ namespace NeoTrace.Commands
             catch (TimeoutException ex)
             {
                 await app.Error.WriteLineAsync(ex.Message);
-                return 1;
-            }
-            catch (OperationCanceledException)
-            {
-                await app.Error.WriteLineAsync("Operation canceled");
-                return 1;
-            }
-            catch (Exception ex)
-            {
-                await app.Error.WriteLineAsync(ex.Message);
-                return 1;
-            catch (TimeoutException ex)
-            {
-                await app.Error.WriteLineAsync(ex.Message);
             }
             catch (OperationCanceledException)
             {

--- a/src/trace/Commands/BlockCommand.cs
+++ b/src/trace/Commands/BlockCommand.cs
@@ -26,7 +26,10 @@ namespace NeoTrace.Commands
         [Option(Description = "URL of Neo JSON-RPC Node\nSpecify MainNet (default), TestNet or JSON-RPC URL")]
         internal string RpcUri { get; } = string.Empty;
 
-        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
+        [Option("--timeout <SECONDS>", Description = "Maximum tracing time in seconds. Use 0 to disable the timeout.")]
+        internal int Timeout { get; } = Program.DefaultTimeoutSeconds;
+
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
         {
             try
             {
@@ -36,8 +39,21 @@ namespace NeoTrace.Commands
                 }
                 var blockId = ParseBlockIdentifier();
 
-                await Program.TraceBlockAsync(uri, blockId, console).ConfigureAwait(false);
+                await Program.RunWithTimeoutAsync(
+                    traceToken => Program.TraceBlockAsync(uri, blockId, console, traceToken),
+                    Timeout,
+                    token).ConfigureAwait(false);
                 return 0;
+            }
+            catch (TimeoutException ex)
+            {
+                await app.Error.WriteLineAsync(ex.Message);
+                return 1;
+            }
+            catch (OperationCanceledException)
+            {
+                await app.Error.WriteLineAsync("Operation canceled");
+                return 1;
             }
             catch (Exception ex)
             {

--- a/src/trace/Commands/TransactionCommand.cs
+++ b/src/trace/Commands/TransactionCommand.cs
@@ -25,7 +25,10 @@ namespace NeoTrace.Commands
         [Option(Description = "URL of Neo JSON-RPC Node\nSpecify MainNet (default), TestNet or JSON-RPC URL")]
         internal string RpcUri { get; } = string.Empty;
 
-        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
+        [Option("--timeout <SECONDS>", Description = "Maximum tracing time in seconds. Use 0 to disable the timeout.")]
+        internal int Timeout { get; } = Program.DefaultTimeoutSeconds;
+
+        internal async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console, CancellationToken token)
         {
             try
             {
@@ -36,8 +39,21 @@ namespace NeoTrace.Commands
                 var txHash = UInt256.TryParse(TransactionHash, out var _txHash)
                     ? _txHash
                     : throw new ArgumentException($"Invalid transaction hash {TransactionHash}");
-                await Program.TraceTransactionAsync(uri, txHash, console);
+                await Program.RunWithTimeoutAsync(
+                    traceToken => Program.TraceTransactionAsync(uri, txHash, console, traceToken),
+                    Timeout,
+                    token).ConfigureAwait(false);
                 return 0;
+            }
+            catch (TimeoutException ex)
+            {
+                await app.Error.WriteLineAsync(ex.Message);
+                return 1;
+            }
+            catch (OperationCanceledException)
+            {
+                await app.Error.WriteLineAsync("Operation canceled");
+                return 1;
             }
             catch (Exception ex)
             {

--- a/src/trace/Program.cs
+++ b/src/trace/Program.cs
@@ -35,6 +35,8 @@ namespace NeoTrace
     [Subcommand(typeof(BlockCommand), typeof(TransactionCommand))]
     class Program
     {
+        internal const int DefaultTimeoutSeconds = 300;
+
         public static int Main(string[] args) => CommandLineApplication.Execute<Program>(args);
 
         int OnExecute(CommandLineApplication app, IConsole console)
@@ -45,32 +47,56 @@ namespace NeoTrace
         }
 
 
-        internal static async Task TraceBlockAsync(Uri uri, OneOf<uint, UInt256> blockId, IConsole console)
+        internal static async Task RunWithTimeoutAsync(Func<CancellationToken, Task> operation, int timeoutSeconds, CancellationToken token)
         {
+            if (timeoutSeconds < 0)
+                throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "Timeout must be greater than or equal to zero.");
+
+            using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+            if (timeoutSeconds > 0)
+                linkedTokenSource.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+            try
+            {
+                await operation(linkedTokenSource.Token).WaitAsync(linkedTokenSource.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!token.IsCancellationRequested && timeoutSeconds > 0 && linkedTokenSource.IsCancellationRequested)
+            {
+                throw new TimeoutException($"NeoTrace did not complete within {timeoutSeconds} seconds. Use --timeout 0 to disable the timeout.");
+            }
+        }
+
+        internal static async Task TraceBlockAsync(Uri uri, OneOf<uint, UInt256> blockId, IConsole console, CancellationToken token = default)
+        {
+            token.ThrowIfCancellationRequested();
             var settings = await GetProtocolSettingsAsync(uri).ConfigureAwait(false);
 
             using var rpcClient = new RpcClient(uri, protocolSettings: settings);
             var block = await GetBlockAsync(rpcClient, blockId).ConfigureAwait(false);
+            token.ThrowIfCancellationRequested();
             if (block.Transactions.Length == 0)
                 throw new Exception($"Block {block.Index} ({block.Hash}) had no transactions");
 
             await console.Out.WriteLineAsync($"Tracing all the transactions in block {block.Index} ({block.Hash})").ConfigureAwait(false);
-            await TraceBlockAsync(rpcClient, block, settings, console).ConfigureAwait(false);
+            await TraceBlockAsync(rpcClient, block, settings, console, token: token).ConfigureAwait(false);
         }
 
-        internal static async Task TraceTransactionAsync(Uri uri, UInt256 txHash, IConsole console)
+        internal static async Task TraceTransactionAsync(Uri uri, UInt256 txHash, IConsole console, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             var settings = await GetProtocolSettingsAsync(uri).ConfigureAwait(false);
 
             using var rpcClient = new RpcClient(uri, protocolSettings: settings);
             var rpcTx = await rpcClient.GetRawTransactionAsync($"{txHash}").ConfigureAwait(false);
             var block = await GetBlockAsync(rpcClient, rpcTx.BlockHash).ConfigureAwait(false);
+            token.ThrowIfCancellationRequested();
             await console.Out.WriteLineAsync($"Tracing transaction {txHash} in block {block.Index} ({block.Hash})").ConfigureAwait(false);
-            await TraceBlockAsync(rpcClient, block, settings, console, rpcTx.Transaction.Hash).ConfigureAwait(false);
+            await TraceBlockAsync(rpcClient, block, settings, console, rpcTx.Transaction.Hash, token).ConfigureAwait(false);
         }
 
-        static async Task TraceBlockAsync(RpcClient rpcClient, Block block, ProtocolSettings settings, IConsole console, UInt256? txHash = null)
+        static async Task TraceBlockAsync(RpcClient rpcClient, Block block, ProtocolSettings settings, IConsole console, UInt256? txHash = null, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             IReadOnlyStore<byte[], byte[]> roStore;
             IReadOnlyDictionary<UInt160, (int Id, string Name)>? knownContracts = null;
             if (block.Index == 0)
@@ -81,6 +107,7 @@ namespace NeoTrace
             {
                 await console.Out.WriteLineAsync($"Loading state for block {block.Index - 1}").ConfigureAwait(false);
                 var branchInfo = await StateServiceStore.GetBranchInfoAsync(rpcClient, block.Index - 1, includeContractNames: false).ConfigureAwait(false);
+                token.ThrowIfCancellationRequested();
                 await console.Out.WriteLineAsync($"Loaded {branchInfo.Contracts.Count} contracts").ConfigureAwait(false);
                 roStore = new StateServiceStore(rpcClient, branchInfo);
                 knownContracts = branchInfo.Contracts.ToDictionary(c => c.Hash, c => (c.Id, c.Name));
@@ -103,6 +130,7 @@ namespace NeoTrace
             var clonedSnapshot = snapshot.CloneCache();
             for (int i = 0; i < block.Transactions.Length; i++)
             {
+                token.ThrowIfCancellationRequested();
                 Transaction tx = block.Transactions[i];
 
                 using var engine = GetEngine(tx, clonedSnapshot);
@@ -116,6 +144,7 @@ namespace NeoTrace
                 }
 
                 var appLog = await rpcClient.GetApplicationLogAsync(tx.Hash.ToString()).ConfigureAwait(false);
+                token.ThrowIfCancellationRequested();
                 if (appLog.Executions.Count != 1)
                     throw new Exception($"Unexpected Application Log executions count. Expected 1, got {appLog.Executions.Count}");
                 var execution = appLog.Executions[0];

--- a/test/test.workflowvalidation/NeotraceTimeoutTests.cs
+++ b/test/test.workflowvalidation/NeotraceTimeoutTests.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NeotraceTimeoutTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class NeotraceTimeoutTests
+{
+    [Fact]
+    public async Task RunWithTimeoutAsync_throws_clear_timeout()
+    {
+        Func<Task> act = () => NeoTrace.Program.RunWithTimeoutAsync(
+            async token => await Task.Delay(TimeSpan.FromSeconds(10), token),
+            timeoutSeconds: 1,
+            CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<TimeoutException>();
+        exception.Which.Message.Should().Be("NeoTrace did not complete within 1 seconds. Use --timeout 0 to disable the timeout.");
+    }
+
+    [Fact]
+    public async Task RunWithTimeoutAsync_allows_timeout_to_be_disabled()
+    {
+        var completed = false;
+
+        await NeoTrace.Program.RunWithTimeoutAsync(
+            async token =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), token);
+                completed = true;
+            },
+            timeoutSeconds: 0,
+            CancellationToken.None);
+
+        completed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunWithTimeoutAsync_rejects_negative_timeout()
+    {
+        Func<Task> act = () => NeoTrace.Program.RunWithTimeoutAsync(
+            _ => Task.CompletedTask,
+            timeoutSeconds: -1,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Summary
- add --timeout to neotrace block and transaction
- default the timeout to 300 seconds and allow --timeout 0 to disable it
- surface a clear timeout error instead of waiting indefinitely
- update the trace command reference

## Validation
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --verbosity minimal --filter "Neotrace"
- dotnet run --project src/trace/neotrace.csproj --configuration Release --no-build -- transaction --help