### PR TITLE
CI: Keep policy smoke tests offline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,20 +77,8 @@ jobs:
     - name: Test Policy Command (offline) (neoxp)
       shell: bash
       run: |
-        for attempt in 1 2 3; do
-          if neoxp policy get --rpc-uri mainnet --json > mainnet-policy.json; then
-            neoxp policy sync mainnet-policy --account genesis
-            exit 0
-          fi
-
-          if [ "${attempt}" -lt 3 ]; then
-            echo "mainnet policy get failed on attempt ${attempt}; retrying..."
-            sleep 10
-          fi
-        done
-
-        echo "mainnet policy get failed after 3 attempts."
-        exit 1
+        neoxp policy get --json > local-policy.json
+        neoxp policy sync local-policy --account genesis
 
     - name: Test Wallet Command (neoxp)
       run: |


### PR DESCRIPTION
## Summary

- read policy values from the local Neo Express chain
- sync the local values back through the policy command
- remove the MainNet dependency and retry delay from the three-platform smoke test

## Validation

- `actionlint .github/workflows/test.yml`
- `neoxp create --force`
- `neoxp policy get --json > local-policy.json`
- `neoxp policy sync local-policy --account genesis`