### PR TITLE
Fix DBFT plugin settings configuration

### DIFF
--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -415,7 +415,7 @@ namespace NeoExpress
             var settings = new Dictionary<string, string>()
             {
                 { "PluginConfiguration:Network", $"{chain.Network}" },
-                { "IgnoreRecoveryLogs", "true" }
+                { "PluginConfiguration:IgnoreRecoveryLogs", "true" }
             };
 
             if (chain.TryReadSetting<long>(MaxBlockSystemFeeSetting, long.TryParse, out var maxBlockSystemFee)

--- a/src/worknet/Commands/RunCommand.cs
+++ b/src/worknet/Commands/RunCommand.cs
@@ -100,6 +100,19 @@ partial class RunCommand
         return RpcServersSettings.Load(config.GetSection("PluginConfiguration"));
     }
 
+    internal static DbftSettings GetConsensusSettings(WorknetFile worknet)
+    {
+        var settings = new Dictionary<string, string>()
+        {
+            { "PluginConfiguration:Network", $"{worknet.BranchInfo.Network}" },
+            { "PluginConfiguration:IgnoreRecoveryLogs", "true" },
+            { "PluginConfiguration:RecoveryLogs", "ConsensusState" }
+        };
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        return new DbftSettings(config.GetSection("PluginConfiguration"));
+    }
+
     static async Task RunAsync(WorknetFile worknet, string dataDir, uint secondsPerBlock, ushort rpcPort, ushort tcpPort, bool disableLog, IConsole console, CancellationToken token)
     {
         var tcs = new TaskCompletionSource<bool>();
@@ -146,19 +159,6 @@ partial class RunCommand
             }
         }, CancellationToken.None);
         await tcs.Task.ConfigureAwait(false);
-
-        static DbftSettings GetConsensusSettings(WorknetFile worknet)
-        {
-            var settings = new Dictionary<string, string>()
-            {
-                { "PluginConfiguration:Network", $"{worknet.BranchInfo.Network}" },
-                { "IgnoreRecoveryLogs", "true" },
-                { "RecoveryLogs", "ConsensusState" }
-            };
-
-            var config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
-            return new DbftSettings(config.GetSection("PluginConfiguration"));
-        }
     }
 
     static void ValidatePort(ushort port, string name)

--- a/test/test.workflowvalidation/ExpressChainManagerSettingsTests.cs
+++ b/test/test.workflowvalidation/ExpressChainManagerSettingsTests.cs
@@ -28,6 +28,14 @@ public class ExpressChainManagerSettingsTests
         settings.MaxBlockSystemFee.Should().Be(40_00000000L);
     }
 
+    [Fact]
+    public void CreateConsensusSettings_sets_ignore_recovery_logs()
+    {
+        var settings = ExpressChainManager.CreateConsensusSettings(CreateChain());
+
+        settings.IgnoreRecoveryLogs.Should().BeTrue();
+    }
+
     [Theory]
     [InlineData("not-a-number")]
     [InlineData("-1")]

--- a/test/test.worknet/RunCommandPortTests.cs
+++ b/test/test.worknet/RunCommandPortTests.cs
@@ -77,6 +77,15 @@ public class RunCommandPortTests
     }
 
     [Fact]
+    public void get_consensus_settings_configures_recovery_logs()
+    {
+        var settings = RunCommand.GetConsensusSettings(CreateWorknetFile());
+
+        settings.IgnoreRecoveryLogs.Should().BeTrue();
+        settings.RecoveryLogs.Should().Be("ConsensusState");
+    }
+
+    [Fact]
     public void validate_ports_rejects_shared_port()
     {
         Action act = () => RunCommand.ValidatePorts(40332, 40332);


### PR DESCRIPTION
Fixes DBFT plugin settings that were added outside the PluginConfiguration section.

The in-memory configuration passed to DbftSettings reads the PluginConfiguration section. neoxp was setting IgnoreRecoveryLogs at the root level, and worknet was setting both IgnoreRecoveryLogs and RecoveryLogs at the root level, so those values were silently ignored.

Changes:
- Prefix IgnoreRecoveryLogs with PluginConfiguration for neoxp.
- Prefix IgnoreRecoveryLogs and RecoveryLogs with PluginConfiguration for worknet.
- Expose worknet consensus settings construction for focused tests.
- Add regression coverage for both settings paths.

Validation:
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --filter "FullyQualifiedName~ExpressChainManagerSettingsTests" --verbosity minimal
- dotnet test test/test.worknet/test.worknet.csproj --configuration Release --filter "FullyQualifiedName~RunCommandPortTests" --verbosity minimal
- dotnet build neo-express.sln --configuration Release --no-restore --verbosity minimal
- dotnet test test/test.worknet/test.worknet.csproj --configuration Release --no-build --verbosity minimal
- dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj --configuration Release --no-build --filter "FullyQualifiedName~ExpressChainManagerSettingsTests" --verbosity minimal
- git diff --check