### PR TITLE
CI: Run format within the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,30 +8,7 @@ env:
   DOTNET_VERSION: '10.0.x'
 
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v6.0.2
-      with:
-        fetch-depth: 0
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5.2.0
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Restore
-      run: dotnet restore neo-express.sln
-
-    - name: Format
-      run: |
-        dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity diagnostic
-
   build:
-    needs: [format]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -55,6 +32,10 @@ jobs:
 
     - name: Restore
       run: dotnet restore neo-express.sln
+
+    - name: Format
+      if: matrix.os == 'ubuntu-latest'
+      run: dotnet format neo-express.sln --verify-no-changes --no-restore --verbosity diagnostic
 
     - name: Build
       run: dotnet build neo-express.sln --configuration ${{ env.CONFIGURATION }} --no-restore --verbosity normal


### PR DESCRIPTION
## Summary

- run format validation in the Ubuntu matrix job after restore
- start macOS, Ubuntu, and Windows validation in parallel
- remove the separate format job and its duplicate setup and restore work

## Validation

- `actionlint .github/workflows/test.yml`
- `dotnet format neo-express.sln --verify-no-changes --no-restore`
- Release build, non-integration tests, and solution pack