### PR TITLE
CI: Cache NuGet packages on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
 env:
   CONFIGURATION: 'Release'
   DOTNET_VERSION: '10.0.x'
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
 jobs:
   format:
@@ -52,6 +53,13 @@ jobs:
     - name: Nerdbank.GitVersioning
       uses: dotnet/nbgv@v0.5.1
       id: nbgv
+
+    - name: Cache NuGet Packages
+      if: matrix.os == 'windows-latest'
+      uses: actions/cache@v5.0.5
+      with:
+        path: ${{ env.NUGET_PACKAGES }}
+        key: ${{ runner.os }}-dotnet-${{ env.DOTNET_VERSION }}-nuget-${{ hashFiles('global.json', 'NuGet.Config', 'Directory.Build.props', '**/*.csproj') }}
 
     - name: Restore
       run: dotnet restore neo-express.sln


### PR DESCRIPTION
## Summary

- keep restored NuGet packages in the workflow workspace
- cache the Windows package directory with an exact dependency key
- avoid restore-key fallbacks when dependency inputs change
- limit the initial cache scope to the Windows critical path

## Validation

- `actionlint .github/workflows/test.yml`
- cold and cache-hit workflow runs passed on Windows, macOS, and Ubuntu
- the repeated Windows run restored the exact primary cache key
- Windows restore completed in about 4.8 seconds on the cache-hit run