### PR TITLE
CI: Remove duplicate extension compilation

### DIFF
--- a/.github/workflows/pr_extension.yml
+++ b/.github/workflows/pr_extension.yml
@@ -47,10 +47,6 @@ jobs:
       working-directory: extentions/neo3-visual-tracker
       run: npm run typecheck
 
-    - name: Compile
-      working-directory: extentions/neo3-visual-tracker
-      run: npm run compile
-
     - name: Lint
       working-directory: extentions/neo3-visual-tracker
       run: npm run lint


### PR DESCRIPTION
## Summary

- remove the development webpack build from the extension PR workflow
- keep type checking, linting, unit tests, and the production VSIX build
- avoid compiling the same extension and panel entry points twice

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm test`
- `npx vsce package --no-git-tag-version`
- verified the VSIX contains `extension/deps/nxp/tools/net10.0/any/neoxp.dll`