### PR TITLE
CI: Pass release outputs with workflow artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,53 +35,21 @@ jobs:
     - name: Pack NeoExpress
       run: dotnet pack neo-express.sln --output ./dist --configuration Release --no-restore --verbosity normal
 
-    # - name: Download Express Files (Standalone)
-    #   uses: actions/download-artifact@v3
-    #   with:
-    #     name: ${{ steps.nbgv.outputs.NuGetPackageVersion }}
-    #     path: ./out
-
-    - name: Get Cache Files (osx-x64)
-      uses: actions/cache@v5.0.5
+    - name: Download Standalone Distributions
+      uses: actions/download-artifact@v8.0.1
       with:
-        path: /tmp/dist/*
-        key: osx-x64
+        path: /tmp/dist
+        pattern: standalone-*
+        merge-multiple: true
 
-    - name: Get Cache Files (osx-arm64)
-      uses: actions/cache@v5.0.5
-      with:
-        path: /tmp/dist/*
-        key: osx-arm64
-
-    - name: Get Cache Files (linux-x64)
-      uses: actions/cache@v5.0.5
-      with:
-        path: /tmp/dist/*
-        key: linux-x64
-
-    - name: Get Cache Files (linux-arm64)
-      uses: actions/cache@v5.0.5
-      with:
-        path: /tmp/dist/*
-        key: linux-arm64
-
-    - name: Get Cache Files (linux-musl-arm64)
-      uses: actions/cache@v5.0.5
-      with:
-        path: /tmp/dist/*
-        key: linux-musl-arm64
-
-    - name: Get Cache Files (win-x64)
-      uses: actions/cache@v5.0.5
-      with:
-        path: /tmp/dist/*
-        key: win-x64
-
-    - name: Get Cache Files (win-arm64)
-      uses: actions/cache@v5.0.5
-      with:
-        path: /tmp/dist/*
-        key: win-arm64
+    - name: Verify Standalone Distributions
+      shell: bash
+      run: |
+        archive_count=$(find /tmp/dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.tar.xz' -o -name '*.zip' \) | wc -l | tr -d ' ')
+        if [ "$archive_count" -ne 7 ]; then
+          echo "Expected 7 standalone distributions, found $archive_count."
+          exit 1
+        fi
 
     - name: Create Release
       uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -78,9 +78,10 @@ jobs:
         ZIP_FILE: ${{ format('{0}/Neo.Express-{1}-{2}.zip', env.DIST_PATH, matrix.runtime, steps.nbgv.outputs.NuGetPackageVersion) }}
       run: zip ${{ env.ZIP_FILE }} -r *
 
-    - name: Cache Files
-      id: cache
-      uses: actions/cache@v5.0.5
+    - name: Upload Distribution
+      uses: actions/upload-artifact@v7.0.1
       with:
+        name: standalone-${{ matrix.runtime }}
         path: ${{ env.DIST_PATH }}/*
-        key: ${{ matrix.runtime }}
+        if-no-files-found: error
+        retention-days: 1


### PR DESCRIPTION
## Summary

- upload each standalone distribution as a workflow artifact
- download all seven runtime artifacts into the release job
- verify the complete archive set before creating the release
- avoid reusing immutable cache entries as release outputs

## Validation

- `actionlint` on the changed workflows
- `git diff --check`
- combined workflow validation with the other CI changes