### PR TITLE
Align Neo Express repository with Neo 3.10.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.109" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.8.118" PrivateAssets="all" />
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -30,7 +30,7 @@ compile and drops `<name>.nef`, `<name>.manifest.json` and `<name>.nefdbgnfo` un
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.1" />
     <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -70,7 +70,7 @@ The `chain.SecondsPerBlock` setting and the `run --seconds-per-block` option sti
 
 Protocol values are specified as unsigned integers, except `protocol.MemoryPoolMaxTransactions`,
 which is a positive integer. Hardfork names use the Neo `Hardfork` enum names, such as
-`HF_Echidna` or `HF_Faun`, and values are activation block heights.
+`HF_Echidna`, `HF_Faun`, or `HF_Huyao`, and values are activation block heights.
 
 Example usage:
 
@@ -83,7 +83,8 @@ Example usage:
     "protocol.MaxValidUntilBlockIncrement": "86400",
     "protocol.InitialGasDistribution": "5200000000000000",
     "protocol.Hardforks.HF_Echidna": "0",
-    "protocol.Hardforks.HF_Faun": "0"
+    "protocol.Hardforks.HF_Faun": "0",
+    "protocol.Hardforks.HF_Huyao": "0"
   }
 ```
 

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/.config/dotnet-tools.json
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "neo.express": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "commands": [
         "neoxp"
       ]
     },
     "neo.compiler.csharp": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "commands": [
         "nccs"
       ]

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.1" />
     <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/.config/dotnet-tools.json
+++ b/extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "neo.compiler.csharp": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "commands": [
         "nccs"
       ]

--- a/extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/Sample/SampleContract.csproj
+++ b/extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/Sample/SampleContract.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
-    <PackageReference Include="Neo.BuildTasks" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.1" />
+    <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/samples/.config/dotnet-tools.json
+++ b/samples/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "neo.express": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "commands": [
         "neoxp"
       ]
     },
     "neo.compiler.csharp": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "commands": [
         "nccs"
       ]

--- a/samples/src/contract.csproj
+++ b/samples/src/contract.csproj
@@ -7,7 +7,7 @@
     <NeoTestVersion>3.10.1</NeoTestVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Neo.SmartContract.Framework" Version="3.10.0" />
+    <PackageReference Include="Neo.SmartContract.Framework" Version="$(NeoTestVersion)" />
     <PackageReference Include="Neo.BuildTasks" Version="$(NeoTestVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/test/test.bctklib/ExpressChainSettingsTests.cs
+++ b/test/test.bctklib/ExpressChainSettingsTests.cs
@@ -41,6 +41,7 @@ namespace test.bctklib
             chain.Settings["protocol.MaxValidUntilBlockIncrement"] = "100";
             chain.Settings["protocol.InitialGasDistribution"] = "123456789";
             chain.Settings["protocol.Hardforks.HF_Faun"] = "42";
+            chain.Settings["protocol.Hardforks.HF_Huyao"] = "84";
 
             var settings = chain.GetProtocolSettings();
 
@@ -51,6 +52,7 @@ namespace test.bctklib
             settings.MaxValidUntilBlockIncrement.Should().Be(100);
             settings.InitialGasDistribution.Should().Be(123456789);
             settings.Hardforks[Hardfork.HF_Faun].Should().Be(42);
+            settings.Hardforks[Hardfork.HF_Huyao].Should().Be(84);
         }
 
         [Fact]

--- a/test/test.workflowvalidation/RepositoryVersionConsistencyTests.cs
+++ b/test/test.workflowvalidation/RepositoryVersionConsistencyTests.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RepositoryVersionConsistencyTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using System.Text.Json;
+using System.Xml.Linq;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class RepositoryVersionConsistencyTests
+{
+    [Fact]
+    public void Repository_assets_use_current_version()
+    {
+        var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+        var releaseVersion = ReadReleaseVersion(repositoryRoot);
+
+        ReadPropertyVersion(repositoryRoot, "src/Directory.Build.props", "NeoVersion")
+            .Should().Be(releaseVersion);
+        ReadPropertyVersion(repositoryRoot, "src/Directory.Build.props", "NeoModuleVersion")
+            .Should().Be(releaseVersion);
+        ReadPropertyVersion(repositoryRoot, "samples/src/contract.csproj", "NeoTestVersion")
+            .Should().Be(releaseVersion);
+        ReadPropertyVersion(repositoryRoot, "samples/test/contract-test.csproj", "NeoTestVersion")
+            .Should().Be(releaseVersion);
+
+        ReadToolVersion(repositoryRoot, "samples/.config/dotnet-tools.json", "neo.express")
+            .Should().Be(releaseVersion);
+        ReadToolVersion(repositoryRoot, "samples/.config/dotnet-tools.json", "neo.compiler.csharp")
+            .Should().Be(releaseVersion);
+        ReadToolVersion(repositoryRoot, "extentions/neo3-visual-tracker/resources/new-contract/csharp/.config/dotnet-tools.json", "neo.express")
+            .Should().Be(releaseVersion);
+        ReadToolVersion(repositoryRoot, "extentions/neo3-visual-tracker/resources/new-contract/csharp/.config/dotnet-tools.json", "neo.compiler.csharp")
+            .Should().Be(releaseVersion);
+        ReadToolVersion(repositoryRoot, "extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/.config/dotnet-tools.json", "neo.express")
+            .Should().Be(releaseVersion);
+        ReadToolVersion(repositoryRoot, "extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/.config/dotnet-tools.json", "neo.compiler.csharp")
+            .Should().Be(releaseVersion);
+
+        ReadPackageVersion(repositoryRoot, "extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt", "Neo.SmartContract.Framework")
+            .Should().Be(releaseVersion);
+        ReadPackageVersion(repositoryRoot, "extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt", "Neo.BuildTasks")
+            .Should().Be(releaseVersion);
+        ReadPackageVersion(repositoryRoot, "extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/Sample/SampleContract.csproj", "Neo.SmartContract.Framework")
+            .Should().Be(releaseVersion);
+        ReadPackageVersion(repositoryRoot, "extentions/neo3-visual-tracker/sample-workspaces/sample-workspace/Sample/SampleContract.csproj", "Neo.BuildTasks")
+            .Should().Be(releaseVersion);
+    }
+
+    private static string FindRepositoryRoot(string startPath)
+    {
+        for (var directory = new DirectoryInfo(startPath); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "version.json"))
+                && File.Exists(Path.Combine(directory.FullName, "neo-express.sln")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException($"Could not find the repository root from {startPath}.");
+    }
+
+    private static string ReadReleaseVersion(string repositoryRoot)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(repositoryRoot, "version.json")));
+        return document.RootElement.GetProperty("version").GetString()
+            ?? throw new InvalidDataException("version.json does not contain a version.");
+    }
+
+    private static string ReadToolVersion(string repositoryRoot, string relativePath, string toolName)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(repositoryRoot, relativePath)));
+        return document.RootElement
+            .GetProperty("tools")
+            .GetProperty(toolName)
+            .GetProperty("version")
+            .GetString()
+            ?? throw new InvalidDataException($"{relativePath} does not contain a version for {toolName}.");
+    }
+
+    private static string ReadPackageVersion(string repositoryRoot, string relativePath, string packageName)
+    {
+        var document = XDocument.Load(Path.Combine(repositoryRoot, relativePath));
+        return document.Descendants()
+            .Where(element => element.Name.LocalName == "PackageReference")
+            .Single(element => (string?)element.Attribute("Include") == packageName)
+            .Attribute("Version")?.Value
+            ?? throw new InvalidDataException($"{relativePath} does not contain a version for {packageName}.");
+    }
+
+    private static string ReadPropertyVersion(string repositoryRoot, string relativePath, string propertyName)
+    {
+        var document = XDocument.Load(Path.Combine(repositoryRoot, relativePath));
+        return document.Descendants()
+            .SingleOrDefault(element => element.Name.LocalName == propertyName)?.Value
+            ?? throw new InvalidDataException($"{relativePath} does not contain {propertyName}.");
+    }
+}


### PR DESCRIPTION
## Summary

- align repository samples and C# contract templates with Neo 3.10.1
- document and test HF_Huyao protocol settings compatibility
- update Nerdbank.GitVersioning to an available version
- add repository version consistency coverage

## Validation

- `dotnet format neo-express.sln --verify-no-changes --no-restore`
- `dotnet build neo-express.sln --configuration Release --no-restore`
- `dotnet test neo-express.sln --configuration Release --no-build --filter "Category!=Integration"`
- verified Neo Express create, show block, run, block production, and RPC getversion
- built and tested the smart-contract sample with 3.10.1 dependencies
- built the Visual Tracker sample workspace
- packaged the Visual Tracker VSIX for compatibility verification
- built and ran the osx-arm64 standalone executable