### PR TITLE
Improve VS Code DevTracker, official C# samples, and Neo Express deploy UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,8 @@ $RECYCLE.BIN/
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
 src/neoxp/default.neo-express
+samples/examples/**/default.neo-express
+**/.neoxp.deploy.touch
 src/trace/*.neo-trace
 src/worknet/default.neo-worknet
 src/worknet/data/*

--- a/docs/Neo Express Invocation File.md
+++ b/docs/Neo Express Invocation File.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-enable -->
 # Neo Express Contract Invocation File
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 ## Overview
 
 Neo Express uses a JSON file containing contract invocation information, which can be passed by path to the `contract invoke` neo-express command.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-enable -->
 # Neo-Express N3 Command Reference
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 > Note: This is the command reference for Neo-Express 3.10.1, targeting N3.
 >
 > You can pass -?|-h|--help to show a list of supported commands or to show

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-enable -->
 # Testing Neo Smart Contracts in C#
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 This repository ships four NuGet packages that together provide an end-to-end workflow for
 building and testing Neo N3 smart contracts from a standard `dotnet test` run — no running
 network required:
@@ -12,8 +14,9 @@ network required:
 | `Neo.Assertions` | [FluentAssertions](https://fluentassertions.com/) extensions for `StackItem`, `NotifyEventArgs` and `StorageItem` |
 | `Neo.Collector` | A VSTest data collector that reports per-instruction contract coverage in Cobertura and LCOV formats |
 
-A complete working example lives under [`samples/`](../samples): a contract project, a test
-project, and the batch file that connects them.
+A complete working example lives under [`samples/`](../samples/README.md): a contract project, a test
+project, and the batch file that connects them. Official C# starters (no unit-test projects)
+are in [`samples/examples/`](../samples/examples/README.md).
 
 ## 1. The contract project
 
@@ -25,8 +28,9 @@ compile and drops `<name>.nef`, `<name>.manifest.json` and `<name>.nefdbgnfo` un
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NeoContractName>$(AssemblyName)</NeoContractName>
+    <NeoContractName>SampleContract</NeoContractName>
     <NeoExpressBatchFile>../express.batch</NeoExpressBatchFile>
+    <NeoExpressBatchInputFile>../default.neo-express</NeoExpressBatchInputFile>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
@@ -48,6 +52,11 @@ Useful MSBuild properties understood by `Neo.BuildTasks`:
 | `NeoExpressBatchInputFile` | *(unset)* | `.neo-express` file the batch runs against |
 | `NeoExpressBatchNoReset` | `false` | Skip the chain reset that normally precedes the batch |
 
+`Neo.BuildTasks` writes a stamp under `obj/` after a successful batch. **Clean** and
+**Rebuild** delete that stamp (including the older `obj/$(Configuration)/*.neoxp.touch`
+path) so the next build resets the chain and redeploys. Incremental `dotnet build` skips
+the batch when the `.nef` and batch file have not changed.
+
 ## 2. Creating the test checkpoint
 
 Contract tests run against a **checkpoint**: a frozen snapshot of a Neo-Express chain with the
@@ -56,9 +65,13 @@ contract already deployed. The sample produces one automatically on every contra
 ([`samples/express.batch`](../samples/express.batch)):
 
 ```
-contract deploy ./src/bin/sc/contract.nef genesis
+contract deploy ./src/bin/sc/SampleContract.nef genesis
 checkpoint create ./checkpoints/contract-deployed -f
 ```
+
+The deploy path is relative to the batch file (`samples/`). The checkpoint path is relative
+to the contract project directory (`samples/src`), so the file is
+`samples/src/checkpoints/contract-deployed.neoxp-checkpoint`.
 
 The batch runs against the default `.neo-express` file, resetting the chain first, so the
 checkpoint is reproducible: genesis state, plus your contract, and nothing else. Any other
@@ -76,12 +89,12 @@ project ([`samples/test/contract-test.csproj`](../samples/test/contract-test.csp
   <NeoContractReference Include="..\src\contract.csproj" />
 </ItemGroup>
 <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   <PackageReference Include="Neo.Assertions" Version="3.10.1" />
   <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
   <PackageReference Include="Neo.Test.Harness" Version="3.10.1" />
-  <PackageReference Include="xunit" Version="2.4.2" />
-  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  <PackageReference Include="xunit" Version="2.9.3" />
+  <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
 </ItemGroup>
 ```
 
@@ -96,7 +109,7 @@ Tests bind a checkpoint to an xUnit class fixture with the `CheckpointPath` attr
 ([`samples/test/contract-tests.cs`](../samples/test/contract-tests.cs)):
 
 ```csharp
-[CheckpointPath("checkpoints/contract-deployed.neoxp-checkpoint")]
+[CheckpointPath("src/checkpoints/contract-deployed.neoxp-checkpoint")]
 public class ContractDeployedTests : IClassFixture<CheckpointFixture<ContractDeployedTests>>
 {
     readonly CheckpointFixture fixture;
@@ -115,7 +128,7 @@ public class ContractDeployedTests : IClassFixture<CheckpointFixture<ContractDep
         using var snapshot = fixture.GetSnapshot();
         using var engine = new TestApplicationEngine(snapshot, settings);
 
-        var state = engine.ExecuteScript<contract>(c => c.symbol());
+        var state = engine.ExecuteScript<SampleContract>(c => c.symbol());
 
         engine.State.Should().Be(VMState.HALT);
         engine.ResultStack.Should().HaveCount(1);
@@ -131,7 +144,7 @@ the script in-process against that snapshot: no node, no block times, millisecon
 
 Beyond executing scripts, `Neo.Test.Harness` and `Neo.Assertions` provide:
 
-- `engine.GetContractStorages<contract>()` — the contract's storage as a dictionary, with
+- `engine.GetContractStorages<SampleContract>()` — the contract's storage as a dictionary, with
   `StorageMap(prefix)` and `TryGetValue(key, out item)` helpers for drilling into storage maps;
 - signer-aware engines — `new TestApplicationEngine(snapshot, settings, signer, witnessScope)`
   runs the script as a specific account so `CheckWitness`-guarded paths can be tested;

--- a/docs/debugger-command-reference.md
+++ b/docs/debugger-command-reference.md
@@ -1,0 +1,64 @@
+<!-- markdownlint-enable -->
+# Neo Smart Contract Debugger
+
+The [Neo Smart Contract Debugger](../extensions/neodebug-vscode/README.md) VS Code extension
+registers the `neo-contract` debug type and launches [`neodebug`](../src/neodebug) (`Neo.Debug`
+global tool) as a Debug Adapter.
+
+Getting started: [getting-started.md](getting-started.md#debugger).
+
+## Install
+
+```shell
+dotnet tool install Neo.Debug -g
+```
+
+The extension runs `neodebug` from `PATH`. Override with
+`neo-contract.debugAdapterPath` in VS Code settings.
+
+Requires [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) and VS Code 1.104+.
+
+## Launch configuration
+
+Add a configuration to `.vscode/launch.json`. `program` and `invocation` are required.
+
+| Property | Meaning |
+| -------- | ------- |
+| `program` | Absolute path to the compiled `.nef`. Sibling `.manifest.json` and `.nefdbgnfo` / `.debug.json` are loaded automatically. |
+| `invocation` | Either `{ "trace-file": "<path>" }` to replay a `.neo-trace`, or `{ "operation": "<method>", "args": [ ... ] }` to deploy and run live. |
+| `return-types` | Optional cast hints for return values: `int`, `bool`, `string`, `hex`, `byte[]`, `addr`. |
+| `sourceFileMap` | Optional map from paths stored in debug info to paths on this machine. |
+| `debug-view` | `source` (default) or `disassembly`. |
+
+### Replay a recorded trace (step backward)
+
+Produce a `.neo-trace` with `neoxp contract invoke --trace` (or `neoxp run --trace`) locally,
+or with `neotrace` for a public-chain transaction ([trace-command-reference.md](trace-command-reference.md)).
+
+```jsonc
+{
+  "name": "Debug Neo contract (trace)",
+  "type": "neo-contract",
+  "request": "launch",
+  "program": "${workspaceFolder}/src/bin/sc/Nep17Contract.nef",
+  "invocation": { "trace-file": "${workspaceFolder}/traces/transaction.neo-trace" },
+  "return-types": [ "string" ]
+}
+```
+
+### Live invocation
+
+```jsonc
+{
+  "name": "Debug Neo contract (live)",
+  "type": "neo-contract",
+  "request": "launch",
+  "program": "${workspaceFolder}/src/bin/sc/Nep17Contract.nef",
+  "invocation": { "operation": "symbol", "args": [] }
+}
+```
+
+Set breakpoints in the C# contract source, then start debugging.
+
+Example contracts that emit `.nef` + `.nefdbgnfo` on `dotnet build` are under
+[`samples/examples/`](../samples/examples/README.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,195 @@
+<!-- markdownlint-enable -->
+# Getting started
+
+This is the shortest path from a clean machine to a running local Neo N3 chain with a
+contract you can invoke. Use [Visual Studio Code](#use-visual-studio-code) or the
+[command line](#use-the-command-line). Both use the same tools: Neo Express (`neoxp`),
+the C# compiler (`nccs`), and `Neo.BuildTasks`.
+
+## What you need
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) (`dotnet --list-sdks`
+  should list a `10.x` version)
+- Optional: [Visual Studio Code](https://code.visualstudio.com/Download) 1.104 or later
+- Optional: Node.js 20+ only if you load the Visual DevTracker extension from this repo
+
+On Ubuntu, install RocksDB libraries and **do not** install .NET via Snap (see
+[installation](installation.md#ubuntu)). On macOS, `brew install rocksdb`.
+
+## 1. Install Neo Express
+
+```shell
+dotnet tool install Neo.Express -g
+neoxp --version
+```
+
+This repo's samples also pin `neoxp` and `nccs` as local tools. From the `samples/` folder:
+
+```shell
+cd samples
+dotnet tool restore
+dotnet tool run neoxp -- --version
+```
+
+Full install options (release zip, Trace, WorkNet) are in [installation.md](installation.md).
+
+## 2. Create and run a local chain
+
+```shell
+neoxp create
+neoxp wallet list
+neoxp run --seconds-per-block 1
+```
+
+`neoxp create` writes `default.neo-express` in the current directory (genesis plus `node1`).
+Leave `neoxp run` in that terminal. In another terminal:
+
+```shell
+neoxp show balances genesis
+```
+
+By default a new block is minted every 15 seconds. `--seconds-per-block 1` makes transfers
+and deploys show up immediately while you are iterating.
+
+## 3. Build and deploy a contract
+
+Pick one of the following.
+
+### Option A — official templates already laid out for Neo Express
+
+From this repository:
+
+```shell
+cd samples/examples/Nep17
+dotnet build
+```
+
+Or from the repository root: `dotnet build samples/examples/Nep17`.
+
+The first build creates `default.neo-express` if it is missing, compiles
+`bin/sc/Nep17Contract.nef`, and deploys with `genesis`. This works while a local
+Neo Express instance is running (for example after **Start Neo Express** in VS Code).
+
+That chain file is separate from the `default.neo-express` in [step 2](#2-create-and-run-a-local-chain).
+
+Other starters in [`samples/examples/`](../samples/examples/README.md):
+
+| Folder | What it is |
+| ------ | ---------- |
+| `Blank` | Owner + `MyMethod` |
+| `Nep17` | NEP-17 token |
+| `Nep11` | NEP-11 NFT |
+| `Oracle` | Oracle request / response |
+| `Ownable` | Owner + `Destroy` |
+
+`dotnet clean` or `dotnet rebuild` on a contract that sets `NeoExpressBatchFile` deletes the
+batch stamp so the next build resets the chain and redeploys.
+
+The original simple sample (a `TokenContract` plus checkpoint tests) is
+[`samples/src`](../samples/src) — see [contract testing](contract-testing.md).
+
+### Option B — New contract wizard in Visual Studio Code
+
+1. Open a folder in VS Code.
+2. Open the Neo N3 Visual DevTracker view (Neo logo in the activity bar).
+3. **Quick Start** or **Smart contracts** → **New contract**.
+4. Choose **C#**, then a template: Blank, NEP-17, NEP-11, Oracle, Ownable, or Storage.
+5. Name the contract. Files land under `contracts/<name>/`.
+6. The scaffold restores tools and builds. Start the Express instance from **Blockchains**,
+   connect, then deploy from **Smart contracts**.
+
+How to load the extension from this repo is in
+[Use Visual Studio Code](#use-visual-studio-code).
+
+### Option C — `dotnet new` from Neo.SmartContract.Template
+
+```shell
+dotnet new install Neo.SmartContract.Template
+dotnet new neocontractnep17 -n MyToken -o ./MyToken
+```
+
+That template compiles with `nccs`. To get the Neo Express layout used in this repo
+(auto-compile via `Neo.BuildTasks` and deploy on build), copy a `samples/examples/*`
+project and replace the `.cs` files, or use the VS Code wizard (option B).
+
+## 4. Invoke the contract
+
+With the example chain running (`neoxp run -i samples/examples/Nep17/default.neo-express --seconds-per-block 1`):
+
+```shell
+neoxp contract run -i samples/examples/Nep17/default.neo-express Nep17Contract symbol --results
+neoxp contract run -i samples/examples/Nep17/default.neo-express Nep17Contract decimals --results
+```
+
+`--results` is a trial run (no transaction). Drop it and pass `--account genesis` to submit.
+
+Or use a `.neo-invoke.json` file:
+
+```shell
+neoxp contract invoke transfer.neo-invoke.json genesis
+```
+
+File format: [Neo Express Invocation File](Neo%20Express%20Invocation%20File.md).
+
+In VS Code, select the rocket on a workspace contract to open Contract Studio, pick a
+method, choose the signing account, and run.
+
+## 5. Reset and rebuild
+
+```shell
+# wipe chain state (keeps wallets)
+neoxp reset -f
+
+# rebuild contract + reset + redeploy (when NeoExpressBatchFile is set)
+dotnet rebuild samples/examples/Nep17
+```
+
+`Neo.BuildTasks` records a stamp under `obj/` after a successful batch. **Clean** and
+**Rebuild** delete that stamp so the batch runs again (chain reset + deploy). Incremental
+`dotnet build` skips the batch when the `.nef` and batch file have not changed.
+
+## Use Visual Studio Code
+
+### Load Visual DevTracker from this repo
+
+```shell
+cd extentions/neo3-visual-tracker
+npm install
+npm run compile
+```
+
+Then press **F5** in that folder (Extension Development Host), or:
+
+```shell
+code --extensionDevelopmentPath="<repo>/extentions/neo3-visual-tracker" "<your-workspace>"
+```
+
+The packaged extension bundles `neoxp`. A source checkout without `deps/nxp` uses `neoxp`
+from PATH (the global tool from step 1, or `dotnet tool restore` in `samples/`).
+
+Open **Quick Start** and work through: create/start Express → New contract → deploy → invoke.
+
+### Debugger
+
+Install the debugger tool and the [Neo Smart Contract Debugger](../extensions/neodebug-vscode/README.md)
+extension:
+
+```shell
+dotnet tool install Neo.Debug -g
+```
+
+Launch configurations are documented in [debugger-command-reference.md](debugger-command-reference.md).
+
+## What to read next
+
+| Doc | When |
+| --- | ---- |
+| [installation.md](installation.md) | Global tools, release zips, Ubuntu/macOS |
+| [quickstart.md](quickstart.md) | Longer CLI walkthrough (create, compile, deploy, invoke) |
+| [contract-testing.md](contract-testing.md) | `dotnet test` against a checkpoint |
+| [samples/examples/README.md](../samples/examples/README.md) | Official C# starters for Express |
+| [command-reference.md](command-reference.md) | Every `neoxp` command |
+| [settings.md](settings.md) | `.neo-express` settings (block time, AutoMine, …) |
+| [Visual DevTracker README](../extentions/neo3-visual-tracker/README.md) | VS Code UI |
+| [worknet-command-reference.md](worknet-command-reference.md) | Branch MainNet/TestNet locally |
+| [trace-command-reference.md](trace-command-reference.md) | Trace public-chain transactions |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Neo-Express Installation
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 Neo-Express ships as a set of cross-platform [.NET global tools](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools):
 
 | Package | Command | Purpose |
@@ -79,7 +81,18 @@ brew install rocksdb
 Apple Silicon is supported by both .NET and Homebrew. If you run into problems on Apple
 Silicon hardware, please [open an issue](https://github.com/neo-project/neo-express/issues).
 
+## Local tools (this repository)
+
+[`samples/.config/dotnet-tools.json`](../samples/.config/dotnet-tools.json) pins `Neo.Express`
+and `Neo.Compiler.CSharp` for the samples. From `samples/`:
+
+```shell
+dotnet tool restore
+dotnet tool run neoxp -- --version
+```
+
 ## Next steps
 
-- The [readme](../readme.md) has a quick-start guide and a command overview.
-- [settings.md](settings.md) documents the `.neo-express` configuration values.
+- **[Getting started](getting-started.md)** — create a chain, build a template contract, invoke it.
+- [quickstart.md](quickstart.md) — longer CLI walkthrough.
+- [settings.md](settings.md) — `.neo-express` configuration values.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,173 +1,125 @@
 <!-- markdownlint-enable -->
+# Neo Express quickstart
 
-# NeoExpress Quickstart
+A longer CLI walkthrough: install, create a chain, compile a C# contract, deploy, and invoke.
+For the shortest path (including VS Code), start at [getting-started.md](getting-started.md).
 
-This article is divided into the following sections: 
+Works on Windows, macOS, and Ubuntu.
 
-[Setting up a private chain using NeoExpress](#setting-up-a-private-chain-using-neoexpress)
+## 1. Install Neo Express
 
-[Writing and compiling smart contracts with NeoDevpackDotnet](#writing-and-compiling-smart-contracts-with-neodevpackdotnet)
+### .NET tool (recommended)
 
-[Deploying and invoking smart contracts using NeoExpress](#deploying-and-invoking-smart-contracts-using-NeoExpress)
+Requires [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
-The following steps are applicable to multiple system platforms, such as Windows, macOS, and Ubuntu.
+```shell
+dotnet tool install Neo.Express -g
+neoxp --version
+```
 
-## Setting up a private chain using NeoExpress
+### Release package
 
-### Install NeoExpress via Release Package
+1. Download the latest build from [neo-express releases](https://github.com/neo-project/neo-express/releases/latest).
+2. Unzip it.
+3. Run `neoxp` (`neoxp.exe` on Windows) from that directory.
 
-1. Download the latest release package from [neo-express releases](https://github.com/neo-project/neo-express/releases) for your operating system.
-2. Unzip the package on your local machine.
-3. Run the `neoxp.exe` command in the terminal from the directory where you unzipped the package
+Platform libraries (RocksDB) are listed in [installation.md](installation.md).
 
-### Usage Guide
+## 2. Create and use a private chain
 
-- Create a new local Neo network:
+```shell
+neoxp create
+neoxp wallet list
+neoxp show balances genesis
+neoxp transfer 1 gas genesis node1
+neoxp run --seconds-per-block 1
+```
 
-  ```shell
-  .\neoxp create
-  ```
+`genesis` is the consensus multi-sig that holds the genesis NEO and GAS. `node1` is the
+default consensus-node wallet.
 
-  Use this command to create a single node private chain (local blockchain network) creating both genesis wallet and node1 wallet. 
+Leave `neoxp run` going. Other commands use a second terminal in the same folder
+(where `default.neo-express` lives).
 
-- List all wallets:
+Full command list: [command-reference.md](command-reference.md).
 
-  ```shell
-  .\neoxp wallet list
-  ```
+## 3. Compile a C# contract
 
-  The `wallet list` command writes out a list of all the wallets - including consensus node wallets - 
-  along with their account addresses, private and public keys.
+This repo already has Express-ready starters. From the repository root:
 
-- Show genesis account balance:
+```shell
+dotnet build samples/examples/Nep17
+```
 
-  `genesis` to use the consensus node multi-sig account which holds the genesis NEO and GAS.
+That:
 
-  ```shell
-  .\neoxp show balances genesis
-  ```
+- restores local `neoxp` and `nccs` tools
+- compiles `Nep17Contract.nef` / `.manifest.json` to `samples/examples/Nep17/bin/sc`
+- creates `default.neo-express` next to the example if it is missing
+- resets the chain and deploys with `genesis` (`express.batch`)
 
-- Send 1 gas from genesis account to node1 account:
+| Starter | Path |
+| ------- | ---- |
+| Blank | `samples/examples/Blank` |
+| NEP-17 token | `samples/examples/Nep17` |
+| NEP-11 NFT | `samples/examples/Nep11` |
+| Oracle | `samples/examples/Oracle` |
+| Ownable | `samples/examples/Ownable` |
 
-  ```shell
-  .\neoxp transfer 1 gas genesis node1
-  ```
+Details: [samples/examples/README.md](../samples/examples/README.md).
 
-Please review the [Command Reference](command-reference.md) to get an understanding of Neo-Express capabilities.
+### Create your own contract
 
-## Writing and compiling smart contracts with NeoDevpackDotnet
+**VS Code:** Quick Start / Smart contracts → **New contract** → C# → pick Blank, NEP-17,
+NEP-11, Oracle, Ownable, or Storage.
 
-We have completed setting up the private chain and configuring the node. In this section we will walk you through configuring the environment, writing, and compiling an NEP17 contract using C#.
-
-## Installing tools
-
-Download and install [Visual Studio Code](https://code.visualstudio.com/Download)
-
-1. Download and install [.NET 10.0 SDK](https://dotnet.microsoft.com/download)
-
-2. Run the command line and enter the following command to check if you have installed SDK successfully.
-
-   ```shell
-   dotnet --list-sdks
-   ```
-
-   If there is no issue the SDK version number is displayed.
-
-## Installing contract template
-
-[Neo.SmartContract.Template](https://www.nuget.org/packages/Neo.SmartContract.Template) is a project template used when developing Neo smart contracts. After installing the template, you can create a Neo smart contract project using either the Terminal or Visual Studio.
-
-Install the template
+**Terminal:** install [Neo.SmartContract.Template](https://www.nuget.org/packages/Neo.SmartContract.Template)
+and add `Neo.BuildTasks` like the examples, or copy an example folder:
 
 ```shell
 dotnet new install Neo.SmartContract.Template
+dotnet new neocontractnep17 -n MyToken -o ./MyToken
 ```
 
-List all dotnet templates
+`dotnet build` on an example project runs `nccs` through `Neo.BuildTasks`. You can also run
+`nccs` yourself after `dotnet tool install Neo.Compiler.CSharp -g`. Output is `bin/sc/*.nef`.
+
+## 4. Deploy and invoke
+
+If you used `samples/examples/*`, the first `dotnet build` already deployed. With `neoxp run`
+in another terminal:
 
 ```shell
-dotnet new list
+neoxp contract run Nep17Contract symbol --results
 ```
 
-These default templates are available after installing [Neo.SmartContract.Template](https://www.nuget.org/packages/Neo.SmartContract.Template):
-
-- neocontractowner - Standard contract template with the Owner, including the GetOwner and SetOwner methods.
-- neocontractoracle - A contract template using OracleRequest.
-- neocontractnep17 - NEP-17 contract template, including the Mint and Burn methods.
-
-More Neo.SmartContract.Template information can be found [here](https://docs.neo.org/docs/n3/develop/write/1_dotnet.html#neosmartcontracttemplate).
-
-### Create a project using templates with Terminal
+`--results` is a dry run. To submit a transaction:
 
 ```shell
-dotnet new neocontractnep17 
+neoxp contract run Nep17Contract symbol --account genesis
 ```
 
-The project name defaults to the name of the current directory. You can also specify the project name with `-n, --name <name>`, e.g. `dotnet new neocontractnep17 -n MyFirstContract`.
-
-## Neo.Compiler.CSharp
-
-[Neo.Compiler.CSharp](https://www.nuget.org/packages/Neo.Compiler.CSharp) (nccs) is the Neo smart contract compiler that compiles the C# language into NeoVM executable OpCodes.
-
-### Install the compiler
-
-```undefined
-dotnet tool install --global Neo.Compiler.CSharp
-```
-
-### Compile the contract file with Terminal
-
-In the Terminal interface, go to the project path and run the following command to build your contract：
+Deploy a `.nef` you compiled yourself:
 
 ```shell
-dotnet build
+neoxp contract deploy ./src/bin/sc/MyToken.nef genesis
 ```
 
-or
+Reusable calls belong in a `.neo-invoke.json` file:
 
 ```shell
-nccs
+neoxp contract invoke ./invoke-files/contract.neo-invoke.json genesis
 ```
 
-Related contract files are outputted under `bin\sc` path in the contract project directory.
+See [Neo Express Invocation File](Neo%20Express%20Invocation%20File.md).
 
-More Neo.Compiler.CSharp information can be found [here](https://docs.neo.org/docs/n3/develop/write/1_dotnet.html#neocompilercsharp).
+## 5. Rebuild so the contract redeploys
 
-## Deploying and invoking smart contracts using NeoExpress
-
-Copy the smart contract file, include `*.nef` and `*.manifest.json` to the neoxp directory.
-
-### Deploy
-
-Run the following command. Note: please replace `hello.nef` with the name of your contract file.
+`Neo.BuildTasks` skips the Express batch when the `.nef` has not changed. After **Clean**
+or **Rebuild**, the stamp is deleted and the next build resets the chain and deploys again:
 
 ```shell
-> .\neoxp contract deploy hello.nef genesis
-Deployment of hello (0x4e97b0370712bf9f5f0bbb7beb5e4127fac55040) Transaction 0x5933870616f13ceb41462fbae1d460edf998defda9d5c3f074ad785465130cf7 submitted
+dotnet rebuild samples/examples/Nep17
 ```
 
-### Invoke
-
-To invoke a smart contract, use the `neoxp` run command, see [here](command-reference.md#neoxp-contract-run).
-
-The --results option indicates a trial run, which queries the results of the execution without sending a contract.
-
-```
-> .\neoxp contract run 0x4e97b0370712bf9f5f0bbb7beb5e4127fac55040 symbol --results
-VM State:     HALT
-Gas Consumed: 1364220
-Result Stack:
-  4558414d504c45(EXAMPLE)
-```
-
-"EXAMPLE" is the symbol of our test contract. 
-
-4558414d504c45 is hexadecimal little-endian string of "EXAMPLE".
-
-If we want to call the contract and send the transaction, we can execute it:
-
-```shell
-> .\neoxp contract run 0x4e97b0370712bf9f5f0bbb7beb5e4127fac55040 symbol --account genesis
-Invocation Transaction 0x1bf5b40cf217c278c331e915f6fc0e0164c7ae84113375947a529e3f2ae8411b submitted
-```
-
+Checkpoint-backed `dotnet test` workflow: [contract-testing.md](contract-testing.md).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,5 +1,7 @@
 # Neo-Express for N3 Settings Reference
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 The `.neo-express` file for Neo N3 compatible versions of N3 includes a `settings` object property. 
 This document details the values that Neo-Express reads from the `settings` object.
 

--- a/docs/trace-command-reference.md
+++ b/docs/trace-command-reference.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-enable -->
 # NeoTrace Command Reference
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 NeoTrace generates `.neo-trace` files for transactions on public Neo N3 blockchains. These
 files can be opened in the [Neo Smart Contract Debugger](https://github.com/neo-project/neo-debugger)
 to step through the recorded execution.

--- a/docs/worknet-command-reference.md
+++ b/docs/worknet-command-reference.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-enable -->
 # Neo-WorkNet Command Reference
 
+New to Neo Express? Start at [getting-started.md](getting-started.md).
+
 The `neo-worknet` tool enables a developer to create and run a Neo N3 consensus node that branches
 from a public Neo N3 blockchain - including the official Neo N3 MainNet and T5 TestNet. This provides
 the developer a local scratchpad environment that mirrors the state of a known public network at a 

--- a/extensions/neodebug-vscode/README.md
+++ b/extensions/neodebug-vscode/README.md
@@ -5,7 +5,22 @@ A source-level, time-travel debugger for Neo N3 smart contracts. This extension 
 tool (the `Neo.Debug` global tool) as a [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)
 host.
 
+Repo-wide walkthrough: [Getting started](../../docs/getting-started.md#debugger).
+Launch-configuration schema: [debugger-command-reference.md](../../docs/debugger-command-reference.md).
+
+## Getting started
+
+1. Install [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
+2. `dotnet tool install Neo.Debug -g`
+3. Build a contract that emits `.nef` and `.nefdbgnfo` (for example
+   `dotnet build samples/examples/Nep17`).
+4. Add a `neo-contract` configuration to `.vscode/launch.json` (see below).
+5. Set breakpoints in the C# source and start debugging.
+
 ## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- Visual Studio Code 1.104 or later
 
 Install the debugger tool:
 
@@ -44,8 +59,8 @@ Add a configuration to `.vscode/launch.json`. Replay a recorded trace (supports 
 ```
 
 Set breakpoints in your C# source, then start debugging. See the
-[NeoDebug command reference](../../docs/debugger-command-reference.md) for the full launch-configuration
-schema, the source/disassembly views, and debug-console expression evaluation.
+[debugger command reference](../../docs/debugger-command-reference.md) for the full launch-configuration
+schema (`return-types`, `sourceFileMap`, `debug-view`).
 
 ## Packaging
 

--- a/extensions/neodebug-vscode/package.json
+++ b/extensions/neodebug-vscode/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/neo-project/neo-express.git"
   },
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.104.0"
   },
   "categories": [
     "Debuggers"
@@ -52,7 +52,7 @@
               "program": {
                 "type": "string",
                 "description": "Absolute path to the compiled .nef file. Its sibling .manifest.json and .nefdbgnfo/.debug.json are loaded automatically.",
-                "default": "${workspaceFolder}/bin/sc/Contract.nef"
+                "default": "${workspaceFolder}/bin/sc/contract.nef"
               },
               "invocation": {
                 "type": "object",

--- a/extentions/neo3-visual-tracker/.vscode/launch.json
+++ b/extentions/neo3-visual-tracker/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Visual DevTracker",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/extentions/neo3-visual-tracker/.vscode/tasks.json
+++ b/extentions/neo3-visual-tracker/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "compile",
+      "problemMatcher": ["$tsc"],
+      "label": "npm: compile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/extentions/neo3-visual-tracker/README.md
+++ b/extentions/neo3-visual-tracker/README.md
@@ -4,8 +4,28 @@ Neo N3 Visual DevTracker brings the local Neo Express development workflow into 
 
 > This extension targets Neo N3 only. The Neo Legacy network has been shut down and is no longer supported.
 
+Repo-wide walkthrough: [Getting started](../../docs/getting-started.md).
+
+## Getting started
+
+1. Install [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) and
+   `dotnet tool install Neo.Express -g` (a packaged VSIX already bundles `neoxp`).
+2. Open a folder in VS Code. For this repo, `samples/examples/Nep17` (then `dotnet build` in the terminal) or the repo root works.
+3. Load the extension: from the Marketplace, or from source (`npm install` and `npm run compile`
+   in this directory, then **F5**, or
+   `code --extensionDevelopmentPath=<this-folder> <workspace>`).
+4. Open the Neo N3 view (logo in the activity bar) → **Quick Start**.
+5. Create or start a Neo Express instance, then **New contract**.
+6. For C#, pick a template: **Blank**, **NEP-17**, **NEP-11**, **Oracle**, **Ownable**, or
+   **Storage**. The scaffold restores tools and builds under `contracts/<name>/`.
+7. Deploy from **Smart contracts**, then open Contract Studio (rocket) to invoke.
+
+Ready-made Express layouts (no wizard) are in
+[`samples/examples/`](../../samples/examples/README.md).
+
 ## Features
 
+- Create a new C#, Python, or Java contract from the **Smart contracts** view (**New contract** button). C# starters match [Neo.SmartContract.Template](https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template) (Blank, NEP-17, NEP-11, Oracle, Ownable) plus the existing storage example.
 - Create, start, stop, reset, and restore Neo Express blockchains.
 - Create wallets, transfer assets, deploy contracts, and explore contract storage.
 - Inspect blocks, transactions, contracts, and wallets from the Neo N3 activity view.
@@ -22,7 +42,8 @@ Contract Studio keeps contract source in the normal VS Code editor while opening
 
 ### Run a contract invocation
 
-1. Open a folder containing a `.neo-express` file and a Neo smart contract project.
+1. Open a folder containing a `.neo-express` file and a Neo smart contract project
+   (`dotnet build` on `samples/examples/*` creates the chain file if it is missing).
 2. Build the contract so its `.nef`, manifest, and debug information are available.
 3. Start the blockchain from the **Blockchains** view and connect to it.
 4. In **Smart contracts**, select the rocket action on a workspace contract. You can also right-click a `.nef` file and select **Open Contract Studio**.
@@ -61,10 +82,10 @@ Open the Neo logo in the VS Code activity bar to access:
 ## Requirements
 
 - Visual Studio Code 1.104 or later.
-- A supported .NET installation available through the `dotnet` command.
-- A Neo smart contract toolchain when building C# contracts.
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) available as `dotnet` (`dotnet --version` starts with 10).
+- A Neo smart contract toolchain when building C# contracts (`Neo.SmartContract.Framework` 3.10.x).
 
-Neo Express is bundled with the extension package. The extension checks the local .NET installation before starting it.
+Neo Express 3.10 is bundled with the extension package (`neoxp.dll` under `deps/nxp`). If you are developing the extension from source without a packaged nupkg, install `dotnet tool install Neo.Express -g` so `neoxp` is on PATH. The extension checks for .NET 10 before starting it.
 
 ## Troubleshooting
 

--- a/extentions/neo3-visual-tracker/package.json
+++ b/extentions/neo3-visual-tracker/package.json
@@ -42,6 +42,7 @@
     "onCommand:neo3-visual-devtracker.express.run",
     "onCommand:neo3-visual-devtracker.express.runAdvanced",
     "onCommand:neo3-visual-devtracker.express.transfer",
+    "onCommand:neo3-visual-devtracker.express.transferNft",
     "onCommand:neo3-visual-devtracker.express.walletCreate",
     "onCommand:neo3-visual-devtracker.neo.contractDeploy",
     "onCommand:neo3-visual-devtracker.neo.invokeContract",
@@ -138,7 +139,12 @@
       },
       {
         "command": "neo3-visual-devtracker.express.transfer",
-        "title": "Transfer assets",
+        "title": "Transfer NEO, GAS, or NEP-17",
+        "category": "Neo Express N3"
+      },
+      {
+        "command": "neo3-visual-devtracker.express.transferNft",
+        "title": "Transfer NFT (NEP-11)",
         "category": "Neo Express N3"
       },
       {
@@ -164,8 +170,9 @@
       },
       {
         "command": "neo3-visual-devtracker.neo.newContract",
-        "title": "Create contract",
-        "category": "Neo N3"
+        "title": "New contract",
+        "category": "Neo N3",
+        "icon": "$(new-file)"
       },
       {
         "command": "neo3-visual-devtracker.neo.walletCreate",
@@ -209,6 +216,11 @@
     ],
     "menus": {
       "explorer/context": [
+        {
+          "command": "neo3-visual-devtracker.neo.newContract",
+          "when": "explorerResourceIsFolder",
+          "group": "navigation@2"
+        },
         {
           "command": "neo3-visual-devtracker.neo.openContractStudio",
           "when": "isFileSystemResource && resourceExtname == .nef",
@@ -270,6 +282,10 @@
           "when": "view == neo3-visual-devtracker.views.blockchains && viewItem == express"
         },
         {
+          "command": "neo3-visual-devtracker.express.transferNft",
+          "when": "view == neo3-visual-devtracker.views.blockchains && viewItem == express"
+        },
+        {
           "command": "neo3-visual-devtracker.express.walletCreate",
           "when": "view == neo3-visual-devtracker.views.blockchains && viewItem == express"
         },
@@ -307,7 +323,8 @@
         },
         {
           "command": "neo3-visual-devtracker.neo.newContract",
-          "when": "view == neo3-visual-devtracker.views.contracts"
+          "when": "view == neo3-visual-devtracker.views.contracts",
+          "group": "navigation"
         },
         {
           "command": "neo3-visual-devtracker.neo.walletCreate",
@@ -317,6 +334,10 @@
     },
     "views": {
       "neo3-visual-devtracker-mainView": [
+        {
+          "id": "neo3-visual-devtracker.views.quickStart",
+          "name": "Quick Start"
+        },
         {
           "id": "neo3-visual-devtracker.views.blockchains",
           "name": "Blockchains"
@@ -328,11 +349,6 @@
         {
           "id": "neo3-visual-devtracker.views.contracts",
           "name": "Smart contracts"
-        },
-        {
-          "id": "neo3-visual-devtracker.views.quickStart",
-          "name": "Quick Start",
-          "type": "webview"
         }
       ]
     },
@@ -344,7 +360,13 @@
           "icon": "resources/n3-logo.png"
         }
       ]
-    }
+    },
+    "viewsWelcome": [
+      {
+        "view": "neo3-visual-devtracker.views.contracts",
+        "contents": "[Create a new contract](command:neo3-visual-devtracker.neo.newContract)"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile-prod && npm run bundle-nxp",

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/blank/src/$_CLASSNAME_$.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/blank/src/$_CLASSNAME_$.cs.template.txt
@@ -1,0 +1,83 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+
+namespace $_CONTRACTNAME_$
+{
+    [DisplayName(nameof($_CLASSNAME_$))]
+    [ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+    [ContractDescription("<Description Here>")]
+    [ContractVersion("<Version String Here>")]
+    [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template")]
+    [ContractPermission(Permission.Any, Method.Any)]
+    public class $_CLASSNAME_$ : SmartContract
+    {
+        #region Owner
+
+        private const byte Prefix_Owner = 0xff;
+
+        [Safe]
+        public static UInt160 GetOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_Owner });
+        }
+
+        private static bool IsOwner() =>
+            Runtime.CheckWitness(GetOwner());
+
+        public delegate void OnSetOwnerDelegate(UInt160 previousOwner, UInt160 newOwner);
+
+        [DisplayName("SetOwner")]
+        public static event OnSetOwnerDelegate OnSetOwner;
+
+        public static void SetOwner(UInt160 newOwner)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+            UInt160 previous = GetOwner();
+            Storage.Put(new[] { Prefix_Owner }, newOwner);
+            OnSetOwner(previous, newOwner);
+        }
+
+        #endregion
+
+        [Safe]
+        public static bool Verify() => IsOwner();
+
+        public static string MyMethod()
+        {
+            return Storage.Get("Hello");
+        }
+
+        public static void _deploy(object data, bool update)
+        {
+            if (update)
+            {
+                return;
+            }
+
+            if (data is null) data = Runtime.Transaction.Sender;
+
+            UInt160 initialOwner = (UInt160)data;
+
+            ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exist");
+
+            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OnSetOwner(null, initialOwner);
+            Storage.Put("Hello", "World");
+        }
+
+        public static void Update(ByteString nefFile, string manifest, object? data = null)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No authorization.");
+            ContractManagement.Update(nefFile, manifest, data);
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/blank/test/$_CLASSNAME_$Tests.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/blank/test/$_CLASSNAME_$Tests.cs.template.txt
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Neo.Assertions;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.VM;
+using NeoTestHarness;
+using Xunit;
+
+namespace $_CONTRACTNAME_$Tests
+{
+    [CheckpointPath("test/bin/checkpoints/contract-deployed.neoxp-checkpoint")]
+    public class $_CLASSNAME_$Tests : IClassFixture<CheckpointFixture<$_CLASSNAME_$Tests>>
+    {
+        readonly CheckpointFixture fixture;
+        readonly ExpressChain chain;
+
+        public const byte CONTRACT_OWNER_PREFIX = 0xff;
+
+        public $_CLASSNAME_$Tests(CheckpointFixture<$_CLASSNAME_$Tests> fixture)
+        {
+            this.fixture = fixture;
+            this.chain = fixture.FindChain();
+        }
+
+        [Fact]
+        public void contract_owner_in_storage()
+        {
+            var settings = chain.GetProtocolSettings();
+            var owner = chain.GetDefaultAccount("owner").ToScriptHash(settings.AddressVersion);
+
+            using var snapshot = fixture.GetSnapshot();
+            var storages = snapshot.GetContractStorages<$_CLASSNAME_$>();
+            storages.TryGetValue(CONTRACT_OWNER_PREFIX, out var item).Should().BeTrue();
+            item!.Should().Be(owner);
+        }
+
+        [Fact]
+        public void my_method_returns_world()
+        {
+            var settings = chain.GetProtocolSettings();
+            using var snapshot = fixture.GetSnapshot();
+            using var engine = new TestApplicationEngine(snapshot, settings);
+
+            engine.ExecuteScript<$_CLASSNAME_$>(c => c.MyMethod());
+
+            engine.State.Should().Be(VMState.HALT);
+            engine.ResultStack.Should().HaveCount(1);
+            engine.ResultStack.Peek(0).Should().BeEquivalentTo("World");
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep11/src/$_CLASSNAME_$.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep11/src/$_CLASSNAME_$.cs.template.txt
@@ -1,0 +1,133 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+
+namespace $_CONTRACTNAME_$
+{
+    [DisplayName(nameof($_CLASSNAME_$))]
+    [ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+    [ContractDescription("<Description Here>")]
+    [ContractVersion("<Version String Here>")]
+    [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractnep11")]
+    [ContractPermission(Permission.Any, Method.OnNEP11Payment)]
+    [SupportedStandards(NepStandard.Nep11)]
+    public class $_CLASSNAME_$ : Nep11Token<TokenState>
+    {
+        #region Owner
+
+        private const byte Prefix_Owner = 0xff;
+
+        [Safe]
+        public static UInt160 GetOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_Owner });
+        }
+
+        private static bool IsOwner() =>
+            Runtime.CheckWitness(GetOwner());
+
+        public delegate void OnSetOwnerDelegate(UInt160? previousOwner, UInt160? newOwner);
+
+        [DisplayName("SetOwner")]
+        public static event OnSetOwnerDelegate OnSetOwner = null!;
+
+        public static void SetOwner(UInt160 newOwner)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+            UInt160? previousOwner = GetOwner();
+            ExecutionEngine.Assert(previousOwner != newOwner, "owner must change");
+
+            Storage.Put(new[] { Prefix_Owner }, newOwner);
+            OnSetOwner(previousOwner, newOwner);
+        }
+
+        #endregion
+
+        #region NEP11
+
+        public override string Symbol { [Safe] get => "EXAMPLE"; }
+
+        public static ByteString Mint(UInt160 to, string name, string description, string image)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(to.IsValid && to.NotZero, "recipient must be valid");
+
+            ByteString tokenId = NewTokenId();
+            Nep11Token<TokenState>.Mint(tokenId, new TokenState
+            {
+                Owner = to,
+                Name = name,
+                Description = description,
+                Image = image
+            });
+
+            return tokenId;
+        }
+
+        [Safe]
+        public override Map<string, object> Properties(ByteString tokenId)
+        {
+            if (tokenId.Length >= 64) throw new Exception("The argument \"tokenId\" should be 64 or less bytes long.");
+
+            var tokenMap = new LocalStorageMap(Prefix_Token);
+            var tokenKey = tokenMap[tokenId] ?? throw new Exception("The token with given \"tokenId\" does not exist.");
+            TokenState token = (TokenState)StdLib.Deserialize(tokenKey);
+
+            return new Map<string, object>()
+            {
+                ["name"] = token.Name,
+                ["description"] = token.Description,
+                ["image"] = token.Image
+            };
+        }
+
+        #endregion
+
+        [Safe]
+        public static bool Verify() => IsOwner();
+
+        public static string MyMethod()
+        {
+            return Storage.Get("Hello");
+        }
+
+        public static void _deploy(object data, bool update)
+        {
+            if (update)
+            {
+                return;
+            }
+
+            if (data is null) data = Runtime.Transaction.Sender;
+            UInt160 initialOwner = (UInt160)data;
+
+            ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exists");
+
+            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OnSetOwner(null, initialOwner);
+            Storage.Put("Hello", "World");
+        }
+
+        public static void Update(ByteString nefFile, string manifest, object? data = null)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No authorization.");
+            ContractManagement.Update(nefFile, manifest, data);
+        }
+    }
+
+    public class TokenState : Nep11TokenState
+    {
+        public string Description = string.Empty;
+        public string Image = string.Empty;
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep11/test/$_CLASSNAME_$Tests.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep11/test/$_CLASSNAME_$Tests.cs.template.txt
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using Neo.Assertions;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.VM;
+using NeoTestHarness;
+using Xunit;
+
+namespace $_CONTRACTNAME_$Tests
+{
+    [CheckpointPath("test/bin/checkpoints/contract-deployed.neoxp-checkpoint")]
+    public class $_CLASSNAME_$Tests : IClassFixture<CheckpointFixture<$_CLASSNAME_$Tests>>
+    {
+        readonly CheckpointFixture fixture;
+        readonly ExpressChain chain;
+
+        public $_CLASSNAME_$Tests(CheckpointFixture<$_CLASSNAME_$Tests> fixture)
+        {
+            this.fixture = fixture;
+            this.chain = fixture.FindChain();
+        }
+
+        [Fact]
+        public void symbol_is_example()
+        {
+            var settings = chain.GetProtocolSettings();
+            using var snapshot = fixture.GetSnapshot();
+            using var engine = new TestApplicationEngine(snapshot, settings);
+
+            engine.ExecuteScript<$_CLASSNAME_$>(c => c.symbol());
+            engine.State.Should().Be(VMState.HALT);
+            engine.ResultStack.Peek(0).Should().BeEquivalentTo("EXAMPLE");
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep17/src/$_CLASSNAME_$.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep17/src/$_CLASSNAME_$.cs.template.txt
@@ -1,0 +1,108 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+
+using System;
+using System.ComponentModel;
+using System.Numerics;
+
+namespace $_CONTRACTNAME_$
+{
+    [DisplayName(nameof($_CLASSNAME_$))]
+    [ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+    [ContractDescription("<Description Here>")]
+    [ContractVersion("<Version String Here>")]
+    [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractnep17")]
+    [ContractPermission(Permission.Any, "onNEP17Payment")]
+    [SupportedStandards(NepStandard.Nep17)]
+    public class $_CLASSNAME_$ : Nep17Token
+    {
+        #region Owner
+
+        private const byte Prefix_Owner = 0xff;
+
+        [Safe]
+        public static UInt160 GetOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_Owner });
+        }
+
+        private static bool IsOwner() =>
+            Runtime.CheckWitness(GetOwner());
+
+        public delegate void OnSetOwnerDelegate(UInt160 previousOwner, UInt160 newOwner);
+
+        [DisplayName("SetOwner")]
+        public static event OnSetOwnerDelegate OnSetOwner;
+
+        public static void SetOwner(UInt160 newOwner)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+            UInt160 previous = GetOwner();
+            Storage.Put(new[] { Prefix_Owner }, newOwner);
+            OnSetOwner(previous, newOwner);
+        }
+
+        #endregion
+
+        #region NEP17
+
+        public override string Symbol { [Safe] get => "EXAMPLE"; }
+
+        public override byte Decimals { [Safe] get => 8; }
+
+        public static new void Burn(UInt160 account, BigInteger amount)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+            Nep17Token.Burn(account, amount);
+        }
+
+        public static new void Mint(UInt160 to, BigInteger amount)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+            Nep17Token.Mint(to, amount);
+        }
+
+        #endregion
+
+        [Safe]
+        public static bool Verify() => IsOwner();
+
+        public static string MyMethod()
+        {
+            return Storage.Get("Hello");
+        }
+
+        public static void _deploy(object data, bool update)
+        {
+            if (update)
+            {
+                return;
+            }
+
+            if (data is null) data = Runtime.Transaction.Sender;
+
+            UInt160 initialOwner = (UInt160)data;
+
+            ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exists");
+
+            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OnSetOwner(null, initialOwner);
+            Storage.Put("Hello", "World");
+        }
+
+        public static void Update(ByteString nefFile, string manifest, object? data = null)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No authorization.");
+            ContractManagement.Update(nefFile, manifest, data);
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep17/test/$_CLASSNAME_$Tests.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/nep17/test/$_CLASSNAME_$Tests.cs.template.txt
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Neo.Assertions;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.VM;
+using NeoTestHarness;
+using Xunit;
+
+namespace $_CONTRACTNAME_$Tests
+{
+    [CheckpointPath("test/bin/checkpoints/contract-deployed.neoxp-checkpoint")]
+    public class $_CLASSNAME_$Tests : IClassFixture<CheckpointFixture<$_CLASSNAME_$Tests>>
+    {
+        readonly CheckpointFixture fixture;
+        readonly ExpressChain chain;
+
+        public $_CLASSNAME_$Tests(CheckpointFixture<$_CLASSNAME_$Tests> fixture)
+        {
+            this.fixture = fixture;
+            this.chain = fixture.FindChain();
+        }
+
+        [Fact]
+        public void symbol_and_decimals()
+        {
+            var settings = chain.GetProtocolSettings();
+            using var snapshot = fixture.GetSnapshot();
+            using var engine = new TestApplicationEngine(snapshot, settings);
+
+            engine.ExecuteScript<$_CLASSNAME_$>(c => c.symbol());
+            engine.State.Should().Be(VMState.HALT);
+            engine.ResultStack.Peek(0).Should().BeEquivalentTo("EXAMPLE");
+
+            using var decimalsEngine = new TestApplicationEngine(snapshot, settings);
+            decimalsEngine.ExecuteScript<$_CLASSNAME_$>(c => c.decimals());
+            decimalsEngine.State.Should().Be(VMState.HALT);
+            decimalsEngine.ResultStack.Peek(0).Should().BeEquivalentTo(8);
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/oracle/src/$_CLASSNAME_$.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/oracle/src/$_CLASSNAME_$.cs.template.txt
@@ -1,0 +1,48 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+
+using System;
+using System.ComponentModel;
+
+namespace $_CONTRACTNAME_$
+{
+    [DisplayName(nameof($_CLASSNAME_$))]
+    [ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+    [ContractDescription("<Description Here>")]
+    [ContractVersion("<Version String Here>")]
+    [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractoracle")]
+    public class $_CLASSNAME_$ : SmartContract
+    {
+        [Safe]
+        public static string GetResponse()
+        {
+            return Storage.Get(Storage.CurrentReadOnlyContext, "Response");
+        }
+
+        public static void DoRequest()
+        {
+            var requestUrl = "https://api.jsonbin.io/v3/qs/6520ad3c12a5d3765988542a";
+            Neo.SmartContract.Framework.Native.Oracle.Request(
+                requestUrl,
+                "$.record.propertyName",
+                "onOracleResponse",
+                null,
+                Neo.SmartContract.Framework.Native.Oracle.MinimumResponseFee);
+        }
+
+        public static void onOracleResponse(string requestedUrl, object userData, OracleResponseCode oracleResponse, string jsonString)
+        {
+            if (Runtime.CallingScriptHash != Neo.SmartContract.Framework.Native.Oracle.Hash)
+                throw new InvalidOperationException("No Authorization!");
+            if (oracleResponse != OracleResponseCode.Success)
+                throw new Exception("Oracle response failure with code " + (byte)oracleResponse);
+
+            var jsonArrayValues = (object[])StdLib.JsonDeserialize(jsonString);
+            var jsonFirstValue = (string)jsonArrayValues[0];
+
+            Storage.Put(Storage.CurrentContext, "Response", jsonFirstValue);
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/oracle/test/$_CLASSNAME_$Tests.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/oracle/test/$_CLASSNAME_$Tests.cs.template.txt
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.VM;
+using NeoTestHarness;
+using Xunit;
+
+namespace $_CONTRACTNAME_$Tests
+{
+    [CheckpointPath("test/bin/checkpoints/contract-deployed.neoxp-checkpoint")]
+    public class $_CLASSNAME_$Tests : IClassFixture<CheckpointFixture<$_CLASSNAME_$Tests>>
+    {
+        readonly CheckpointFixture fixture;
+        readonly ExpressChain chain;
+
+        public $_CLASSNAME_$Tests(CheckpointFixture<$_CLASSNAME_$Tests> fixture)
+        {
+            this.fixture = fixture;
+            this.chain = fixture.FindChain();
+        }
+
+        [Fact]
+        public void get_response_halts_after_deploy()
+        {
+            var settings = chain.GetProtocolSettings();
+            using var snapshot = fixture.GetSnapshot();
+            using var engine = new TestApplicationEngine(snapshot, settings);
+
+            engine.ExecuteScript<$_CLASSNAME_$>(c => c.GetResponse());
+            engine.State.Should().Be(VMState.HALT);
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/ownable/src/$_CLASSNAME_$.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/ownable/src/$_CLASSNAME_$.cs.template.txt
@@ -1,0 +1,87 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+
+using System;
+using System.ComponentModel;
+
+namespace $_CONTRACTNAME_$
+{
+    [DisplayName(nameof($_CLASSNAME_$))]
+    [ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+    [ContractDescription("<Description Here>")]
+    [ContractVersion("<Version String Here>")]
+    [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractowner")]
+    public class $_CLASSNAME_$ : SmartContract
+    {
+        #region Owner
+
+        private const byte Prefix_Owner = 0xff;
+
+        [Safe]
+        public static UInt160 GetOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_Owner });
+        }
+
+        private static bool IsOwner() =>
+            Runtime.CheckWitness(GetOwner());
+
+        public delegate void OnSetOwnerDelegate(UInt160 previousOwner, UInt160 newOwner);
+
+        [DisplayName("SetOwner")]
+        public static event OnSetOwnerDelegate OnSetOwner;
+
+        public static void SetOwner(UInt160 newOwner)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+            UInt160 previous = GetOwner();
+            Storage.Put(new[] { Prefix_Owner }, newOwner);
+            OnSetOwner(previous, newOwner);
+        }
+
+        #endregion
+
+        public static string MyMethod()
+        {
+            return Storage.Get(Storage.CurrentReadOnlyContext, "Hello");
+        }
+
+        public static void _deploy(object data, bool update)
+        {
+            if (update)
+            {
+                return;
+            }
+
+            if (data is null) data = Runtime.Transaction.Sender;
+
+            UInt160 initialOwner = (UInt160)data;
+
+            ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exists");
+
+            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OnSetOwner(null, initialOwner);
+            Storage.Put(Storage.CurrentContext, "Hello", "World");
+        }
+
+        public static void Update(ByteString nefFile, string manifest, object? data = null)
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No authorization.");
+            ContractManagement.Update(nefFile, manifest, data);
+        }
+
+        public static void Destroy()
+        {
+            if (!IsOwner())
+                throw new InvalidOperationException("No authorization.");
+            ContractManagement.Destroy();
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/ownable/test/$_CLASSNAME_$Tests.cs.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp-starters/ownable/test/$_CLASSNAME_$Tests.cs.template.txt
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Neo.Assertions;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Neo.BlockchainToolkit.SmartContract;
+using Neo.VM;
+using NeoTestHarness;
+using Xunit;
+
+namespace $_CONTRACTNAME_$Tests
+{
+    [CheckpointPath("test/bin/checkpoints/contract-deployed.neoxp-checkpoint")]
+    public class $_CLASSNAME_$Tests : IClassFixture<CheckpointFixture<$_CLASSNAME_$Tests>>
+    {
+        readonly CheckpointFixture fixture;
+        readonly ExpressChain chain;
+
+        public const byte CONTRACT_OWNER_PREFIX = 0xff;
+
+        public $_CLASSNAME_$Tests(CheckpointFixture<$_CLASSNAME_$Tests> fixture)
+        {
+            this.fixture = fixture;
+            this.chain = fixture.FindChain();
+        }
+
+        [Fact]
+        public void contract_owner_in_storage()
+        {
+            var settings = chain.GetProtocolSettings();
+            var owner = chain.GetDefaultAccount("owner").ToScriptHash(settings.AddressVersion);
+
+            using var snapshot = fixture.GetSnapshot();
+            var storages = snapshot.GetContractStorages<$_CLASSNAME_$>();
+            storages.TryGetValue(CONTRACT_OWNER_PREFIX, out var item).Should().BeTrue();
+            item!.Should().Be(owner);
+        }
+
+        [Fact]
+        public void my_method_returns_world()
+        {
+            var settings = chain.GetProtocolSettings();
+            using var snapshot = fixture.GetSnapshot();
+            using var engine = new TestApplicationEngine(snapshot, settings);
+
+            engine.ExecuteScript<$_CLASSNAME_$>(c => c.MyMethod());
+
+            engine.State.Should().Be(VMState.HALT);
+            engine.ResultStack.Should().HaveCount(1);
+            engine.ResultStack.Peek(0).Should().BeEquivalentTo("World");
+        }
+    }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/.config/dotnet-tools.json.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/.config/dotnet-tools.json.template.txt
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "neo.express": {
+      "version": "3.10.1",
+      "commands": [
+        "neoxp"
+      ]
+    },
+    "neo.compiler.csharp": {
+      "version": "3.10.1",
+      "commands": [
+        "nccs"
+      ]
+    }
+  }
+}

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/nuget.config.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/nuget.config.template.txt
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/src/$_CLASSNAME_$.csproj.template.txt
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
     <NeoContractName>$_CLASSNAME_$</NeoContractName>
+    <Nullable>enable</Nullable>
     <RootNamespace>$_CONTRACTNAME_$</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>

--- a/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/csharp/test/$_CLASSNAME_$Tests.csproj.template.txt
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <NeoExpressBatchFile>.\setup-test-chain.batch</NeoExpressBatchFile>
-    <NeoExpressBatchInputFile>.\default.neo-express</NeoExpressBatchInputFile>
-    <NeoExpressBatchInputFileFromWorkspace>test/default.neo-express</NeoExpressBatchInputFileFromWorkspace>
+    <NeoExpressBatchInputFile>.\$_CLASSNAME_$Tests.neo-express</NeoExpressBatchInputFile>
+    <NeoExpressBatchInputFileFromWorkspace>test/$_CLASSNAME_$Tests.neo-express</NeoExpressBatchInputFileFromWorkspace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <RootNamespace>$_CONTRACTNAME_$Tests</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
@@ -14,16 +16,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Neo.Assertions" Version="3.10.1" />
     <PackageReference Include="Neo.BuildTasks" Version="3.10.1" PrivateAssets="all" />
     <PackageReference Include="Neo.Test.Harness" Version="3.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -31,6 +33,8 @@
 
   <Target Name="ExecuteCreateNeoExpressInstance" Condition="!Exists($(NeoExpressBatchInputFile))"
           AfterTargets="Build" BeforeTargets="ExecuteNeoExpressBatch">
+    <Exec WorkingDirectory="$(ProjectDir).."
+          Command="dotnet tool restore" />
     <Exec WorkingDirectory="$(ProjectDir).."
           Command="dotnet tool run neoxp -- create -o &quot;$(NeoExpressBatchInputFileFromWorkspace)&quot;" />
     <Exec WorkingDirectory="$(ProjectDir).."

--- a/extentions/neo3-visual-tracker/resources/new-contract/java/build.gradle.template.txt
+++ b/extentions/neo3-visual-tracker/resources/new-contract/java/build.gradle.template.txt
@@ -6,11 +6,10 @@ plugins {
 group '$_REVERSEDOMAINNAME_$'
 version '1.0-SNAPSHOT'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
@@ -18,7 +17,7 @@ dependencies {
     implementation 'io.neow3j:contract:$_NEOW3JLIBVERSION_$'
     implementation 'io.neow3j:devpack:$_NEOW3JLIBVERSION_$'
     implementation 'io.neow3j:compiler:$_NEOW3JLIBVERSION_$'
-    implementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 neow3jCompiler {

--- a/extentions/neo3-visual-tracker/src/extension/autoComplete.ts
+++ b/extentions/neo3-visual-tracker/src/extension/autoComplete.ts
@@ -15,6 +15,7 @@ import NeoExpressDetector from "./fileDetectors/neoExpressDetector";
 import NeoExpressIo from "./neoExpress/neoExpressIo";
 import WalletDetector from "./fileDetectors/walletDetector";
 import wellKnownContractsCacheKey from "./util/wellKnownContractsCacheKey";
+import { workspaceWalletDisplayName } from "../shared/expressWalletAddresses";
 
 const LOG_PREFIX = "AutoComplete";
 
@@ -52,6 +53,7 @@ export default class AutoComplete {
       contractPaths: {},
       wellKnownAddresses: {},
       addressNames: {},
+      accountSigners: {},
     };
     this.onChangeEmitter = new vscode.EventEmitter<AutoCompleteData>();
     this.onChange = this.onChangeEmitter.event;
@@ -87,8 +89,14 @@ export default class AutoComplete {
     let wellKnownContracts: {
       [name: string]: { hash: string; manifest: neonSc.ContractManifestJson };
     } = {};
+    const status = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      41
+    );
+    status.text = "$(sync~spin) Loading native Neo contracts...";
+    status.show();
     try {
-      const versionResult = await this.neoExpress.run("-v");
+      const versionResult = await this.neoExpress.runUnlocked("-v");
       let cacheKey = "";
       if (versionResult.isError) {
         Log.error(LOG_PREFIX, "Could not determine neo-express version");
@@ -102,7 +110,7 @@ export default class AutoComplete {
         Log.log(LOG_PREFIX, "Using cache");
       } else {
         Log.log(LOG_PREFIX, "Creating temporary instance");
-        const result = await this.neoExpress.run(
+        const result = await this.neoExpress.runUnlocked(
           "create",
           "-f",
           "-c",
@@ -161,6 +169,7 @@ export default class AutoComplete {
         await fs.promises.rm(tempDir, { recursive: true, force: true });
       } catch {}
       Log.log(LOG_PREFIX, "Finished initializing well-known manifests...");
+      status.dispose();
       await this.update("finished initializing well-known manifests");
     }
   }
@@ -174,19 +183,26 @@ export default class AutoComplete {
       contractNames: { ...this.wellKnownNames },
       wellKnownAddresses: {},
       addressNames: {},
+      accountSigners: {},
     };
 
     const wallets = [...this.walletDetector.wallets];
     for (const wallet of wallets) {
       for (const account of wallet.accounts) {
+        const displayName = workspaceWalletDisplayName(
+          wallet.path,
+          account.label
+        );
         newData.addressNames[account.address] =
           newData.addressNames[account.address] || [];
-        newData.addressNames[account.address].push(
-          account.label || wallet.path
-        );
+        newData.addressNames[account.address].push(displayName);
         newData.addressNames[account.address] = dedupeAndSort(
           newData.addressNames[account.address]
         );
+        if (!newData.wellKnownAddresses[displayName]) {
+          newData.wellKnownAddresses[displayName] = account.address;
+          newData.accountSigners![displayName] = wallet.path;
+        }
       }
     }
 
@@ -196,20 +212,30 @@ export default class AutoComplete {
       const contractName = (manifest as any)?.name;
       const contractPath = workspaceContract.absolutePathToNef;
       if (contractName) {
+        const nefBaseName = path.basename(contractPath, ".nef");
         newData.contractManifests[contractName] = manifest;
+        newData.contractManifests[nefBaseName] = manifest;
         newData.contractPaths[contractName] =
           newData.contractPaths[contractName] || [];
         newData.contractPaths[contractName].push(contractPath);
         newData.contractPaths[contractName] = dedupeAndSort(
           newData.contractPaths[contractName]
         );
+        newData.contractPaths[nefBaseName] = newData.contractPaths[contractName];
       }
     }
 
     const connection = this.activeConnection.connection;
 
-    newData.wellKnownAddresses =
+    const expressAddresses =
       (await connection?.blockchainIdentifier.getWalletAddresses()) || {};
+    newData.wellKnownAddresses = {
+      ...newData.wellKnownAddresses,
+      ...expressAddresses,
+    };
+    for (const name of Object.keys(expressAddresses)) {
+      newData.accountSigners![name] = name;
+    }
 
     for (const walletName of Object.keys(newData.wellKnownAddresses)) {
       const walletAddress = newData.wellKnownAddresses[walletName];

--- a/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainIdentifier.ts
@@ -7,6 +7,7 @@ import IoHelpers from "./util/ioHelpers";
 import JSONC from "./util/JSONC";
 import Log from "./util/log";
 import posixPath from "./util/posixPath";
+import { parseExpressWalletAddresses } from "../shared/expressWalletAddresses";
 
 const LOG_PREFIX = "BlockchainIdentifier";
 
@@ -45,11 +46,16 @@ export default class BlockchainIdentifier {
         Log.log(LOG_PREFIX, "No RPC ports found", configPath);
         return undefined;
       }
+      const relative = vscode.workspace.asRelativePath(configPath, false);
+      const name =
+        relative && relative !== configPath
+          ? relative.replace(/\\/g, "/")
+          : path.basename(configPath);
       return new BlockchainIdentifier(
         extensionPath,
         "express",
         "parent",
-        path.basename(configPath),
+        name,
         nodePorts.map((_: number) => `http://127.0.0.1:${_}`),
         0,
         configPath
@@ -127,28 +133,7 @@ export default class BlockchainIdentifier {
       const neoExpressConfig = JSONC.parse(
         (await fs.promises.readFile(this.configPath)).toString()
       );
-      for (const wallet of neoExpressConfig["wallets"]) {
-        if (
-          wallet.name &&
-          wallet.accounts &&
-          wallet.accounts[0] &&
-          wallet.accounts[0]["script-hash"]
-        ) {
-          result[wallet.name] = wallet.accounts[0]["script-hash"];
-        }
-      }
-      for (const consensusNode of neoExpressConfig["consensus-nodes"]) {
-        if (consensusNode.wallet?.accounts) {
-          for (const account of consensusNode.wallet.accounts) {
-            if (
-              account.label === "Consensus MultiSigContract" &&
-              account["script-hash"]
-            ) {
-              result["genesis"] = account["script-hash"];
-            }
-          }
-        }
-      }
+      result = parseExpressWalletAddresses(neoExpressConfig);
     } catch (e : any) {
       Log.log(
         LOG_PREFIX,

--- a/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/blockchainMonitorInternal.ts
+++ b/extentions/neo3-visual-tracker/src/extension/blockchainMonitor/blockchainMonitorInternal.ts
@@ -257,14 +257,40 @@ export default class BlockchainMonitorInternal {
     return new Promise((resolve) => setTimeout(resolve, SLEEP_ON_ERROR_MS));
   }
 
+  private async getBlockCountFallback(): Promise<number> {
+    const response = await fetch(this.rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "getblockcount",
+        params: [],
+        id: 1,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const payload = (await response.json()) as { result?: number };
+    if (typeof payload.result !== "number") {
+      throw new Error("getblockcount returned no height");
+    }
+    return payload.result;
+  }
+
   private async updateState() {
     const wasHealthy = this.healthy;
     let blockHeight = this.state.lastKnownBlockHeight;
     try {
       blockHeight = await this.rpcClient.getBlockCount();
       this.state.isHealthy = true;
-    } catch (e : any) {
-      this.state.isHealthy = false;
+    } catch {
+      try {
+        blockHeight = await this.getBlockCountFallback();
+        this.state.isHealthy = true;
+      } catch {
+        this.state.isHealthy = false;
+      }
     }
 
     let fireChangeEvent =

--- a/extentions/neo3-visual-tracker/src/extension/commands/commandArguments.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/commandArguments.ts
@@ -25,6 +25,7 @@ type CommandArguments = {
   receiver?: string;
   secondsPerBlock?: number;
   sender?: string;
+  force?: boolean;
 };
 
 async function sanitizeCommandArguments(input: any): Promise<CommandArguments> {

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoCommands.ts
@@ -221,44 +221,17 @@ export default class NeoCommands {
 
   static async invokeContract(
     activeConnection: ActiveConnection,
+    autoComplete: AutoComplete,
     blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
+    contractDetector: ContractDetector,
     commandArguments?: CommandArguments
   ) {
-    const identifier =
-      commandArguments?.blockchainIdentifier ||
-      (await blockchainsTreeDataProvider.select());
-    if (!identifier) {
-      return;
-    }
-    if (
-      activeConnection.connection?.blockchainIdentifier.name !== identifier.name
-    ) {
-      await activeConnection.connect(identifier);
-    }
-    const rootFolder = workspaceFolder();
-    if (!rootFolder) {
-      vscode.window.showErrorMessage(
-        "Please open a folder in your Visual Studio Code workspace before invoking a contract"
-      );
-      return;
-    }
-    const invokeFilesFolder = posixPath(rootFolder, "invoke-files");
-    try {
-      await fs.promises.mkdir(invokeFilesFolder);
-    } catch {}
-    let filename = posixPath(invokeFilesFolder, "Untitled.neo-invoke.json");
-    let i = 0;
-    while (fs.existsSync(filename)) {
-      i++;
-      filename = posixPath(
-        invokeFilesFolder,
-        `Untitled (${i}).neo-invoke.json`
-      );
-    }
-    await fs.promises.writeFile(filename, "[{}]");
-    await vscode.commands.executeCommand(
-      "vscode.open",
-      vscode.Uri.file(filename)
+    await NeoCommands.openContractStudio(
+      activeConnection,
+      autoComplete,
+      blockchainsTreeDataProvider,
+      contractDetector,
+      commandArguments || {}
     );
   }
 
@@ -324,10 +297,13 @@ export default class NeoCommands {
         );
         return;
       }
-      contractReference = await IoHelpers.multipleChoice(
-        "Select a contract for Contract Studio",
-        ...uniqueChoices
-      );
+      contractReference =
+        uniqueChoices.length === 1
+          ? uniqueChoices[0]
+          : await IoHelpers.multipleChoice(
+              "Select a contract for Contract Studio",
+              ...uniqueChoices
+            );
       if (!contractReference) {
         return;
       }
@@ -335,6 +311,15 @@ export default class NeoCommands {
       contractName =
         autoComplete.data.contractNames[referenceWithoutPrefix] ||
         referenceWithoutPrefix;
+    }
+
+    const deployedNames = new Set(Object.values(autoComplete.data.contractNames));
+    const studioName = (contractName || "").replace(/^#/, "");
+    if (studioName && !deployedNames.has(studioName) && contractReference?.startsWith("#")) {
+      vscode.window.showWarningMessage(
+        `"${studioName}" is a workspace contract that is not deployed on this chain. ` +
+          `Deploy it before Run invocation, or open SampleContract (or another on-chain name).`
+      );
     }
 
     const invokeFilesFolder = posixPath(rootFolder, "invoke-files");

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCheckpointCommand.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCheckpointCommand.test.ts
@@ -10,11 +10,11 @@ test("Visual Tracker stops a running Neo Express instance before offline checkpo
   );
   assert.match(
     neoExpressCommands,
-    /const wasRunning = neoExpressInstanceManager\.isRunning\(blockchainIdentifier\);\s+await neoExpressInstanceManager\.stopAll\(blockchainIdentifier\);/s
+    /const wasRunning = neoExpressInstanceManager\.isRunning\(blockchainIdentifier\);[\s\S]*await neoExpressInstanceManager\.stopAll\(blockchainIdentifier\);/
   );
   assert.match(
     neoExpressCommands,
-    /const wasRunning = neoExpressInstanceManager\.isRunning\(identifier\);\s+await neoExpressInstanceManager\.stopAll\(identifier\);/s
+    /const wasRunning = neoExpressInstanceManager\.isRunning\(identifier\);[\s\S]*await neoExpressInstanceManager\.stopAll\(identifier\);/
   );
 
   const neoExpressInstanceManager = readFileSync(
@@ -25,4 +25,32 @@ test("Visual Tracker stops a running Neo Express instance before offline checkpo
     neoExpressInstanceManager,
     /"stop",\s+"--all",\s+"-i",\s+target\.configPath/s
   );
+});
+
+test("Reset stops leftover nodes, does not restart after failure, and does not hang the status bar", () => {
+  const neoExpressCommands = readFileSync(
+    join(__dirname, "neoExpressCommands.ts"),
+    "utf8"
+  );
+  assert.match(neoExpressCommands, /"reset",\s+"-f",\s+"--all"/);
+  assert.match(neoExpressCommands, /isNodeStillRunningError/);
+  assert.match(
+    neoExpressCommands,
+    /if \(output\.isError \|\| isFailedTx\(output\.message\) \|\| isNodeStillRunningError\(output\.message\)\) \{\s*return;/
+  );
+  assert.doesNotMatch(
+    neoExpressCommands,
+    /finally \{\s*if \(wasRunning\) \{\s*report\("Restarting node\.\.\."\)/
+  );
+
+  const txPrep = readFileSync(join(__dirname, "../util/txPrep.ts"), "utf8");
+  assert.doesNotMatch(txPrep, /createStatusBarItem/);
+  assert.match(txPrep, /ProgressLocation\.Window/);
+
+  const neoExpress = readFileSync(
+    join(__dirname, "../neoExpress/neoExpress.ts"),
+    "utf8"
+  );
+  assert.match(neoExpress, /START_TIMEOUT_MS/);
+  assert.match(neoExpress, /onDidExit/);
 });

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCommands.ts
@@ -12,20 +12,53 @@ import IoHelpers from "../util/ioHelpers";
 import NeoExpress from "../neoExpress/neoExpress";
 import NeoExpressInstanceManager from "../neoExpress/neoExpressInstanceManager";
 import posixPath from "../util/posixPath";
+import stripAnsi from "../util/stripAnsi";
+import { contractsWithStandard } from "../../shared/expressWalletAddresses";
+import { isFailedTx, isNodeStillRunningError, parseSubmittedTxids } from "../../shared/neoExpressTx";
+import { ensureAccountHasGas, passwordFlags, waitForContract, waitForTransactionResult, withStatus } from "../util/txPrep";
 import StorageExplorerPanelController from "../panelControllers/storageExplorerPanelController";
 import TrackerPanelController from "../panelControllers/trackerPanelController";
 import workspaceFolder from "../util/workspaceFolder";
+
+function sortWalletNames(names: string[]): string[] {
+  return [...names].sort((a, b) => {
+    if (a === "genesis") {
+      return -1;
+    }
+    if (b === "genesis") {
+      return 1;
+    }
+    return a.localeCompare(b);
+  });
+}
+
+async function accountChoices(
+  identifier: BlockchainIdentifier,
+  autoComplete?: AutoComplete
+): Promise<string[]> {
+  const wellKnown = Object.keys(autoComplete?.data.wellKnownAddresses ?? {});
+  if (wellKnown.length) {
+    return sortWalletNames(wellKnown);
+  }
+  return sortWalletNames(Object.keys(await identifier.getWalletAddresses()));
+}
+
+function accountSigner(name: string, autoComplete?: AutoComplete): string {
+  return autoComplete?.data.accountSigners?.[name] || name;
+}
 
 export default class NeoExpressCommands {
   static async contractDeploy(
     neoExpress: NeoExpress,
     contractDetector: ContractDetector,
     blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
-    commandArguments?: CommandArguments
+    commandArguments?: CommandArguments,
+    autoComplete?: AutoComplete,
+    preferred?: BlockchainIdentifier
   ) {
     const identifier =
       commandArguments?.blockchainIdentifier ||
-      (await blockchainsTreeDataProvider.select("express"));
+      (await blockchainsTreeDataProvider.select("express", preferred));
     if (!identifier) {
       return;
     }
@@ -35,18 +68,22 @@ export default class NeoExpressCommands {
       );
       return;
     }
-    const walletNames = Object.keys(await identifier.getWalletAddresses());
-    const account = await IoHelpers.multipleChoice(
-      "Select an account...",
-      ...walletNames
-    );
-    if (!account) {
+    const accountNames = await accountChoices(identifier, autoComplete);
+    let accountName = commandArguments?.sender;
+    if (!accountName || accountNames.indexOf(accountName) === -1) {
+      accountName = await IoHelpers.multipleChoice(
+        "Select an account (genesis holds NEO/GAS)...",
+        ...accountNames
+      );
+    }
+    if (!accountName) {
       return;
     }
+    const account = accountSigner(accountName, autoComplete);
     const contractFile =
       commandArguments?.path ||
       (await IoHelpers.multipleChoiceFiles(
-        `Use account "${account}" to deploy...`,
+        `Use account "${accountName}" to deploy...`,
         ...Object.values(contractDetector.contracts).map(
           (_) => _.absolutePathToNef
         )
@@ -54,15 +91,53 @@ export default class NeoExpressCommands {
     if (!contractFile) {
       return;
     }
-    const output = await neoExpress.run(
-      "contract",
-      "deploy",
-      contractFile,
-      account,
-      "-i",
-      identifier.configPath
-    );
-    NeoExpressCommands.showResult(output);
+    const password = await passwordFlags(account);
+    if (!password) {
+      return;
+    }
+    await withStatus("Deploying contract", async (report) => {
+      report("Checking GAS balance...");
+      if (
+        !(await ensureAccountHasGas(
+          neoExpress,
+          identifier,
+          accountName,
+          account,
+          autoComplete,
+          report
+        ))
+      ) {
+        return;
+      }
+      const contractName =
+        contractDetector.contracts[
+          Object.keys(contractDetector.contracts).find(
+            (name) =>
+              contractDetector.contracts[name].absolutePathToNef ===
+              posixPath(contractFile)
+          ) || ""
+        ]?.manifest?.name ||
+        posixPath(contractFile).split("/").pop()?.replace(/\.nef$/i, "") ||
+        "";
+      report("Submitting deploy transaction...");
+      const output = await NeoExpressCommands.runDeploy(
+        neoExpress,
+        identifier,
+        contractFile,
+        account,
+        password,
+        !!commandArguments?.force,
+        report,
+        contractName
+      );
+      if (!output) {
+        return;
+      }
+      await contractDetector.refresh();
+      vscode.window.showInformationMessage(
+        stripAnsi(output) || `Deployed ${contractName}.`
+      );
+    });
   }
 
   static async create(
@@ -219,15 +294,113 @@ export default class NeoExpressCommands {
     );
   }
 
+  private static async runDeploy(
+    neoExpress: NeoExpress,
+    identifier: BlockchainIdentifier,
+    contractFile: string,
+    account: string,
+    password: string[],
+    force: boolean,
+    report: (msg: string) => void,
+    contractName?: string
+  ): Promise<string | null> {
+    const gasFlags = (await neoExpress.supportsDeployGasOption())
+      ? (["-g", "1"] as const)
+      : [];
+    let output = await neoExpress.run(
+      "contract",
+      "deploy",
+      contractFile,
+      account,
+      ...gasFlags,
+      "-i",
+      identifier.configPath,
+      ...(force ? ["-f"] : []),
+      ...password
+    );
+    if (
+      output.isError &&
+      gasFlags.length &&
+      /unrecognized option\s+'?-g/i.test(stripAnsi(output.message))
+    ) {
+      output = await neoExpress.run(
+        "contract",
+        "deploy",
+        contractFile,
+        account,
+        "-i",
+        identifier.configPath,
+        ...(force ? ["-f"] : []),
+        ...password
+      );
+    }
+    const confirmed = await NeoExpressCommands.confirmSubmittedTx(
+      neoExpress,
+      identifier,
+      output,
+      report
+    );
+    if (!confirmed) {
+      return null;
+    }
+    if (!parseSubmittedTxids(confirmed)[0] && contractName) {
+      const onChain = await waitForContract(
+        neoExpress,
+        identifier,
+        contractName,
+        12000,
+        report
+      );
+      if (!onChain) {
+        vscode.window.showErrorMessage(
+          confirmed +
+            " The transaction was submitted, but the contract is not on chain."
+        );
+        return null;
+      }
+    }
+    return confirmed;
+  }
+
+  private static async confirmSubmittedTx(
+    neoExpress: NeoExpress,
+    identifier: BlockchainIdentifier,
+    output: { message: string; isError?: boolean },
+    report: (msg: string) => void
+  ): Promise<string | null> {
+    if (output.isError || isFailedTx(output.message)) {
+      NeoExpressCommands.showResult(output);
+      return null;
+    }
+    const txid = parseSubmittedTxids(output.message)[0];
+    if (txid) {
+      const confirmed = await waitForTransactionResult(
+        neoExpress,
+        identifier,
+        txid,
+        20000,
+        report
+      );
+      if (!confirmed.ok) {
+        vscode.window.showErrorMessage(
+          `Transaction failed.\n${confirmed.message}`
+        );
+        return null;
+      }
+    }
+    return stripAnsi(output.message);
+  }
+
   static async reset(
     neoExpress: NeoExpress,
     neoExpressInstanceManager: NeoExpressInstanceManager,
     blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
-    commandArguments?: CommandArguments
+    commandArguments?: CommandArguments,
+    preferred?: BlockchainIdentifier
   ) {
     const blockchainIdentifier =
       commandArguments?.blockchainIdentifier ||
-      (await blockchainsTreeDataProvider.select("express"));
+      (await blockchainsTreeDataProvider.select("express", preferred));
     if (!blockchainIdentifier) {
       return;
     }
@@ -238,22 +411,40 @@ export default class NeoExpressCommands {
       return;
     }
     const wasRunning = neoExpressInstanceManager.isRunning(blockchainIdentifier);
-    await neoExpressInstanceManager.stopAll(blockchainIdentifier);
-    try {
-      const output = await neoExpress.run(
+    await withStatus("Resetting Neo Express", async (report) => {
+      report("Stopping node...");
+      await neoExpressInstanceManager.stopAll(blockchainIdentifier);
+      report("Resetting chain data...");
+      let output = await neoExpress.run(
         "reset",
         "-f",
+        "--all",
         "-i",
         blockchainIdentifier.configPath
       );
+      if (isNodeStillRunningError(output.message)) {
+        report("Node still running; stopping again...");
+        await neoExpressInstanceManager.stopAll(blockchainIdentifier);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        output = await neoExpress.run(
+          "reset",
+          "-f",
+          "--all",
+          "-i",
+          blockchainIdentifier.configPath
+        );
+      }
       NeoExpressCommands.showResult(output);
-    } finally {
+      if (output.isError || isFailedTx(output.message) || isNodeStillRunningError(output.message)) {
+        return;
+      }
       if (wasRunning) {
+        report("Restarting node...");
         await neoExpressInstanceManager.run(blockchainsTreeDataProvider, {
           blockchainIdentifier,
         });
       }
-    }
+    });
   }
 
   static async restoreCheckpoint(
@@ -284,43 +475,51 @@ export default class NeoExpressCommands {
     }
     const wasRunning = neoExpressInstanceManager.isRunning(identifier);
     await neoExpressInstanceManager.stopAll(identifier);
-    try {
-      const output = await neoExpress.run(
-        "checkpoint",
-        "restore",
-        "-f",
-        "-i",
-        identifier.configPath,
-        filename
-      );
-      NeoExpressCommands.showResult(output);
-    } finally {
-      if (wasRunning) {
-        await neoExpressInstanceManager.run(blockchainsTreeDataProvider, {
-          blockchainIdentifier: identifier,
-        });
-      }
+    const output = await neoExpress.run(
+      "checkpoint",
+      "restore",
+      "-f",
+      "-i",
+      identifier.configPath,
+      filename
+    );
+    NeoExpressCommands.showResult(output);
+    if (output.isError || isNodeStillRunningError(output.message)) {
+      return;
+    }
+    if (wasRunning) {
+      await neoExpressInstanceManager.run(blockchainsTreeDataProvider, {
+        blockchainIdentifier: identifier,
+      });
     }
   }
 
   static async transfer(
     neoExpress: NeoExpress,
     blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
-    commandArguments?: CommandArguments
+    autoComplete?: AutoComplete,
+    commandArguments?: CommandArguments,
+    preferred?: BlockchainIdentifier
   ) {
     const identifier =
       commandArguments?.blockchainIdentifier ||
-      (await blockchainsTreeDataProvider.select("express"));
+      (await blockchainsTreeDataProvider.select("express", preferred));
     if (!identifier) {
       return;
     }
-    let asset: string | undefined = undefined;
-    if (commandArguments?.asset?.toUpperCase() === "NEO") {
-      asset = "NEO";
-    } else if (commandArguments?.asset?.toUpperCase() === "GAS") {
-      asset = "GAS";
-    } else {
-      asset = await IoHelpers.multipleChoice("Select an asset", "NEO", "GAS");
+    const nep17 = autoComplete
+      ? contractsWithStandard(
+          autoComplete.data.contractManifests,
+          "NEP-17"
+        )
+      : [];
+    const assets = ["NEO", "GAS", ...nep17];
+    let asset: string | undefined = commandArguments?.asset;
+    if (!asset || assets.indexOf(asset) === -1) {
+      asset = await IoHelpers.multipleChoice(
+        "Select an asset (NEO, GAS, or NEP-17)",
+        ...assets
+      );
     }
     if (!asset) {
       return;
@@ -328,13 +527,13 @@ export default class NeoExpressCommands {
     const amount =
       commandArguments?.amount === undefined
         ? await IoHelpers.enterNumber(
-            `How many ${asset} should be transferred?`
+            `How many ${asset} should be transferred? Use a whole number, or check the token decimals.`
           )
         : commandArguments.amount;
     if (amount === undefined) {
       return;
     }
-    const walletNames = Object.keys(await identifier.getWalletAddresses());
+    const walletNames = await accountChoices(identifier, autoComplete);
     let sender = commandArguments?.sender;
     if (!sender || walletNames.indexOf(sender) === -1) {
       sender = await IoHelpers.multipleChoice(
@@ -343,6 +542,22 @@ export default class NeoExpressCommands {
       );
     }
     if (!sender) {
+      return;
+    }
+    const senderArg = accountSigner(sender, autoComplete);
+    const senderPassword = await passwordFlags(senderArg);
+    if (!senderPassword) {
+      return;
+    }
+    if (
+      !(await ensureAccountHasGas(
+        neoExpress,
+        identifier,
+        sender,
+        senderArg,
+        autoComplete
+      ))
+    ) {
       return;
     }
     let receiver = commandArguments?.receiver;
@@ -355,7 +570,7 @@ export default class NeoExpressCommands {
       );
     }
     if (receiver === CUSTOM_ADDRESS) {
-      receiver = await IoHelpers.enterString("Enter the recipients address");
+      receiver = await IoHelpers.enterString("Enter the recipient address");
     }
     if (!receiver) {
       return;
@@ -366,8 +581,96 @@ export default class NeoExpressCommands {
       identifier.configPath,
       `${amount}`,
       asset,
-      sender,
-      receiver
+      senderArg,
+      accountSigner(receiver, autoComplete),
+      ...senderPassword
+    );
+    NeoExpressCommands.showResult(output);
+  }
+
+  static async transferNft(
+    neoExpress: NeoExpress,
+    blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
+    autoComplete?: AutoComplete,
+    commandArguments?: CommandArguments,
+    preferred?: BlockchainIdentifier
+  ) {
+    const identifier =
+      commandArguments?.blockchainIdentifier ||
+      (await blockchainsTreeDataProvider.select("express", preferred));
+    if (!identifier) {
+      return;
+    }
+    const nep11 = autoComplete
+      ? contractsWithStandard(
+          autoComplete.data.contractManifests,
+          "NEP-11"
+        )
+      : [];
+    const contract =
+      commandArguments?.asset ||
+      (await IoHelpers.multipleChoice(
+        "Select a NEP-11 contract",
+        ...(nep11.length ? nep11 : ["(enter a symbol or hash)"])
+      ));
+    const nftContract =
+      !contract || contract.startsWith("(")
+        ? await IoHelpers.enterString("NEP-11 symbol or script hash")
+        : contract;
+    if (!nftContract) {
+      return;
+    }
+    const tokenId = await IoHelpers.enterString(
+      "Token id (0x-prefixed hex or base64)"
+    );
+    if (!tokenId) {
+      return;
+    }
+    const walletNames = await accountChoices(identifier, autoComplete);
+    const sender = await IoHelpers.multipleChoice(
+      "Transfer NFT from which wallet?",
+      ...walletNames
+    );
+    if (!sender) {
+      return;
+    }
+    const senderArg = accountSigner(sender, autoComplete);
+    const senderPassword = await passwordFlags(senderArg);
+    if (!senderPassword) {
+      return;
+    }
+    if (
+      !(await ensureAccountHasGas(
+        neoExpress,
+        identifier,
+        sender,
+        senderArg,
+        autoComplete
+      ))
+    ) {
+      return;
+    }
+    const CUSTOM_ADDRESS = "(enter an address manually)";
+    let receiver = await IoHelpers.multipleChoice(
+      `Transfer NFT from '${sender}' to...`,
+      ...walletNames,
+      CUSTOM_ADDRESS
+    );
+    if (receiver === CUSTOM_ADDRESS) {
+      receiver = await IoHelpers.enterString("Enter the recipient address");
+    }
+    if (!receiver) {
+      return;
+    }
+    const output = await neoExpress.run(
+      "transfernft",
+      "-i",
+      identifier.configPath,
+      nftContract,
+      tokenId,
+      senderArg,
+      accountSigner(receiver, autoComplete),
+      ...senderPassword
     );
     NeoExpressCommands.showResult(output);
   }
@@ -375,11 +678,12 @@ export default class NeoExpressCommands {
   static async walletCreate(
     neoExpress: NeoExpress,
     blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
-    commandArguments?: CommandArguments
+    commandArguments?: CommandArguments,
+    preferred?: BlockchainIdentifier
   ) {
     const identifier =
       commandArguments?.blockchainIdentifier ||
-      (await blockchainsTreeDataProvider.select("express"));
+      (await blockchainsTreeDataProvider.select("express", preferred));
     if (!identifier) {
       return;
     }
@@ -395,15 +699,37 @@ export default class NeoExpressCommands {
       identifier.configPath
     );
     NeoExpressCommands.showResult(output);
+    if (output.isError) {
+      return;
+    }
+    const fund = await IoHelpers.yesNo(
+      `Send 10000 GAS from genesis to "${walletName}" so it can pay fees?`
+    );
+    if (!fund) {
+      return;
+    }
+    const fundOutput = await neoExpress.run(
+      "transfer",
+      "-i",
+      identifier.configPath,
+      "10000",
+      "gas",
+      "genesis",
+      walletName
+    );
+    NeoExpressCommands.showResult(fundOutput);
   }
 
   private static showResult(output: { message: string; isError?: boolean }) {
-    if (output.isError) {
-      vscode.window.showErrorMessage(output.message || "Unknown error");
-    } else {
-      vscode.window.showInformationMessage(
-        output.message || "Command succeeded"
+    const message = stripAnsi(output.message || "");
+    if (output.isError || isFailedTx(message) || isNodeStillRunningError(message)) {
+      vscode.window.showErrorMessage(
+        isNodeStillRunningError(message)
+          ? "Could not reset or start Neo Express because a node is still running. Close the Neo Express terminal and try again."
+          : message || "Unknown error"
       );
+    } else {
+      vscode.window.showInformationMessage(message || "Command succeeded");
     }
   }
 }

--- a/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCreateCommand.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/commands/neoExpressCreateCommand.test.ts
@@ -5,6 +5,22 @@ import test from "node:test";
 
 const packageRoot = join(__dirname, "../../..");
 
+test("Visual Tracker deploy sends --gas only when the CLI supports it", () => {
+  const neoExpressCommands = readFileSync(
+    join(__dirname, "neoExpressCommands.ts"),
+    "utf8"
+  );
+  const neoExpress = readFileSync(
+    join(__dirname, "../neoExpress/neoExpress.ts"),
+    "utf8"
+  );
+  assert.match(neoExpressCommands, /supportsDeployGasOption/);
+  assert.match(neoExpressCommands, /unrecognized option/);
+  assert.match(neoExpress, /findRepoNeoxp/);
+  assert.match(neoExpress, /"src",\s+"neoxp",\s+"bin"/);
+  assert.match(neoExpress, /supportsDeployGasOption/);
+});
+
 test("Visual Tracker create commands pass Neo Express output explicitly", () => {
   const neoExpressCommands = readFileSync(
     join(__dirname, "neoExpressCommands.ts"),
@@ -33,4 +49,15 @@ test("Visual Tracker create commands pass Neo Express output explicitly", () => 
   );
   assert.match(csharpTemplate, /dotnet tool run neoxp -- create -o &quot;\$\(NeoExpressBatchInputFileFromWorkspace\)&quot;/);
   assert.match(csharpTemplate, /dotnet tool run neoxp -- wallet create -i &quot;\$\(NeoExpressBatchInputFileFromWorkspace\)&quot; owner/);
+  assert.match(csharpTemplate, /test\/\$_CLASSNAME_\$Tests\.neo-express/);
+  assert.doesNotMatch(csharpTemplate, /test\/default\.neo-express/);
+
+  const tools = JSON.parse(
+    readFileSync(
+      join(packageRoot, "resources/new-contract/csharp/.config/dotnet-tools.json"),
+      "utf8"
+    )
+  );
+  assert.equal(tools.tools["neo.express"].commands[0], "neoxp");
+  assert.equal(tools.tools["neo.compiler.csharp"].commands[0], "nccs");
 });

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/contractDetector.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/contractDetector.ts
@@ -43,11 +43,14 @@ export default class ContractDetector extends DetectorBase {
   ) {
     // TODO: Replace with a call to an RPC method that also exists on TestNet/MainNet
     //       See: https://github.com/neo-project/neo-modules/issues/426
+    const name = contractName.startsWith("#")
+      ? contractName.slice(1)
+      : contractName;
     try {
       return (await rpcClient.execute(
         new neonRpc.Query({
           method: "expressgetcontractstate",
-          params: [contractName],
+          params: [name],
         })
       )) as any[];
     } catch (e : any) {

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/neoExpressDetector.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/neoExpressDetector.ts
@@ -1,5 +1,6 @@
 import BlockchainIdentifier from "../blockchainIdentifier";
 import DetectorBase from "./detectorBase";
+import { isHiddenExpressConfig } from "../../shared/expressWalletAddresses";
 
 const SEARCH_PATTERN = "**/*.neo-express";
 
@@ -15,9 +16,10 @@ export default class NeoExpressDetector extends DetectorBase {
   }
 
   async processFiles() {
+    const visible = this.files.filter((file) => !isHiddenExpressConfig(file));
     this.blockchainsSnapshot = (
       await Promise.all(
-        this.files.map((_) =>
+        visible.map((_) =>
           BlockchainIdentifier.fromNeoExpressConfig(this.extensionPath, _)
         )
       )

--- a/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
+++ b/extentions/neo3-visual-tracker/src/extension/fileDetectors/serverListDetector.ts
@@ -10,6 +10,7 @@ import Log from "../util/log";
 import posixPath from "../util/posixPath";
 import parseServerListConfig from "./serverListConfig";
 import getTrustedWorkspaceServerListFiles from "./serverListWorkspaceTrust";
+import { knownGenesisHashForSeed } from "../../shared/publicChainSeeds";
 
 const LOG_PREFIX = "ServerListDetector";
 
@@ -168,7 +169,7 @@ export default class ServerListDetector extends DetectorBase {
     }
     const uniqueUrls = Object.getOwnPropertyNames(rpcUrls);
     const genesisBlockHashes = await Promise.all(
-      uniqueUrls.map((_) => this.tryGetGenesisBlockHash(_))
+      uniqueUrls.map((url) => this.identifyGenesisBlockHash(url))
     );
     const urlsByBlockchain: { [genesisHash: string]: string[] } = {};
     for (let i = 0; i < uniqueUrls.length; i++) {
@@ -193,10 +194,23 @@ export default class ServerListDetector extends DetectorBase {
     this.blockchainsSnapshot = newBlockchainsSnapshot;
   }
 
+  private identifyGenesisBlockHash(rpcUrl: string): Promise<string> {
+    const known = knownGenesisHashForSeed(rpcUrl);
+    if (known) {
+      return Promise.resolve(known);
+    }
+    return this.tryGetGenesisBlockHash(rpcUrl);
+  }
+
   private async tryGetGenesisBlockHash(rpcUrl: string) {
     try {
       const rpcClient = new neonCore.rpc.RPCClient(rpcUrl);
-      const genesisBlock = await rpcClient.getBlock(0, true);
+      const genesisBlock = await Promise.race([
+        rpcClient.getBlock(0, true),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("RPC timeout")), 2500)
+        ),
+      ]);
       return genesisBlock.hash;
     } catch (e : any) {
       Log.log(
@@ -209,3 +223,5 @@ export default class ServerListDetector extends DetectorBase {
     }
   }
 }
+
+

--- a/extentions/neo3-visual-tracker/src/extension/index.ts
+++ b/extentions/neo3-visual-tracker/src/extension/index.ts
@@ -12,7 +12,10 @@ import {
 } from "./commands/commandArguments";
 import ContractDetector from "./fileDetectors/contractDetector";
 import ContractsTreeDataProvider from "./vscodeProviders/contractsTreeDataProvider";
-import { getWorkspaceContractPath } from "./vscodeProviders/contractTreeCommand";
+import {
+  ContractTreeItemData,
+  getWorkspaceContractPath,
+} from "./vscodeProviders/contractTreeCommand";
 import Log from "./util/log";
 import NeoCommands from "./commands/neoCommands";
 import NeoExpress from "./neoExpress/neoExpress";
@@ -20,7 +23,7 @@ import NeoExpressCommands from "./commands/neoExpressCommands";
 import NeoExpressDetector from "./fileDetectors/neoExpressDetector";
 import NeoExpressInstanceManager from "./neoExpress/neoExpressInstanceManager";
 import NeoInvokeFileEditorProvider from "./vscodeProviders/neoInvokeFileEditorProvider";
-import QuickStartViewProvider from "./vscodeProviders/quickStartViewProvider";
+import QuickStartTreeDataProvider from "./vscodeProviders/quickStartTreeDataProvider";
 import ServerListDetector from "./fileDetectors/serverListDetector";
 import Templates from "./templates/templates";
 import TrackerCommands from "./commands/trackerCommands";
@@ -42,6 +45,9 @@ function registerCommand(
         if (context && !!(context as vscode.Uri).fsPath) {
           // Activation was by right-click on an item in the VS Code file explorer
           commandArguments.path = (context as vscode.Uri).fsPath;
+        } else if (context instanceof ContractTreeItemData) {
+          commandArguments.hash = context.hash;
+          commandArguments.path = context.path;
         } else if (getWorkspaceContractPath(context)) {
           // Activation was by a workspace contract in the Smart contracts tree
           commandArguments.path = getWorkspaceContractPath(context);
@@ -61,6 +67,9 @@ function registerCommand(
 
 export async function activate(context: vscode.ExtensionContext) {
   Log.log(LOG_PREFIX, "Activating extension...");
+  const loading = vscode.window.setStatusBarMessage(
+    "$(sync~spin) Loading Neo N3 Visual DevTracker..."
+  );
   const blockchainMonitorPool = new BlockchainMonitorPool();
   const walletDetector = new WalletDetector();
   const neoExpress = new NeoExpress(context);
@@ -143,11 +152,12 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
+  loading.dispose();
+
   context.subscriptions.push(
-    vscode.window.registerWebviewViewProvider(
+    vscode.window.registerTreeDataProvider(
       "neo3-visual-devtracker.views.quickStart",
-      new QuickStartViewProvider(
-        context,
+      new QuickStartTreeDataProvider(
         blockchainsTreeDataProvider,
         neoExpressInstanceManager,
         checkpointDetector,
@@ -197,7 +207,9 @@ export async function activate(context: vscode.ExtensionContext) {
         neoExpress,
         contractDetector,
         blockchainsTreeDataProvider,
-        commandArguments
+        commandArguments,
+        autoComplete,
+        activeConnection.connection?.blockchainIdentifier
       )
   );
 
@@ -245,7 +257,8 @@ export async function activate(context: vscode.ExtensionContext) {
         neoExpress,
         neoExpressInstanceManager,
         blockchainsTreeDataProvider,
-        commandArguments
+        commandArguments,
+        activeConnection.connection?.blockchainIdentifier
       )
   );
 
@@ -299,7 +312,22 @@ export async function activate(context: vscode.ExtensionContext) {
       NeoExpressCommands.transfer(
         neoExpress,
         blockchainsTreeDataProvider,
-        commandArguments
+        autoComplete,
+        commandArguments,
+        activeConnection.connection?.blockchainIdentifier
+      )
+  );
+
+  registerCommand(
+    context,
+    "neo3-visual-devtracker.express.transferNft",
+    (commandArguments) =>
+      NeoExpressCommands.transferNft(
+        neoExpress,
+        blockchainsTreeDataProvider,
+        autoComplete,
+        commandArguments,
+        activeConnection.connection?.blockchainIdentifier
       )
   );
 
@@ -310,7 +338,8 @@ export async function activate(context: vscode.ExtensionContext) {
       NeoExpressCommands.walletCreate(
         neoExpress,
         blockchainsTreeDataProvider,
-        commandArguments
+        commandArguments,
+        activeConnection.connection?.blockchainIdentifier
       )
   );
 
@@ -332,7 +361,9 @@ export async function activate(context: vscode.ExtensionContext) {
     (commandArguments) =>
       NeoCommands.invokeContract(
         activeConnection,
+        autoComplete,
         blockchainsTreeDataProvider,
+        contractDetector,
         commandArguments
       )
   );

--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpress.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpress.ts
@@ -16,26 +16,36 @@ type Command =
   | "show"
   | "stop"
   | "transfer"
+  | "transfernft"
   | "wallet"
   | "-v";
 
 const DOTNET_CHECK_EXPIRY_IN_MS = 60000;
 const LOG_PREFIX = "NeoExpress";
-const TIMEOUT_IN_MS = 5000;
+// create / reset / checkpoint / deploy routinely exceed a few seconds.
+const TIMEOUT_IN_MS = 60000;
 const TIMEOUT_POLLING_INTERVAL_IN_MS = 2000;
+const MIN_DOTNET_MAJOR = 10;
 
 export default class NeoExpress {
   private readonly binaryPath: string;
   private readonly dotnetPath: string;
+  private readonly busyStatus: vscode.StatusBarItem;
 
   private runLock: boolean;
   private checkForDotNetPassedAt: number;
+  private deployGasSupported: boolean | null;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.binaryPath = NeoExpress.resolveBinaryPath(this.context.extensionPath);
     this.dotnetPath = which.sync("dotnet", { nothrow: true }) || "dotnet";
     this.runLock = false;
     this.checkForDotNetPassedAt = 0;
+    this.deployGasSupported = null;
+    this.busyStatus = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      40
+    );
   }
 
   // A packed .NET tool places its assemblies under tools/<target-framework>/any/.
@@ -54,37 +64,105 @@ export default class NeoExpress {
         return posixPath(toolsRoot, framework, "any", "neoxp.dll");
       }
     } catch {
-      // toolsRoot is missing or unreadable; fall through to the error below.
+      // toolsRoot is missing or unreadable; fall through to a repo build or PATH.
+    }
+    const fromRepo = NeoExpress.findRepoNeoxp(extensionPath);
+    if (fromRepo) {
+      Log.log(
+        LOG_PREFIX,
+        `Bundled neoxp not found under ${toolsRoot}; using repo build: ${fromRepo}`
+      );
+      return fromRepo;
+    }
+    const fromPath = which.sync("neoxp", { nothrow: true });
+    if (fromPath) {
+      Log.log(
+        LOG_PREFIX,
+        `Bundled neoxp not found under ${toolsRoot}; using PATH: ${fromPath}`
+      );
+      return fromPath;
     }
     Log.error(
       LOG_PREFIX,
-      `Could not locate bundled neoxp under ${toolsRoot}; the extension package may be incomplete.`
+      `Could not locate bundled neoxp under ${toolsRoot} and neoxp is not on PATH.`
     );
     return posixPath(toolsRoot, "neoxp.dll");
+  }
+
+  private static findRepoNeoxp(extensionPath: string): string | null {
+    const binRoot = posixPath(extensionPath, "..", "..", "src", "neoxp", "bin");
+    for (const configuration of ["Debug", "Release"]) {
+      const configurationDir = posixPath(binRoot, configuration);
+      try {
+        const tfm = fs
+          .readdirSync(configurationDir)
+          .find((name) =>
+            fs.existsSync(posixPath(configurationDir, name, "neoxp.dll"))
+          );
+        if (tfm) {
+          return posixPath(configurationDir, tfm, "neoxp.dll");
+        }
+      } catch {
+        // This configuration has not been built.
+      }
+    }
+    return null;
+  }
+
+  async supportsDeployGasOption(): Promise<boolean> {
+    if (this.deployGasSupported !== null) {
+      return this.deployGasSupported;
+    }
+    const help = await this.runUnlocked("contract", "deploy", "--help");
+    this.deployGasSupported = /\s(-g|--gas)\b/i.test(help.message);
+    return this.deployGasSupported;
+  }
+
+  private spawnArgs(commandArgs: string[]): { command: string; args: string[] } {
+    if (this.binaryPath.toLowerCase().endsWith(".dll")) {
+      return { command: this.dotnetPath, args: [this.binaryPath, ...commandArgs] };
+    }
+    return { command: this.binaryPath, args: commandArgs };
   }
 
   async runInTerminal(name: string, command: Command, ...options: string[]) {
     if (!(await this.checkForDotNetAsync())) {
       return null;
     }
-    const dotNetArguments = [this.binaryPath, command, ...options];
-    const pty = new NeoExpressTerminal(this.dotnetPath, dotNetArguments);
+    const spawned = this.spawnArgs([command, ...options]);
+    const pty = new NeoExpressTerminal(spawned.command, spawned.args);
     const terminal = vscode.window.createTerminal({ name, pty });
+    terminal.show();
 
-    const hasStarted: Promise<void> = new Promise((resolve) => {
+    const START_TIMEOUT_MS = 30000;
+    const started = await new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (value: boolean) => {
+        if (!settled) {
+          settled = true;
+          resolve(value);
+        }
+      };
+      const timeout = setTimeout(() => finish(false), START_TIMEOUT_MS);
       pty.onDidWrite((data) => {
         if (data.indexOf("Neo express is running") !== -1) {
-          resolve();
+          clearTimeout(timeout);
+          finish(true);
         }
+      });
+      pty.onDidExit((code) => {
+        clearTimeout(timeout);
+        finish(code === 0);
       });
     });
 
-    terminal.show();
-
-    // Give the terminal a chance to get a lock on the blockchain before
-    // starting to do any offline commands.
-    await hasStarted;
-
+    if (!started) {
+      Log.warn(
+        LOG_PREFIX,
+        `Neo Express did not start in ${name} (timeout or process exited)`
+      );
+      return null;
+    }
     return terminal;
   }
 
@@ -95,6 +173,13 @@ export default class NeoExpress {
     return this.runInDirectory(undefined, command, ...options);
   }
 
+  runUnlocked(
+    command: string,
+    ...options: string[]
+  ): Promise<{ message: string; isError?: boolean }> {
+    return this.runUnsafe(undefined, command, ...options);
+  }
+
   async runInDirectory(
     cwd: string | undefined,
     command: Command,
@@ -102,7 +187,7 @@ export default class NeoExpress {
   ): Promise<{ message: string; isError?: boolean }> {
     let durationInternal = 0;
     const startedAtExternal = new Date().getTime();
-    const releaseLock = await this.getRunLock();
+    const releaseLock = await this.getRunLock(`neoxp ${command}...`);
     try {
       const startedAtInternal = new Date().getTime();
       const result = await this.runUnsafe(cwd, command, ...options);
@@ -116,7 +201,7 @@ export default class NeoExpress {
       if (durationExternal > 1000) {
         Log.log(
           LOG_PREFIX,
-          `\`neoexp ${command} ${options.join(
+          `\`neoxp ${command} ${options.join(
             " "
           )}\` took ${durationInternal}ms (${durationExternal}ms including time spent awaiting run-lock)`
         );
@@ -132,15 +217,11 @@ export default class NeoExpress {
     if (!(await this.checkForDotNetAsync())) {
       return { message: "Could not launch Neo Express", isError: true };
     }
-    const dotNetArguments = [
-      this.binaryPath,
-      ...command.split(/\s/),
-      ...options,
-    ];
+    const spawned = this.spawnArgs([...command.split(/\s/), ...options]);
     try {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         const startedAt = new Date().getTime();
-        const process = childProcess.spawn(this.dotnetPath, dotNetArguments, {
+        const process = childProcess.spawn(spawned.command, spawned.args, {
           cwd,
         });
         let complete = false;
@@ -155,28 +236,33 @@ export default class NeoExpress {
                 `Could not kill timed out neoxp command: ${command} (${e.message})`
               );
             }
-            reject("Operation timed out");
+            resolve({
+              message: `Neo Express CLI timed out after ${TIMEOUT_IN_MS / 1000}s: neoxp ${command} ${options.join(" ")}`,
+              isError: true,
+            });
           } else if (!complete) {
             setTimeout(watchdog, TIMEOUT_POLLING_INTERVAL_IN_MS);
           }
         };
         watchdog();
         let message = "";
-        process.stdout.on(
-          "data",
-          (d) => (message = `${message}${d.toString()}`)
-        );
-        process.stderr.on(
-          "data",
-          (d) => (message = `${message}${d.toString()}`)
-        );
+        const append = (chunk: Buffer | string) => {
+          const text = chunk.toString();
+          message = `${message}${text}`;
+          Log.log(LOG_PREFIX, text.trimEnd());
+        };
+        process.stdout.on("data", append);
+        process.stderr.on("data", append);
         process.on("close", (code) => {
           complete = true;
           resolve({ message, isError: code !== 0 });
         });
-        process.on("error", () => {
+        process.on("error", (error) => {
           complete = true;
-          reject();
+          resolve({
+            message: error.message || "Failed to start Neo Express CLI",
+            isError: true,
+          });
         });
       });
     } catch (e : any) {
@@ -203,7 +289,7 @@ export default class NeoExpress {
       ok =
         parseInt(
           childProcess.execFileSync(this.dotnetPath, ["--version"]).toString()
-        ) >= 6;
+        ) >= MIN_DOTNET_MAJOR;
     } catch (e : any) {
       Log.error(LOG_PREFIX, "checkForDotNetAsync error:", e.message);
       ok = false;
@@ -212,7 +298,7 @@ export default class NeoExpress {
       this.checkForDotNetPassedAt = now;
     } else {
       const response = await vscode.window.showErrorMessage(
-        ".NET 6 or higher is required to use this functionality.",
+        ".NET 10 or higher is required to use this functionality.",
         "Dismiss",
         "More info"
       );
@@ -226,13 +312,20 @@ export default class NeoExpress {
     return ok;
   }
 
-  private async getRunLock(): Promise<() => void> {
+  private async getRunLock(label: string): Promise<() => void> {
+    const started = Date.now();
     while (this.runLock) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      const seconds = Math.round((Date.now() - started) / 1000);
+      this.busyStatus.text = `$(sync~spin) Waiting for Neo Express CLI (${seconds}s)...`;
+      this.busyStatus.show();
+      await new Promise((resolve) => setTimeout(resolve, 200));
     }
     this.runLock = true;
+    this.busyStatus.text = `$(sync~spin) ${label}`;
+    this.busyStatus.show();
     return () => {
       this.runLock = false;
+      this.busyStatus.hide();
     };
   }
 }

--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressInstanceManager.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressInstanceManager.ts
@@ -60,18 +60,9 @@ export default class NeoExpressInstanceManager {
       return;
     }
 
-    const secondsPerBlock = commandArguments.secondsPerBlock || 15;
+    const secondsPerBlock = commandArguments.secondsPerBlock || 3;
 
-    const runningPreviously = this.running;
-    await this.stopAll();
-
-    const connectedTo = this.activeConnection.connection?.blockchainIdentifier;
-    if (
-      connectedTo?.blockchainType === "express" &&
-      connectedTo?.configPath === runningPreviously?.configPath
-    ) {
-      await this.activeConnection.disconnect(true);
-    }
+    await this.stopAll(identifier);
 
     const children = identifier.getChildren();
     if (children.length) {
@@ -106,12 +97,17 @@ export default class NeoExpressInstanceManager {
       }
     }
 
-    this.running = identifier;
-
-    if (!this.activeConnection.connection?.blockchainMonitor.healthy) {
-      await this.activeConnection.connect(identifier);
+    if (!this.terminals.length) {
+      this.running = null;
+      vscode.window.showErrorMessage(
+        "Neo Express failed to start. Check the terminal for details."
+      );
+      this.onChangeEmitter.fire();
+      return;
     }
 
+    this.running = identifier;
+    await this.activeConnection.connect(identifier);
     this.onChangeEmitter.fire();
   }
 
@@ -153,6 +149,14 @@ export default class NeoExpressInstanceManager {
 
   async stopAll(identifier?: BlockchainIdentifier) {
     const target = identifier || this.running;
+    if (
+      target &&
+      this.activeConnection.connection?.blockchainIdentifier.configPath ===
+        target.configPath
+    ) {
+      await this.activeConnection.disconnect(true);
+    }
+
     if (target?.blockchainType === "express") {
       const output = await this.neoExpress.run(
         "stop",
@@ -171,14 +175,18 @@ export default class NeoExpressInstanceManager {
     }
 
     try {
-      for (const terminal of this.terminals) {
+      const terminals = this.matchingTerminals(target);
+      for (const terminal of terminals) {
         if (!terminal.exitStatus) {
           terminal.dispose();
-          while (!terminal.exitStatus) {
-            Log.log("Waiting for terminal to close...");
-            await new Promise((resolve) => setTimeout(resolve, 500));
-          }
         }
+      }
+      const deadline = Date.now() + 8000;
+      while (
+        terminals.some((terminal) => !terminal.exitStatus) &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
       }
     } catch (e : any) {
       Log.warn(
@@ -192,6 +200,22 @@ export default class NeoExpressInstanceManager {
       this.running = null;
       this.onChangeEmitter.fire();
     }
+  }
+
+  private matchingTerminals(target?: BlockchainIdentifier | null) {
+    const known = new Set(this.terminals);
+    if (target) {
+      const names = new Set<string>([
+        target.name,
+        ...target.getChildren().map((child) => child.name),
+      ]);
+      for (const terminal of vscode.window.terminals) {
+        if (names.has(terminal.name)) {
+          known.add(terminal);
+        }
+      }
+    }
+    return [...known];
   }
 
   private async checkTerminals() {

--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressIo.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressIo.ts
@@ -16,7 +16,7 @@ export default class NeoExpressIo {
     if (identifer.blockchainType !== "express") {
       return null;
     }
-    const output = await neoExpress.run(
+    const output = await neoExpress.runUnlocked(
       "contract",
       "get",
       hashOrNefPath,
@@ -42,7 +42,7 @@ export default class NeoExpressIo {
     if (identifer.blockchainType !== "express") {
       return {};
     }
-    const output = await neoExpress.run(
+    const output = await neoExpress.runUnlocked(
       "contract",
       "list",
       "-i",

--- a/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressTerminal.ts
+++ b/extentions/neo3-visual-tracker/src/extension/neoExpress/neoExpressTerminal.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 
 export default class NeoExpressTerminal {
   private readonly closeEmitter: vscode.EventEmitter<void | number>;
+  private readonly exitEmitter: vscode.EventEmitter<number | null>;
   private readonly writeEmitter: vscode.EventEmitter<string>;
 
   private dimensions: vscode.TerminalDimensions | undefined | null;
@@ -13,6 +14,7 @@ export default class NeoExpressTerminal {
     private readonly shellArgs: string[]
   ) {
     this.closeEmitter = new vscode.EventEmitter<void | number>();
+    this.exitEmitter = new vscode.EventEmitter<number | null>();
     this.writeEmitter = new vscode.EventEmitter<string>();
     this.dimensions = null;
     this.process = null;
@@ -22,12 +24,16 @@ export default class NeoExpressTerminal {
     return this.closeEmitter.event;
   }
 
+  get onDidExit() {
+    return this.exitEmitter.event;
+  }
+
   get onDidWrite() {
     return this.writeEmitter.event;
   }
 
   close() {
-    this.process?.kill();
+    this.killProcess();
   }
 
   handleInput(data: string) {
@@ -60,6 +66,7 @@ export default class NeoExpressTerminal {
         )
       );
       this.process = null;
+      this.exitEmitter.fire(code);
     });
     this.process.on("error", () => {
       this.writeEmitter.fire(
@@ -68,11 +75,36 @@ export default class NeoExpressTerminal {
         )
       );
       this.process = null;
+      this.exitEmitter.fire(1);
     });
   }
 
   setDimensions(dimensions: vscode.TerminalDimensions) {
     this.dimensions = dimensions;
+  }
+
+  private killProcess() {
+    const proc = this.process;
+    if (!proc?.pid) {
+      return;
+    }
+    try {
+      if (process.platform === "win32") {
+        childProcess.spawnSync(
+          "taskkill",
+          ["/pid", String(proc.pid), "/t", "/f"],
+          { windowsHide: true }
+        );
+      } else {
+        proc.kill("SIGKILL");
+      }
+    } catch {
+      try {
+        proc.kill();
+      } catch {
+        // Process is already gone.
+      }
+    }
   }
 
   private bold(text: string) {

--- a/extentions/neo3-visual-tracker/src/extension/panelControllers/invokeFilePanelController.ts
+++ b/extentions/neo3-visual-tracker/src/extension/panelControllers/invokeFilePanelController.ts
@@ -10,6 +10,7 @@ import InvokeFileViewRequest from "../../shared/messages/invokeFileViewRequest";
 import InvokeFileViewState from "../../shared/viewState/invokeFileViewState";
 import {
   areInvocationStepsReady,
+  areInvocationStepsSafe,
   isLiveDebugWitnessScopeSupported,
   isWitnessScope,
   resolveSelectedAccount,
@@ -22,10 +23,36 @@ import Log from "../util/log";
 import NeoExpress from "../neoExpress/neoExpress";
 import PanelControllerBase from "./panelControllerBase";
 import posixPath from "../util/posixPath";
+import stripAnsi from "../util/stripAnsi";
+import {
+  formatInvokeMessage,
+  isFailedTx,
+  parseSubmittedTxids,
+} from "../../shared/neoExpressTx";
+import { ensureAccountHasGas, passwordFlags, withStatus } from "../util/txPrep";
 import TransactionStatus from "../../shared/transactionStatus";
 
 const LOG_PREFIX = "InvokeFilePanelController";
 const MAX_RECENT_TXS = 10;
+
+function formatInvokeError(message: string): string {
+  const notFound = /contract "([^"]+)" not found/i.exec(message);
+  if (notFound) {
+    return (
+      `Contract "${notFound[1]}" is not deployed on this Neo Express chain. ` +
+      `Deploy the matching .nef (Smart contracts → deploy, or neoxp contract deploy) ` +
+      `or invoke a deployed name such as SampleContract. ` +
+      `The # prefix is a workspace name, not a file path.`
+    );
+  }
+  if (/insufficient gas/i.test(message)) {
+    return (
+      `${message} The signing account needs GAS for fees. Use genesis (it holds genesis GAS), ` +
+      `or Quick Start → Transfer NEO, GAS, or NEP-17 to send GAS from genesis to the wallet.`
+    );
+  }
+  return message;
+}
 
 export default class InvokeFilePanelController extends PanelControllerBase<
   InvokeFileViewState,
@@ -61,9 +88,11 @@ export default class InvokeFilePanelController extends PanelControllerBase<
         isPartOfDiffView,
         isReadOnly,
         jsonMode: false,
+        lastInvocation: null,
         recentTransactions: [],
         selectedAccount: null,
         selectedTransactionId: null,
+        showInvocationResult: false,
         witnessScope: "CalledByEntry",
       },
       context,
@@ -77,6 +106,7 @@ export default class InvokeFilePanelController extends PanelControllerBase<
       }
     });
     this.autoComplete.onChange(async () => {
+      await this.refreshExecutionContext();
       await this.updateViewState({
         autoCompleteData: await this.augmentAutoCompleteData(
           this.autoComplete.data
@@ -160,8 +190,16 @@ export default class InvokeFilePanelController extends PanelControllerBase<
           "Configure a contract and method for every invocation before running all steps."
         );
       } else {
-        await this.runFile(this.document.uri.fsPath, "All steps");
+        await this.runFile(
+          this.document.uri.fsPath,
+          "All steps",
+          this.viewState.fileContents
+        );
       }
+    }
+
+    if (request.dismissInvocationResult) {
+      await this.updateViewState({ showInvocationResult: false });
     }
 
     if (request.runStep) {
@@ -174,6 +212,7 @@ export default class InvokeFilePanelController extends PanelControllerBase<
         await this.runFragment(fragment);
       }
     }
+
 
     if (request.selectTransaction) {
       await this.updateViewState({
@@ -349,7 +388,11 @@ export default class InvokeFilePanelController extends PanelControllerBase<
     }
   }
 
-  private async runFile(filePath: string, operation?: string) {
+  private async runFile(
+    filePath: string,
+    operation?: string,
+    steps?: { contract?: string; operation?: string }[]
+  ) {
     let connection = this.activeConnection.connection;
     if (!connection) {
       await this.activeConnection.connect();
@@ -366,7 +409,7 @@ export default class InvokeFilePanelController extends PanelControllerBase<
       connection.blockchainIdentifier.blockchainType === "express"
     ) {
       const walletNames = Object.keys(
-        await connection.blockchainIdentifier.getWalletAddresses()
+        this.autoComplete.data.wellKnownAddresses
       );
       let account = this.viewState.selectedAccount || undefined;
       if (!account || !walletNames.includes(account)) {
@@ -378,43 +421,116 @@ export default class InvokeFilePanelController extends PanelControllerBase<
       if (!account) {
         return;
       }
-      const witnessScope = this.viewState.witnessScope;
-      await this.document.save();
-      await this.updateViewState({ collapseTransactions: false });
-      const result = await this.neoExpress.runInDirectory(
-        path.dirname(this.document.uri.fsPath),
-        "contract",
-        "invoke",
-        "-w",
-        witnessScope,
-        "-i",
-        connection.blockchainIdentifier.configPath,
-        filePath,
-        account
-      );
-      if (result.isError) {
-        // showErrorMessage is not await'ed so that the loading spinner does not hang:
-        vscode.window.showErrorMessage(result.message);
-      } else {
-        const recentTransactions = [...this.viewState.recentTransactions];
-        for (const txidMatch of ` ${result.message} `.matchAll(
-          /\s0x[0-9a-f]+\s/gi
-        )) {
-          const txid = txidMatch[0].trim();
-          recentTransactions.unshift({
-            account,
-            txid,
-            blockchain: connection.blockchainIdentifier.name,
-            operation,
-            state: "pending",
-            submittedAt: new Date().toISOString(),
-          });
-        }
-        if (recentTransactions.length > MAX_RECENT_TXS) {
-          recentTransactions.length = MAX_RECENT_TXS;
-        }
-        await this.updateViewState({ recentTransactions });
+      const displayName = account;
+      account =
+        this.autoComplete.data.accountSigners?.[account] || account;
+      const password = await passwordFlags(account);
+      if (!password) {
+        return;
       }
+      const trial = areInvocationStepsSafe(
+        steps || this.viewState.fileContents,
+        this.viewState.autoCompleteData
+      );
+      let result: { message: string; isError?: boolean };
+      try {
+        result = await withStatus("Invoking contract", async (report) => {
+          if (!trial) {
+            report("Checking GAS balance...");
+            if (
+              !(await ensureAccountHasGas(
+                this.neoExpress,
+                connection.blockchainIdentifier,
+                displayName,
+                account,
+                this.autoComplete,
+                report
+              ))
+            ) {
+              return { isError: true, message: "" };
+            }
+          }
+          const witnessScope = this.viewState.witnessScope;
+          await this.document.save();
+          await this.updateViewState({ collapseTransactions: false });
+          report(
+            trial
+              ? "Running invocation for results..."
+              : "Submitting invocation..."
+          );
+          Log.writeInvocation("");
+          Log.writeInvocation(
+            `----- ${operation || "Invocation"} (${trial ? "results" : "submit"}) -----`
+          );
+          Log.writeInvocation("Running...");
+          Log.showInvocation();
+          return this.neoExpress.runInDirectory(
+            path.dirname(this.document.uri.fsPath),
+            "contract",
+            "invoke",
+            "-w",
+            witnessScope,
+            "-i",
+            connection.blockchainIdentifier.configPath,
+            filePath,
+            account,
+            ...(trial ? ["--results", "--json"] : []),
+            ...password
+          );
+        });
+      } catch (error: any) {
+        await this.showInvocationResult({
+          operation,
+          success: false,
+          message: `Invocation failed: ${error?.message || error}`,
+          txids: [],
+        });
+        return;
+      }
+      if (!result.message) {
+        if (result.isError) {
+          return;
+        }
+        await this.showInvocationResult({
+          operation,
+          success: false,
+          message:
+            "Invocation finished with no output. Check the Neo N3 Visual DevTracker output channel.",
+          txids: [],
+        });
+        return;
+      }
+      const rawMessage = stripAnsi(result.message);
+      const success = !result.isError && !isFailedTx(rawMessage);
+      const message = success
+        ? formatInvokeMessage(rawMessage)
+        : formatInvokeError(rawMessage);
+      const txids = parseSubmittedTxids(rawMessage);
+      const submittedAt = new Date().toISOString();
+      const recentTransactions = [...this.viewState.recentTransactions];
+      for (const txid of txids) {
+        recentTransactions.unshift({
+          account,
+          txid,
+          blockchain: connection.blockchainIdentifier.name,
+          operation,
+          output: message,
+          state: "pending",
+          submittedAt,
+        });
+      }
+      if (recentTransactions.length > MAX_RECENT_TXS) {
+        recentTransactions.length = MAX_RECENT_TXS;
+      }
+      await this.showInvocationResult(
+        {
+          operation,
+          success,
+          message,
+          txids,
+        },
+        recentTransactions
+      );
     } else {
       // showWarningMessage is not await'ed so that the loading spinner does not hang:
       vscode.window.showWarningMessage(
@@ -431,7 +547,9 @@ export default class InvokeFilePanelController extends PanelControllerBase<
     );
     try {
       fs.writeFileSync(tempFile, JSONC.stringify([fragment]));
-      await this.runFile(tempFile, fragment?.operation || "Invocation");
+      await this.runFile(tempFile, fragment?.operation || "Invocation", [
+        fragment,
+      ]);
     } catch (e : any) {
       Log.warn(
         LOG_PREFIX,
@@ -536,6 +654,36 @@ export default class InvokeFilePanelController extends PanelControllerBase<
     }
   }
 
+  private async showInvocationResult(
+    result: {
+      message: string;
+      operation?: string;
+      success: boolean;
+      txids: string[];
+    },
+    recentTransactions?: InvokeFileViewState["recentTransactions"]
+  ) {
+    Log.writeInvocation(result.success ? "Succeeded" : "Failed");
+    if (result.operation) {
+      Log.writeInvocation(`Operation: ${result.operation}`);
+    }
+    if (result.message) {
+      Log.writeInvocation(result.message);
+    }
+    for (const txid of result.txids) {
+      Log.writeInvocation(txid);
+    }
+    Log.showInvocation();
+    await this.updateViewState({
+      lastInvocation: {
+        ...result,
+        submittedAt: new Date().toISOString(),
+      },
+      showInvocationResult: true,
+      ...(recentTransactions ? { recentTransactions } : {}),
+    });
+  }
+
   private async updateTransactionList() {
     const connection = this.activeConnection.connection;
 
@@ -579,9 +727,7 @@ export default class InvokeFilePanelController extends PanelControllerBase<
     const isExpressConnection =
       connection?.blockchainIdentifier.blockchainType === "express";
     const executionAccounts = isExpressConnection
-      ? toInvocationAccounts(
-          await connection.blockchainIdentifier.getWalletAddresses()
-        )
+      ? toInvocationAccounts(this.autoComplete.data.wellKnownAddresses)
       : [];
     await this.updateViewState({
       connectionHealthy: connection?.blockchainMonitor.healthy || false,

--- a/extentions/neo3-visual-tracker/src/extension/templates/csharpStarters.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/csharpStarters.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  csharpStarterLabels,
+  csharpStarters,
+  findCsharpStarter,
+} from "./csharpStarters";
+
+const packageRoot = join(__dirname, "../../..");
+const startersRoot = join(packageRoot, "resources/new-contract/csharp-starters");
+const csharpRoot = join(packageRoot, "resources/new-contract/csharp");
+
+test("C# starter catalog matches Neo.SmartContract.Template plus storage", () => {
+  assert.deepEqual(
+    csharpStarters.map((starter) => starter.id),
+    ["blank", "nep17", "nep11", "oracle", "ownable", "storage"]
+  );
+  assert.deepEqual(csharpStarterLabels(), [
+    "Blank contract",
+    "NEP-17 token",
+    "NEP-11 NFT",
+    "Oracle",
+    "Ownable",
+    "Storage (number map)",
+  ]);
+  assert.equal(findCsharpStarter("NEP-17 token")?.id, "nep17");
+  assert.equal(findCsharpStarter("Storage (number map)")?.overlay, false);
+  assert.equal(findCsharpStarter("missing"), undefined);
+});
+
+test("overlay C# starters ship contract source and neo-express tests", () => {
+  for (const starter of csharpStarters.filter((item) => item.overlay)) {
+    const source = join(
+      startersRoot,
+      starter.id,
+      "src",
+      "$_CLASSNAME_$.cs.template.txt"
+    );
+    const tests = join(
+      startersRoot,
+      starter.id,
+      "test",
+      "$_CLASSNAME_$Tests.cs.template.txt"
+    );
+    assert.equal(existsSync(source), true, `missing ${source}`);
+    assert.equal(existsSync(tests), true, `missing ${tests}`);
+    const sourceText = readFileSync(source, "utf8");
+    assert.match(sourceText, /class \$_CLASSNAME_\$/);
+    assert.match(sourceText, /namespace \$_CONTRACTNAME_\$/);
+    assert.match(
+      sourceText,
+      /neo-devpack-dotnet\/tree\/master-n3\/src\/Neo\.SmartContract\.Template/
+    );
+  }
+});
+
+test("storage starter stays the default C# scaffold", () => {
+  const source = join(csharpRoot, "src", "$_CLASSNAME_$.cs.template.txt");
+  const tests = join(csharpRoot, "test", "$_CLASSNAME_$Tests.cs.template.txt");
+  const tools = join(csharpRoot, ".config", "dotnet-tools.json");
+  const csproj = join(csharpRoot, "src", "$_CLASSNAME_$.csproj.template.txt");
+  assert.equal(existsSync(source), true);
+  assert.equal(existsSync(tests), true);
+  assert.equal(existsSync(tools), true);
+  const sourceText = readFileSync(source, "utf8");
+  assert.match(sourceText, /ChangeNumber/);
+  const toolsJson = JSON.parse(readFileSync(tools, "utf8"));
+  assert.equal(toolsJson.tools["neo.express"].version, "3.10.1");
+  assert.equal(toolsJson.tools["neo.compiler.csharp"].version, "3.10.1");
+  const csprojText = readFileSync(csproj, "utf8");
+  assert.match(csprojText, /Neo\.BuildTasks/);
+  assert.match(csprojText, /NeoContractName>\$_CLASSNAME_\$/);
+});
+
+test("csharp-starters contains only cataloged overlay ids", () => {
+  const ids = readdirSync(startersRoot).sort();
+  assert.deepEqual(
+    ids,
+    csharpStarters
+      .filter((starter) => starter.overlay)
+      .map((starter) => starter.id)
+      .sort()
+  );
+});

--- a/extentions/neo3-visual-tracker/src/extension/templates/csharpStarters.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/csharpStarters.ts
@@ -1,0 +1,30 @@
+export type CsharpStarter = {
+  id: string;
+  label: string;
+  /** Overlay files from csharp-starters/<id> after the C# scaffold. */
+  overlay: boolean;
+};
+
+/**
+ * C# starters based on Neo.SmartContract.Template
+ * (https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template).
+ * Official unit-test projects are not included.
+ */
+export const csharpStarters: CsharpStarter[] = [
+  { id: "blank", label: "Blank contract", overlay: true },
+  { id: "nep17", label: "NEP-17 token", overlay: true },
+  { id: "nep11", label: "NEP-11 NFT", overlay: true },
+  { id: "oracle", label: "Oracle", overlay: true },
+  { id: "ownable", label: "Ownable", overlay: true },
+  { id: "storage", label: "Storage (number map)", overlay: false },
+];
+
+export function csharpStarterLabels(): string[] {
+  return csharpStarters.map((starter) => starter.label);
+}
+
+export function findCsharpStarter(
+  label: string
+): CsharpStarter | undefined {
+  return csharpStarters.find((starter) => starter.label === label);
+}

--- a/extentions/neo3-visual-tracker/src/extension/templates/hydrateTemplates.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/hydrateTemplates.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { hydrateFiles, substituteParameters } from "./hydrateTemplates";
+
+const packageRoot = join(__dirname, "../../..");
+
+test("substituteParameters replaces every placeholder", () => {
+  assert.equal(
+    substituteParameters("src/$_CLASSNAME_$.cs in $_CONTRACTNAME_$", {
+      $_CLASSNAME_$: "TokenEscrowContract",
+      $_CONTRACTNAME_$: "TokenEscrow",
+    }),
+    "src/TokenEscrowContract.cs in TokenEscrow"
+  );
+});
+
+test("hydrateFiles overlays a C# starter onto the scaffold", async () => {
+  const destination = await mkdtemp(join(tmpdir(), "neoxp-template-"));
+  const parameters = {
+    $_CLASSNAME_$: "TokenEscrowContract",
+    $_CONTRACTNAME_$: "TokenEscrow",
+    $_MAINFILE_$: "src/TokenEscrowContract.cs",
+  };
+
+  try {
+    await hydrateFiles(
+      join(packageRoot, "resources/new-contract/csharp"),
+      destination,
+      parameters
+    );
+    await hydrateFiles(
+      join(packageRoot, "resources/new-contract/csharp-starters/nep17"),
+      destination,
+      parameters
+    );
+
+    const contract = await readFile(
+      join(destination, "src/TokenEscrowContract.cs"),
+      "utf8"
+    );
+    assert.match(contract, /class TokenEscrowContract : Nep17Token/);
+    assert.match(contract, /namespace TokenEscrow/);
+    assert.doesNotMatch(contract, /\$_CLASSNAME_\$/);
+    assert.doesNotMatch(contract, /ChangeNumber/);
+
+    const tests = await readFile(
+      join(destination, "test/TokenEscrowContractTests.cs"),
+      "utf8"
+    );
+    assert.match(tests, /c\.symbol\(\)/);
+    assert.match(tests, /EXAMPLE/);
+
+    const csproj = await readFile(
+      join(destination, "src/TokenEscrowContract.csproj"),
+      "utf8"
+    );
+    assert.match(csproj, /Neo\.BuildTasks/);
+    assert.match(csproj, /NeoContractName>TokenEscrowContract/);
+
+    const tools = JSON.parse(
+      await readFile(join(destination, ".config/dotnet-tools.json"), "utf8")
+    );
+    assert.equal(tools.tools["neo.express"].commands[0], "neoxp");
+  } finally {
+    await rm(destination, { recursive: true, force: true });
+  }
+});
+
+test("hydrateFiles can create a blank official starter", async () => {
+  const destination = await mkdtemp(join(tmpdir(), "neoxp-blank-"));
+  const parameters = {
+    $_CLASSNAME_$: "HelloContract",
+    $_CONTRACTNAME_$: "Hello",
+  };
+
+  try {
+    await hydrateFiles(
+      join(packageRoot, "resources/new-contract/csharp"),
+      destination,
+      parameters
+    );
+    await hydrateFiles(
+      join(packageRoot, "resources/new-contract/csharp-starters/blank"),
+      destination,
+      parameters
+    );
+    const contract = await readFile(
+      join(destination, "src/HelloContract.cs"),
+      "utf8"
+    );
+    assert.match(contract, /class HelloContract : SmartContract/);
+    assert.match(contract, /MyMethod/);
+    assert.doesNotMatch(contract, /ChangeNumber/);
+  } finally {
+    await rm(destination, { recursive: true, force: true });
+  }
+});

--- a/extentions/neo3-visual-tracker/src/extension/templates/hydrateTemplates.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/hydrateTemplates.ts
@@ -1,0 +1,47 @@
+import * as fs from "fs";
+
+import posixPath from "../util/posixPath";
+
+export function substituteParameters(
+  input: string,
+  parameters: { [key: string]: string }
+): string {
+  let result = input;
+  for (const key of Object.keys(parameters)) {
+    result = result.replaceAll(key, parameters[key]);
+  }
+  return result;
+}
+
+export async function hydrateFiles(
+  templatePath: string,
+  destinationPath: string,
+  parameters: { [key: string]: string }
+) {
+  await fs.promises.mkdir(destinationPath, { recursive: true });
+  const templateFolderContents = await fs.promises.readdir(templatePath);
+  for (const item of templateFolderContents) {
+    const fullPathToSource = posixPath(templatePath, item);
+    const resolvedName = substituteParameters(item, parameters);
+    const fullPathToDestination = posixPath(destinationPath, resolvedName);
+    const stat = await fs.promises.stat(fullPathToSource);
+    if (stat.isDirectory()) {
+      await hydrateFiles(
+        fullPathToSource,
+        posixPath(destinationPath, resolvedName),
+        parameters
+      );
+    } else if (item.endsWith(".template.txt")) {
+      const fileContents = (
+        await fs.promises.readFile(fullPathToSource)
+      ).toString();
+      const resolvedContents = substituteParameters(fileContents, parameters);
+      await fs.promises.writeFile(
+        fullPathToDestination.replace(/\.template\.txt$/, ""),
+        resolvedContents
+      );
+    } else {
+      await fs.promises.copyFile(fullPathToSource, fullPathToDestination);
+    }
+  }
+}

--- a/extentions/neo3-visual-tracker/src/extension/templates/languages.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/languages.ts
@@ -196,7 +196,12 @@ const languages: { [code: string]: Language } = {
         group: "set-private-chain",
         type: "shell",
         command: "neoxp",
-        args: ["batch", "-i", "$_CONTRACTNAME_$Tests.neo-express", "test/setup-test-chain.batch"],
+        args: [
+          "batch",
+          "-i",
+          "test/$_CONTRACTNAME_$Tests.neo-express",
+          "test/setup-test-chain.batch",
+        ],
         problemMatcher: [],
       },
       {

--- a/extentions/neo3-visual-tracker/src/extension/templates/samples.examples.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/samples.examples.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const examplesRoot = join(
+  __dirname,
+  "../../../../../samples/examples"
+);
+
+const expected = [
+  { folder: "Blank", contract: "Contract", batch: "Contract.nef" },
+  { folder: "Nep17", contract: "Nep17Contract", batch: "Nep17Contract.nef" },
+  { folder: "Nep11", contract: "Nep11Contract", batch: "Nep11Contract.nef" },
+  { folder: "Oracle", contract: "OracleRequest", batch: "OracleRequest.nef" },
+  { folder: "Ownable", contract: "Ownable", batch: "Ownable.nef" },
+];
+
+test("samples/examples uses a neo-express + BuildTasks layout", () => {
+  const props = readFileSync(
+    join(examplesRoot, "Directory.Build.props"),
+    "utf8"
+  );
+  assert.match(props, /Neo\.BuildTasks/);
+  assert.match(props, /DeployContractToNeoExpress/);
+  assert.match(props, /contract deploy/);
+  assert.match(props, /dotnet tool run neoxp -- create/);
+  assert.equal(existsSync(join(examplesRoot, "README.md")), true);
+
+  for (const example of expected) {
+    const root = join(examplesRoot, example.folder);
+    const csproj = readdirSync(root).find((name) => name.endsWith(".csproj"));
+    assert.ok(csproj, `${example.folder} is missing a root csproj for 'dotnet build'`);
+    const csprojText = readFileSync(join(root, csproj!), "utf8");
+    assert.match(
+      csprojText,
+      new RegExp(`<NeoContractName>${example.contract}</NeoContractName>`)
+    );
+    const batch = readFileSync(join(root, "express.batch"), "utf8");
+    assert.match(batch, new RegExp(`contract deploy .*${example.batch} genesis`));
+    assert.equal(
+      existsSync(join(root, "src", `${example.contract}.cs`)) ||
+        readdirSync(join(root, "src")).some((name) => name.endsWith(".cs")),
+      true
+    );
+    const sources = readdirSync(join(root, "src")).filter((name) =>
+      name.endsWith(".cs")
+    );
+    for (const source of sources) {
+      const text = readFileSync(join(root, "src", source), "utf8");
+      assert.doesNotMatch(text, /NUnit|MSTest|Xunit/, `${source} pulled in tests`);
+    }
+  }
+});

--- a/extentions/neo3-visual-tracker/src/extension/templates/templates.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/templates.ts
@@ -3,6 +3,12 @@ import * as vscode from "vscode";
 
 import IoHelpers from "../util/ioHelpers";
 import JSONC from "../util/JSONC";
+import {
+  csharpStarterLabels,
+  findCsharpStarter,
+  CsharpStarter,
+} from "./csharpStarters";
+import { hydrateFiles } from "./hydrateTemplates";
 import { Language, languages } from "./languages";
 import posixPath from "../util/posixPath";
 import workspaceFolder from "../util/workspaceFolder";
@@ -17,14 +23,44 @@ export default class Templates {
       return;
     }
 
-    const languageCode = await IoHelpers.multipleChoice(
-      "Choose a programming language",
-      ...Object.keys(languages)
+    const languageLabels: { [code: string]: string } = {
+      csharp: "C# (recommended for N3)",
+      python: "Python (neo3-boa)",
+      java: "Java (neow3j)",
+    };
+    const languageChoices = Object.keys(languages).map(
+      (code) => languageLabels[code] || code
     );
-    if (!languageCode) {
+    const languageChoice = await IoHelpers.multipleChoice(
+      "Language for the new contract",
+      ...languageChoices
+    );
+    if (!languageChoice) {
       return;
     }
+    const languageCode =
+      Object.keys(languageLabels).find(
+        (code) => languageLabels[code] === languageChoice
+      ) || languageChoice;
     const language = languages[languageCode];
+    if (!language) {
+      return;
+    }
+
+    let csharpStarter: CsharpStarter | undefined;
+    if (languageCode === "csharp") {
+      const starterChoice = await IoHelpers.multipleChoice(
+        "Contract template",
+        ...csharpStarterLabels()
+      );
+      if (!starterChoice) {
+        return;
+      }
+      csharpStarter = findCsharpStarter(starterChoice);
+      if (!csharpStarter) {
+        return;
+      }
+    }
 
     const parameters = await Templates.gatherParameters(language);
     if (!parameters) {
@@ -46,11 +82,26 @@ export default class Templates {
       return;
     }
 
-    await Templates.hydrateFiles(
-      language,
-      templatePath,
-      contractPath,
-      parameters
+    await hydrateFiles(templatePath, contractPath, parameters);
+    if (csharpStarter?.overlay) {
+      await hydrateFiles(
+        posixPath(
+          context.extensionPath,
+          "resources",
+          "new-contract",
+          "csharp-starters",
+          csharpStarter.id
+        ),
+        contractPath,
+        parameters
+      );
+    }
+
+    const starterNote = csharpStarter
+      ? ` (${csharpStarter.label})`
+      : "";
+    vscode.window.showInformationMessage(
+      `Created ${contractName}${starterNote} under contracts/${contractName}. Build it, then deploy from Smart contracts.`
     );
 
     const mainFile = parameters["$_MAINFILE_$"];
@@ -206,58 +257,6 @@ export default class Templates {
         }
         result[`$_${variableName}_$`] = value;
       }
-    }
-    return result;
-  }
-
-  private static async hydrateFiles(
-    language: Language,
-    templatePath: string,
-    destinationPath: string,
-    parameters: { [key: string]: string }
-  ) {
-    await fs.promises.mkdir(destinationPath, { recursive: true });
-    const templateFolderContents = await fs.promises.readdir(templatePath);
-    for (const item of templateFolderContents) {
-      const fullPathToSource = posixPath(templatePath, item);
-      const resolvedName = await Templates.substituteParameters(
-        item,
-        parameters
-      );
-      const fullPathToDestination = posixPath(destinationPath, resolvedName);
-      const stat = await fs.promises.stat(fullPathToSource);
-      if (stat.isDirectory()) {
-        await Templates.hydrateFiles(
-          language,
-          fullPathToSource,
-          posixPath(destinationPath, resolvedName),
-          parameters
-        );
-      } else if (item.endsWith(".template.txt")) {
-        const fileContents = (
-          await fs.promises.readFile(fullPathToSource)
-        ).toString();
-        const resolvedContents = await Templates.substituteParameters(
-          fileContents,
-          parameters
-        );
-        await fs.promises.writeFile(
-          fullPathToDestination.replace(/\.template\.txt$/, ""),
-          resolvedContents
-        );
-      } else {
-        await fs.promises.copyFile(fullPathToSource, fullPathToDestination);
-      }
-    }
-  }
-
-  private static async substituteParameters(
-    input: string,
-    parameters: { [key: string]: string }
-  ): Promise<string> {
-    let result = input;
-    for (const key of Object.keys(parameters)) {
-      result = result.replaceAll(key, parameters[key]);
     }
     return result;
   }

--- a/extentions/neo3-visual-tracker/src/extension/templates/templates.wizard.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/templates/templates.wizard.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const templatesSource = readFileSync(join(__dirname, "templates.ts"), "utf8");
+const createContractSource = readFileSync(
+  join(__dirname, "../../panel/components/quickStart/CreateContract.tsx"),
+  "utf8"
+);
+
+test("New contract wizard asks for a C# starter after language", () => {
+  assert.match(templatesSource, /languageCode === "csharp"/);
+  assert.match(templatesSource, /Contract template/);
+  assert.match(templatesSource, /csharpStarterLabels\(\)/);
+  assert.match(templatesSource, /csharpStarter\?\.overlay/);
+  assert.match(
+    templatesSource,
+    /resources",\s+"new-contract",\s+"csharp-starters"/
+  );
+});
+
+test("Quick Start new-contract copy mentions official C# starters", () => {
+  assert.match(createContractSource, /NEP-17/);
+  assert.match(createContractSource, /NEP-11/);
+  assert.match(createContractSource, /Oracle/);
+  assert.match(createContractSource, /Ownable/);
+});

--- a/extentions/neo3-visual-tracker/src/extension/util/log.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/log.ts
@@ -6,6 +6,7 @@ const PREFIX_COLUMN_WIDTH = 20;
 const startTimeMs = new Date().getTime();
 
 let outputChannel: vscode.OutputChannel | null = null;
+let invocationChannel: vscode.OutputChannel | null = null;
 
 function secondsSinceStart() {
   return `${((new Date().getTime() - startTimeMs) / 1000).toFixed(2)}s`;
@@ -27,20 +28,43 @@ function log(
 ) {
   const prefix = `${secondsSinceStart()}\t${truncate(logPrefix)}`;
   consoleLogger(prefix, ...args);
+  ensureOutputChannel().appendLine(
+    `${level} ${prefix} ${args.map((_) => JSON.stringify(_)).join(" ")}`
+  );
+}
+
+function ensureOutputChannel() {
   if (!outputChannel) {
     outputChannel = vscode.window.createOutputChannel(
       "Neo N3 Visual DevTracker"
     );
   }
-  outputChannel.appendLine(
-    `${level} ${prefix} ${args.map((_) => JSON.stringify(_)).join(" ")}`
-  );
+  return outputChannel;
+}
+
+function ensureInvocationChannel() {
+  if (!invocationChannel) {
+    invocationChannel = vscode.window.createOutputChannel(
+      "Neo Express Invocation"
+    );
+  }
+  return invocationChannel;
 }
 
 export default class Log {
   static close() {
     outputChannel?.dispose();
     outputChannel = null;
+    invocationChannel?.dispose();
+    invocationChannel = null;
+  }
+
+  static writeInvocation(text: string) {
+    ensureInvocationChannel().appendLine(text);
+  }
+
+  static showInvocation(preserveFocus = true) {
+    ensureInvocationChannel().show(preserveFocus);
   }
 
   static debug(logPrefix: string, ...args: any[]) {

--- a/extentions/neo3-visual-tracker/src/extension/util/stripAnsi.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/stripAnsi.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import stripAnsi from "./stripAnsi";
+
+test("stripAnsi removes neoxp error coloring", () => {
+  const raw =
+    "\u001b[1m\u001b[31m\u001b[40mSystem.InvalidOperationException: contract \"TestContract\" not found\u001b[0m";
+  assert.equal(
+    stripAnsi(raw),
+    'System.InvalidOperationException: contract "TestContract" not found'
+  );
+});
+
+test("stripAnsi leaves plain text unchanged", () => {
+  assert.equal(stripAnsi("ok"), "ok");
+});

--- a/extentions/neo3-visual-tracker/src/extension/util/stripAnsi.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/stripAnsi.ts
@@ -1,4 +1,4 @@
-const ANSI_RE = /\u001b\[[0-9;]*m/g;
+const ANSI_RE = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
 
 /** Strip VT/ANSI color codes from neoxp CLI output before showing VS Code toasts. */
 export default function stripAnsi(text: string): string {

--- a/extentions/neo3-visual-tracker/src/extension/util/stripAnsi.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/stripAnsi.ts
@@ -1,0 +1,6 @@
+const ANSI_RE = /\u001b\[[0-9;]*m/g;
+
+/** Strip VT/ANSI color codes from neoxp CLI output before showing VS Code toasts. */
+export default function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "").trim();
+}

--- a/extentions/neo3-visual-tracker/src/extension/util/tryFetchJson.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/tryFetchJson.test.ts
@@ -26,6 +26,7 @@ moduleLoader._load = function (
         createOutputChannel: () => ({
           appendLine: () => undefined,
           dispose: () => undefined,
+          show: () => undefined,
         }),
       },
     };

--- a/extentions/neo3-visual-tracker/src/extension/util/txPrep.ts
+++ b/extentions/neo3-visual-tracker/src/extension/util/txPrep.ts
@@ -1,0 +1,211 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+import AutoComplete from "../autoComplete";
+import BlockchainIdentifier from "../blockchainIdentifier";
+import IoHelpers from "./ioHelpers";
+import NeoExpress from "../neoExpress/neoExpress";
+import stripAnsi from "./stripAnsi";
+import {
+  isContractOnChain,
+  isFailedTx,
+  looksLikeEncryptedWallet,
+  parseApplicationLogState,
+  parseGasBalance,
+  parseSubmittedTxids,
+} from "../../shared/neoExpressTx";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withStatus<T>(
+  message: string,
+  work: (report: (msg: string) => void) => Promise<T>
+): Promise<T> {
+  return vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Window,
+      title: "Neo Express",
+    },
+    async (progress) => {
+      progress.report({ message });
+      return work((msg) => {
+        progress.report({ message: msg });
+      });
+    }
+  );
+}
+
+export async function passwordFlags(
+  account: string
+): Promise<string[] | undefined> {
+  if (!looksLikeEncryptedWallet(account)) {
+    return [];
+  }
+  const password = await IoHelpers.enterPassword(
+    `Password for ${path.basename(account)}`
+  );
+  if (password === undefined) {
+    return undefined;
+  }
+  return ["--password", password];
+}
+
+export async function ensureAccountHasGas(
+  neoExpress: NeoExpress,
+  identifier: BlockchainIdentifier,
+  displayName: string,
+  signer: string,
+  autoComplete?: AutoComplete,
+  report?: (msg: string) => void
+): Promise<boolean> {
+  if (displayName === "genesis" || signer === "genesis") {
+    return true;
+  }
+  const lookup = autoComplete?.data.wellKnownAddresses[displayName] || signer;
+  report?.(`Checking GAS for ${displayName}...`);
+  const existing = await readGasBalance(neoExpress, identifier, lookup);
+  if (existing === null || existing > 0) {
+    return true;
+  }
+  const fund = await IoHelpers.yesNo(
+    `"${displayName}" has no GAS. Send 10000 GAS from genesis so this account can pay fees?`
+  );
+  if (!fund) {
+    return false;
+  }
+  report?.(`Sending 10000 GAS from genesis to ${displayName}...`);
+  const fundOutput = await neoExpress.run(
+    "transfer",
+    "-i",
+    identifier.configPath,
+    "10000",
+    "gas",
+    "genesis",
+    lookup
+  );
+  if (fundOutput.isError || isFailedTx(fundOutput.message)) {
+    vscode.window.showErrorMessage(
+      stripAnsi(fundOutput.message) || "Could not send GAS from genesis."
+    );
+    return false;
+  }
+  const confirmed = await waitForGasBalance(
+    neoExpress,
+    identifier,
+    lookup,
+    1,
+    45000,
+    report
+  );
+  if (confirmed === null || confirmed <= 0) {
+    vscode.window.showErrorMessage(
+      `Sent GAS from genesis to ${displayName}, but the balance is still 0. Wait for the next block and try again.`
+    );
+    return false;
+  }
+  vscode.window.showInformationMessage(
+    `Sent 10000 GAS from genesis to ${displayName}. Balance is now ${confirmed} GAS.`
+  );
+  return true;
+}
+
+async function readGasBalance(
+  neoExpress: NeoExpress,
+  identifier: BlockchainIdentifier,
+  account: string
+): Promise<number | null> {
+  const output = await neoExpress.run(
+    "show",
+    "balances",
+    account,
+    "-i",
+    identifier.configPath
+  );
+  return parseGasBalance(output.message);
+}
+
+export async function waitForGasBalance(
+  neoExpress: NeoExpress,
+  identifier: BlockchainIdentifier,
+  account: string,
+  minGas: number,
+  timeoutMs = 45000,
+  report?: (msg: string) => void
+): Promise<number | null> {
+  const started = Date.now();
+  let last: number | null = null;
+  while (Date.now() - started < timeoutMs) {
+    report?.(`Waiting for GAS on ${account}...`);
+    last = await readGasBalance(neoExpress, identifier, account);
+    if (last !== null && last >= minGas) {
+      return last;
+    }
+    await sleep(1000);
+  }
+  return last;
+}
+
+export async function waitForContract(
+  neoExpress: NeoExpress,
+  identifier: BlockchainIdentifier,
+  contractName: string,
+  timeoutMs = 45000,
+  report?: (msg: string) => void
+): Promise<boolean> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    report?.(`Waiting for ${contractName} on chain...`);
+    const output = await neoExpress.run(
+      "contract",
+      "get",
+      contractName,
+      "-i",
+      identifier.configPath
+    );
+    if (!output.isError && isContractOnChain(output.message)) {
+      return true;
+    }
+    await sleep(1000);
+  }
+  return false;
+}
+
+export async function waitForTransactionResult(
+  neoExpress: NeoExpress,
+  identifier: BlockchainIdentifier,
+  txid: string,
+  timeoutMs = 20000,
+  report?: (msg: string) => void
+): Promise<{ ok: boolean; message: string }> {
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    report?.(`Waiting for transaction ${txid.slice(0, 10)}...`);
+    const output = await neoExpress.run(
+      "show",
+      "transaction",
+      txid,
+      "-i",
+      identifier.configPath
+    );
+    last = stripAnsi(output.message);
+    if (!output.isError) {
+      const state = parseApplicationLogState(last);
+      if (state === "FAULT" || isFailedTx(last)) {
+        return { ok: false, message: last };
+      }
+      if (state === "HALT") {
+        return { ok: true, message: last };
+      }
+    }
+    await sleep(500);
+  }
+  return {
+    ok: false,
+    message: last || `Transaction ${txid} did not confirm`,
+  };
+}
+
+export { isFailedTx, parseSubmittedTxids };

--- a/extentions/neo3-visual-tracker/src/extension/vscodeProviders/blockchainsTreeDataProvider.ts
+++ b/extentions/neo3-visual-tracker/src/extension/vscodeProviders/blockchainsTreeDataProvider.ts
@@ -6,6 +6,7 @@ import IoHelpers from "../util/ioHelpers";
 import Log from "../util/log";
 import NeoExpressDetector from "../fileDetectors/neoExpressDetector";
 import ServerListDetector from "../fileDetectors/serverListDetector";
+import sameFilePath from "../util/sameFilePath";
 
 const LOG_PREFIX = "BlockchainsTreeDataProvider";
 
@@ -54,21 +55,55 @@ export default class BlockchainsTreeDataProvider
 
   async refresh() {
     Log.log(LOG_PREFIX, "Refreshing tree view...");
-    this.rootElements = [
+    const combined = [
       ...this.serverListDetector.blockchains,
       ...this.neoExpressDetector.blockchains,
     ];
+    const unique: BlockchainIdentifier[] = [];
+    for (const chain of combined) {
+      if (
+        chain.configPath &&
+        unique.some(
+          (existing) =>
+            existing.configPath &&
+            sameFilePath(existing.configPath, chain.configPath)
+        )
+      ) {
+        continue;
+      }
+      unique.push(chain);
+    }
+    this.rootElements = unique;
     this.onDidChangeTreeDataEmitter.fire();
   }
 
   async select(
-    blockchainTypeFilter?: BlockchainType
+    blockchainTypeFilter?: BlockchainType,
+    preferred?: BlockchainIdentifier
   ): Promise<BlockchainIdentifier | undefined> {
     const candidates = this.rootElements.filter(
       (_) => !blockchainTypeFilter || _.blockchainType === blockchainTypeFilter
     );
     if (!candidates.length) {
       return;
+    }
+    if (
+      preferred &&
+      candidates.some(
+        (candidate) =>
+          candidate.configPath &&
+          preferred.configPath &&
+          sameFilePath(candidate.configPath, preferred.configPath)
+      )
+    ) {
+      return (
+        candidates.find(
+          (candidate) =>
+            candidate.configPath &&
+            preferred.configPath &&
+            sameFilePath(candidate.configPath, preferred.configPath)
+        ) || preferred
+      );
     }
     if (candidates.length === 1) {
       return candidates[0];

--- a/extentions/neo3-visual-tracker/src/extension/vscodeProviders/contractTreeCommand.test.ts
+++ b/extentions/neo3-visual-tracker/src/extension/vscodeProviders/contractTreeCommand.test.ts
@@ -6,19 +6,22 @@ import getContractTreeCommand, {
   getWorkspaceContractPath,
 } from "./contractTreeCommand";
 
-test("getContractTreeCommand opens deployed contracts", () => {
-  assert.deepEqual(getContractTreeCommand({ name: "Sample", hash: "0x1234" }), {
-    command: "neo3-visual-devtracker.tracker.openContract",
-    arguments: [{ hash: "0x1234" }],
-    title: "0x1234",
+test("getContractTreeCommand opens Contract Studio for deployed contracts", () => {
+  const contract = { name: "Sample", hash: "0x1234" };
+  assert.deepEqual(getContractTreeCommand(contract), {
+    command: "neo3-visual-devtracker.neo.openContractStudio",
+    arguments: [contract],
+    title: "Invoke in Contract Studio",
   });
 });
 
-test("getContractTreeCommand does not open workspace contracts on selection", () => {
-  assert.equal(
-    getContractTreeCommand({ name: "Sample", path: "/workspace/Sample.nef" }),
-    undefined
-  );
+test("getContractTreeCommand opens Contract Studio for workspace contracts", () => {
+  const contract = { name: "Sample", path: "/workspace/Sample.nef" };
+  assert.deepEqual(getContractTreeCommand(contract), {
+    command: "neo3-visual-devtracker.neo.openContractStudio",
+    arguments: [contract],
+    title: "Invoke in Contract Studio",
+  });
 });
 
 test("workspace contract tree items expose their trusted file path", () => {

--- a/extentions/neo3-visual-tracker/src/extension/vscodeProviders/contractTreeCommand.ts
+++ b/extentions/neo3-visual-tracker/src/extension/vscodeProviders/contractTreeCommand.ts
@@ -19,13 +19,13 @@ export function getWorkspaceContractPath(context: unknown) {
 }
 
 export default function getContractTreeCommand(contract: ContractTreeData) {
-  if (!contract.hash) {
+  if (!contract.hash && !contract.path) {
     return undefined;
   }
 
   return {
-    command: "neo3-visual-devtracker.tracker.openContract",
-    arguments: [{ hash: contract.hash }],
-    title: contract.hash,
+    command: "neo3-visual-devtracker.neo.openContractStudio",
+    arguments: [contract],
+    title: "Invoke in Contract Studio",
   };
 }

--- a/extentions/neo3-visual-tracker/src/extension/vscodeProviders/quickStartTreeDataProvider.ts
+++ b/extentions/neo3-visual-tracker/src/extension/vscodeProviders/quickStartTreeDataProvider.ts
@@ -1,0 +1,139 @@
+import * as vscode from "vscode";
+
+import ActiveConnection from "../activeConnection";
+import BlockchainsTreeDataProvider from "./blockchainsTreeDataProvider";
+import ContractDetector from "../fileDetectors/contractDetector";
+import CheckpointDetector from "../fileDetectors/checkpointDetector";
+import NeoExpressInstanceManager from "../neoExpress/neoExpressInstanceManager";
+import {
+  describeQuickStartAction,
+  getQuickStartActions,
+  QuickStartActionItem,
+} from "../../panel/components/views/quickStartActions";
+import QuickStartViewState from "../../shared/viewState/quickStartViewState";
+import WalletDetector from "../fileDetectors/walletDetector";
+
+export default class QuickStartTreeDataProvider
+  implements vscode.TreeDataProvider<QuickStartActionItem>
+{
+  onDidChangeTreeData: vscode.Event<void>;
+
+  private readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<void>;
+  private items: QuickStartActionItem[] = [];
+
+  constructor(
+    private readonly blockchainsTreeDataProvider: BlockchainsTreeDataProvider,
+    private readonly neoExpressInstanceManager: NeoExpressInstanceManager,
+    private readonly checkpointDetector: CheckpointDetector,
+    private readonly contractDetector: ContractDetector,
+    private readonly activeConnection: ActiveConnection,
+    private readonly walletDetector: WalletDetector
+  ) {
+    this.onDidChangeTreeDataEmitter = new vscode.EventEmitter<void>();
+    this.onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
+    vscode.workspace.onDidChangeWorkspaceFolders(() => this.refresh());
+    this.blockchainsTreeDataProvider.onDidChangeTreeData(() => this.refresh());
+    this.neoExpressInstanceManager.onChange(() => this.refresh());
+    this.checkpointDetector.onChange(() => this.refresh());
+    this.contractDetector.onChange(() => this.refresh());
+    this.activeConnection.onChange(() => this.refresh());
+    this.walletDetector.onChange(() => this.refresh());
+    this.refresh();
+  }
+
+  getTreeItem(item: QuickStartActionItem): vscode.TreeItem {
+    if (!item.command) {
+      return {
+        label: " ",
+        collapsibleState: vscode.TreeItemCollapsibleState.None,
+      };
+    }
+    return {
+      label: item.label,
+      tooltip: item.tooltip,
+      collapsibleState: vscode.TreeItemCollapsibleState.None,
+      command: {
+        command: item.command,
+        title: item.label,
+      },
+    };
+  }
+
+  getChildren(item?: QuickStartActionItem): QuickStartActionItem[] {
+    return item ? [] : this.items;
+  }
+
+  private async refresh() {
+    const connectionName =
+      this.activeConnection.connection?.blockchainIdentifier.friendlyName ||
+      null;
+
+    let neoDeploymentRequired = false;
+    let neoExpressDeploymentRequired = false;
+    const deploymentRequired =
+      Object.values(this.contractDetector.contracts).filter(
+        (_) => _.deploymentRequired
+      ).length > 0;
+    if (deploymentRequired) {
+      if (
+        this.activeConnection.connection?.blockchainIdentifier
+          .blockchainType === "express"
+      ) {
+        neoExpressDeploymentRequired = true;
+      } else {
+        neoDeploymentRequired = true;
+      }
+    }
+
+    const hasContracts =
+      Object.keys(this.contractDetector.contracts).length > 0;
+
+    const hasDeployedContract =
+      Object.values(this.contractDetector.contracts).filter((_) => _.deployed)
+        .length > 0;
+
+    const neoExpressInstances = this.blockchainsTreeDataProvider
+      .getChildren()
+      .filter((_) => _.blockchainType === "express");
+
+    const hasNeoExpressInstance = neoExpressInstances.length > 0;
+
+    const hasCheckpointCompatibleNeoExpressInstance = (
+      await Promise.all(neoExpressInstances.map((_) => _.isSingleNodeExpress()))
+    ).some(Boolean);
+
+    const viewState: QuickStartViewState = {
+      view: "quickStart",
+      panelTitle: "",
+      connectionName,
+      hasContracts,
+      hasDeployedContract,
+      hasNeoExpressInstance,
+      hasWallets: this.walletDetector.wallets.length > 0,
+      hasCheckpoints: this.checkpointDetector.checkpointFiles.length > 0,
+      hasCheckpointCompatibleNeoExpressInstance,
+      neoDeploymentRequired,
+      neoExpressDeploymentRequired,
+      neoExpressIsRunning:
+        this.neoExpressInstanceManager.runningInstance?.blockchainType ===
+          "express" ||
+        (this.activeConnection.connection?.blockchainIdentifier
+          .blockchainType === "express" &&
+          !!this.activeConnection.connection?.blockchainMonitor.healthy),
+      workspaceIsOpen: !!vscode.workspace.workspaceFolders?.length,
+    };
+
+    this.items = [
+      ...getQuickStartActions(viewState).map((action) =>
+        describeQuickStartAction(action, viewState)
+      ),
+      {
+        action: "createOrOpenWorkspace",
+        label: " ",
+        tooltip: "",
+        command: "",
+      },
+    ];
+    this.onDidChangeTreeDataEmitter.fire();
+  }
+}

--- a/extentions/neo3-visual-tracker/src/extension/vscodeProviders/walletsTreeDataProvider.ts
+++ b/extentions/neo3-visual-tracker/src/extension/vscodeProviders/walletsTreeDataProvider.ts
@@ -5,6 +5,7 @@ import AutoComplete from "../autoComplete";
 import Log from "../util/log";
 import posixPath from "../util/posixPath";
 import WalletDetector from "../fileDetectors/walletDetector";
+import { workspaceWalletDisplayName } from "../../shared/expressWalletAddresses";
 
 const LOG_PREFIX = "WalletsTreeDataProvider";
 
@@ -64,7 +65,7 @@ export default class WalletsTreeDataProvider
       for (const account of nep6Wallet.accounts) {
         newData.push({
           address: account.address,
-          name: account.label,
+          name: workspaceWalletDisplayName(nep6Wallet.path, account.label),
           path: nep6Wallet.path,
           isNeoExpress: false,
         });

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/ContractInput.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/ContractInput.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 
 import AutoCompleteData from "../../../shared/autoCompleteData";
-import ContractTile from "./ContractTile";
 import dedupeAndSort from "../../../extension/util/dedupeAndSort";
-import InputNonDraggable from "../InputNonDraggable";
 
 type Props = {
   autoCompleteData: AutoCompleteData;
@@ -14,6 +12,15 @@ type Props = {
   setContract: (newValue: string) => void;
 };
 
+export function listContractOptions(autoCompleteData: AutoCompleteData): string[] {
+  const names = Object.keys(autoCompleteData.contractManifests)
+    .filter((candidate) => !candidate.startsWith("0x"))
+    .map((candidate) =>
+      candidate.startsWith("#") ? candidate : `#${candidate}`
+    );
+  return dedupeAndSort(names);
+}
+
 export default function ContractInput({
   autoCompleteData,
   contract,
@@ -22,70 +29,63 @@ export default function ContractInput({
   isReadOnly,
   setContract,
 }: Props) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const selectRef = useRef<HTMLSelectElement>(null);
   const inputId = useRef(
     `neo-contract-${Math.random().toString(36).slice(2)}`
   ).current;
-  const [hasFocus, setHasFocus] = useState(false);
 
   useEffect(() => {
     if (forceFocus) {
-      inputRef.current?.focus();
+      selectRef.current?.focus();
     }
   }, [forceFocus]);
 
-  const allNamesAndHashes = dedupeAndSort(
-    Object.keys(autoCompleteData.contractManifests).map((candidate) =>
-      candidate.startsWith("0x")
-        ? autoCompleteData.contractNames[candidate] || candidate
-        : candidate
-    )
-  );
-  let contractHashOrName = contract || "";
-  if (contractHashOrName.startsWith("#")) {
-    contractHashOrName = contractHashOrName.substring(1);
+  const options = listContractOptions(autoCompleteData);
+  const current = contract || "";
+  const known = options.includes(current);
+
+  if (options.length) {
+    return (
+      <div className="neo-field">
+        <label className="neo-field__label" htmlFor={inputId}>
+          Contract
+        </label>
+        <select
+          className="neo-select"
+          disabled={isReadOnly}
+          id={inputId}
+          ref={selectRef}
+          value={known ? current : ""}
+          onChange={(event) => setContract(event.target.value)}
+        >
+          <option value="">Select a contract…</option>
+          {options.map((candidate) => (
+            <option key={candidate} value={candidate}>
+              {candidate.replace(/^#/, "")}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
   }
-  const alternateName =
-    autoCompleteData.contractNames[contractHashOrName] || "";
 
   return (
-    <div className="neo-field neo-combobox">
+    <div className="neo-field">
       <label className="neo-field__label" htmlFor={inputId}>
         Contract
       </label>
-      <InputNonDraggable
+      <input
         className="neo-input"
         disabled={isReadOnly}
         id={inputId}
-        inputRef={inputRef}
         type="text"
-        value={contract || ""}
-        onBlur={() => setHasFocus(false)}
+        value={current}
         onChange={(event) => setContract(event.target.value)}
-        onFocus={() => setHasFocus(true)}
       />
-      {hasFocus && !!allNamesAndHashes.length && (
-        <div className="neo-combobox__menu">
-          {allNamesAndHashes.map((candidate) => (
-            <ContractTile
-              key={candidate}
-              contractHashOrName={candidate}
-              autoCompleteData={autoCompleteData}
-              onMouseDown={setContract}
-            />
-          ))}
-        </div>
-      )}
-      {!isPartOfDiffView && !!alternateName && (
+      {!isPartOfDiffView && (
         <div className="neo-field__meta">
-          Alias:{" "}
-          <button
-            className="neo-inline-action"
-            onClick={() => setContract(alternateName)}
-            type="button"
-          >
-            {alternateName}
-          </button>
+          No contracts found. Build a .nef in the workspace or wait for the
+          connected chain to load native contracts.
         </div>
       )}
     </div>

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/InvocationResult.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/InvocationResult.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { InvocationResult } from "../../../shared/viewState/invokeFileViewState";
+
+type Props = {
+  result: InvocationResult;
+};
+
+export default function InvocationResultView({ result }: Props) {
+  return (
+    <section
+      aria-label="Invocation result"
+      className={`invocation-result invocation-result--${
+        result.success ? "success" : "error"
+      }`}
+    >
+      <header className="invocation-result__header">
+        <h2 className="invocation-result__title">
+          {result.success ? "Invocation result" : "Invocation failed"}
+        </h2>
+        <span className="invocation-result__meta">
+          {result.operation || "Invocation"}
+          {result.submittedAt ? ` · ${formatTime(result.submittedAt)}` : ""}
+        </span>
+      </header>
+      <pre className="invocation-result__body">{result.message}</pre>
+      {!!result.txids.length && (
+        <div className="invocation-result__txids">
+          {result.txids.map((txid) => (
+            <div key={txid}>{txid}</div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatTime(submittedAt: string) {
+  const date = new Date(submittedAt);
+  return Number.isNaN(date.getTime())
+    ? ""
+    : date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/InvocationStep.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/InvocationStep.tsx
@@ -7,6 +7,10 @@ import AutoCompleteData from "../../../shared/autoCompleteData";
 import ContractInput from "./ContractInput";
 import NavButton from "../NavButton";
 import OperationInput from "./OperationInput";
+import {
+  manifestMethods,
+  resolveContractManifest,
+} from "../../../shared/resolveContractManifest";
 
 type Props = {
   i: number;
@@ -56,19 +60,10 @@ export default function InvocationStep({
     if (contractHashOrName.startsWith("#")) {
       contractHashOrName = contractHashOrName.substring(1);
     }
-    let manifest = autoCompleteData.contractManifests[contractHashOrName];
-    if (!manifest) {
-      for (const contractHash of Object.keys(autoCompleteData.contractNames)) {
-        if (autoCompleteData.contractNames[contractHash] === contractHashOrName) {
-          manifest = autoCompleteData.contractManifests[contractHash];
-        }
-      }
-    }
+    const manifest = resolveContractManifest(autoCompleteData, contract);
     const paths = autoCompleteData.contractPaths[contractHashOrName] || [];
     canDebug = !!operation && paths.length > 0 && debugScopeReady;
-    if (manifest?.abi) {
-      operations = manifest.abi.methods;
-    }
+    operations = manifestMethods(manifest) as neonSc.ContractMethodDefinitionJson[];
   }
 
   const canRun = !!contract && !!operation && executionReady;
@@ -117,7 +112,13 @@ export default function InvocationStep({
           forceFocus={forceFocus}
           isPartOfDiffView={isPartOfDiffView}
           isReadOnly={isReadOnly}
-          setContract={(newContract) => onUpdate(newContract, operation, args)}
+          setContract={(newContract) =>
+            onUpdate(
+              newContract,
+              newContract === contract ? operation : undefined,
+              newContract === contract ? args : []
+            )
+          }
         />
         <OperationInput
           isReadOnly={isReadOnly}

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/InvokeFileInteractiveEditor.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/InvokeFileInteractiveEditor.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, useMemo, useState } from "react";
 
 import Dialog from "../Dialog";
 import DropTarget from "../DropTarget";
+import InvocationResultView from "./InvocationResult";
 import InvocationStep from "./InvocationStep";
 import InvokeFileViewRequest from "../../../shared/messages/invokeFileViewRequest";
 import InvokeFileViewState from "../../../shared/viewState/invokeFileViewState";
@@ -180,6 +181,21 @@ export default function InvokeFileInteractiveEditor({
         }`}
       >
         <main className="contract-studio__steps">
+          {viewState.showInvocationResult && viewState.lastInvocation && (
+            <Dialog
+              title={
+                viewState.lastInvocation.success
+                  ? "Invocation result"
+                  : "Invocation failed"
+              }
+              onClose={() => postMessage({ dismissInvocationResult: true })}
+            >
+              <InvocationResultView result={viewState.lastInvocation} />
+            </Dialog>
+          )}
+          {!!viewState.lastInvocation && (
+            <InvocationResultView result={viewState.lastInvocation} />
+          )}
           {viewState.fileContents.map((step, i) => (
             <Fragment key={i}>
               <DropTarget i={i} onDrop={moveStep} dragActive={dragActive} />

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/OperationInput.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/OperationInput.tsx
@@ -1,9 +1,6 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 
 import * as neonSc from "@cityofzion/neon-core/lib/sc";
-
-import InputNonDraggable from "../InputNonDraggable";
-import OperationTile from "./OperationTile";
 
 type Props = {
   isReadOnly: boolean;
@@ -18,42 +15,58 @@ export default function OperationInput({
   operations,
   setOperation,
 }: Props) {
-  const [hasFocus, setHasFocus] = useState(false);
   const inputId = useRef(
     `neo-operation-${Math.random().toString(36).slice(2)}`
   ).current;
 
+  if (operations.length) {
+    const known = operations.some((candidate) => candidate.name === operation);
+    return (
+      <div className="neo-field">
+        <label className="neo-field__label" htmlFor={inputId}>
+          Method
+        </label>
+        <select
+          className="neo-select"
+          disabled={isReadOnly}
+          id={inputId}
+          value={known ? operation : ""}
+          onChange={(event) => setOperation(event.target.value)}
+        >
+          <option value="">Select a method…</option>
+          {operations.map((candidate, index) => (
+            <option
+              key={`${candidate.name}-${index}`}
+              value={candidate.name}
+            >
+              {candidate.name}
+              {candidate.parameters?.length
+                ? ` (${candidate.parameters.map((p) => p.name).join(", ")})`
+                : ""}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
   return (
-    <div className="neo-field neo-combobox">
+    <div className="neo-field">
       <label className="neo-field__label" htmlFor={inputId}>
         Method
       </label>
-      <InputNonDraggable
+      <input
         className="neo-input"
         disabled={isReadOnly}
         id={inputId}
         type="text"
         value={operation || ""}
-        onBlur={() => setHasFocus(false)}
         onChange={(event) => setOperation(event.target.value)}
-        onFocus={() => setHasFocus(true)}
       />
-      {hasFocus && !!operations.length && (
-        <div className="neo-combobox__menu">
-          {operations.map((candidate, index) => (
-            <OperationTile
-              key={`${candidate.name}-${index}`}
-              operation={candidate}
-              onMouseDown={setOperation}
-            />
-          ))}
-        </div>
-      )}
-      {!operations.length && (
-        <div className="neo-field__meta">
-          Enter a method name or select a contract with a detected manifest.
-        </div>
-      )}
+      <div className="neo-field__meta">
+        No ABI methods found for this contract. Build the project so a
+        .manifest.json sits next to the .nef, or pick a deployed contract.
+      </div>
     </div>
   );
 }

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/TransactionList.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/TransactionList.tsx
@@ -23,16 +23,32 @@ export default function TransactionList({
   );
   return (
     <div className="transaction-panel">
-      {!!selectedEntry?.tx && (
+      {!!selectedEntry && (
         <Dialog
-          title="Transaction receipt"
+          title={
+            selectedEntry.tx ? "Transaction receipt" : "Invocation transaction"
+          }
           onClose={() => onSelectTransaction(null)}
         >
-          <TransactionDetails
-            applicationLog={selectedEntry.log}
-            autoCompleteData={autoCompleteData}
-            transaction={selectedEntry.tx}
-          />
+          {selectedEntry.tx ? (
+            <TransactionDetails
+              applicationLog={selectedEntry.log}
+              autoCompleteData={autoCompleteData}
+              transaction={selectedEntry.tx}
+            />
+          ) : (
+            <>
+              <p>
+                {selectedEntry.operation || "Invocation"} is {selectedEntry.state}
+                {selectedEntry.txid ? ` (${selectedEntry.txid})` : ""}.
+              </p>
+              {!!selectedEntry.output && (
+                <pre className="invocation-result__body">
+                  {selectedEntry.output}
+                </pre>
+              )}
+            </>
+          )}
         </Dialog>
       )}
       <header className="transaction-panel__header">
@@ -47,7 +63,6 @@ export default function TransactionList({
             <button
               aria-label={`${entry.operation || "Invocation"}, ${entry.state}`}
               className="transaction-row"
-              disabled={!entry.tx}
               onClick={() => onSelectTransaction(entry.txid)}
               type="button"
             >

--- a/extentions/neo3-visual-tracker/src/panel/components/contracts/contractInput.test.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/contracts/contractInput.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { listContractOptions } from "./ContractInput";
+import AutoCompleteData from "../../../shared/autoCompleteData";
+
+function data(
+  manifests: AutoCompleteData["contractManifests"]
+): AutoCompleteData {
+  return {
+    contractManifests: manifests,
+    contractNames: {},
+    contractPaths: {},
+    wellKnownAddresses: {},
+    addressNames: {},
+  };
+}
+
+test("listContractOptions uses #names and skips hashes", () => {
+  assert.deepEqual(
+    listContractOptions(
+      data({
+        Nep17Contract: { abi: { methods: [], events: [] } },
+        "0xabc": { abi: { methods: [], events: [] } },
+        OracleRequest: { abi: { methods: [], events: [] } },
+      })
+    ),
+    ["#Nep17Contract", "#OracleRequest"]
+  );
+});

--- a/extentions/neo3-visual-tracker/src/panel/components/quickStart/CreateContract.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/quickStart/CreateContract.tsx
@@ -9,15 +9,11 @@ type Props = {
 export default function CreateContract({ onCreate }: Props) {
   return (
     <>
-      <div style={{ margin: 10, textAlign: "left" }}>
-        You don't appear to have any smart contracts in the current Visual
-        Studio Code workspace. Would you like to create a new smart contract?
-        You can write your smart contract's code in a programming language of
-        your choice and then deploy and test it locally using Neo Express.
+      <div style={{ textAlign: "left" }}>
+        Scaffold a C# (Blank, NEP-17, NEP-11, Oracle, Ownable), Python, or
+        Java contract under <code>contracts/</code>.
       </div>
-      <NavButton style={{ margin: 10 }} onClick={onCreate}>
-        Create a new contract
-      </NavButton>
+      <NavButton onClick={onCreate}>New contract</NavButton>
     </>
   );
 }

--- a/extentions/neo3-visual-tracker/src/panel/components/views/QuickStart.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/QuickStart.tsx
@@ -31,17 +31,7 @@ export default function QuickStart({ viewState, postMessage }: Props) {
   });
 
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-evenly",
-        alignItems: "center",
-        textAlign: "center",
-        minHeight: "calc(100% - 20px)",
-        padding: 10,
-      }}
-    >
+    <div className="quick-start">
       {actions}
     </div>
   );

--- a/extentions/neo3-visual-tracker/src/panel/components/views/Tracker.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/Tracker.tsx
@@ -60,39 +60,26 @@ export default function Tracker({ viewState, postMessage }: Props) {
           />
         </Dialog>
       )}
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          alignItems: "stretch",
-          alignContent: "stretch",
-          height: "100%",
-        }}
-      >
+      <div className="tracker">
         <Search
           searchHistory={viewState.searchHistory}
           onSearch={(query) => postMessage({ search: query })}
         />
-        <div
-          style={{ flex: "none 1", overflow: "hidden", position: "relative" }}
-        >
-          <div style={{ minHeight: "100vh" }}>
-            <BlockList
-              blocks={viewState.blocks}
-              populatedBlocksFilterEnabled={
-                viewState.populatedBlocksFilterEnabled
-              }
-              populatedBlocksFilterSupported={
-                viewState.populatedBlocksFilterSupported
-              }
-              selectedBlock={viewState.selectedBlock}
-              selectBlock={(hash) => postMessage({ selectBlock: hash })}
-              togglePopulatedBlocksFilter={(enabled) =>
-                postMessage({ togglePopulatedBlockFilter: { enabled } })
-              }
-            />
-          </div>
+        <div className="tracker__blocks">
+          <BlockList
+            blocks={viewState.blocks}
+            populatedBlocksFilterEnabled={
+              viewState.populatedBlocksFilterEnabled
+            }
+            populatedBlocksFilterSupported={
+              viewState.populatedBlocksFilterSupported
+            }
+            selectedBlock={viewState.selectedBlock}
+            selectBlock={(hash) => postMessage({ selectBlock: hash })}
+            togglePopulatedBlocksFilter={(enabled) =>
+              postMessage({ togglePopulatedBlockFilter: { enabled } })
+            }
+          />
         </div>
         <BlockNavigation
           style={{ margin: 10, textAlign: "center" }}

--- a/extentions/neo3-visual-tracker/src/panel/components/views/invokeFileLayout.test.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/invokeFileLayout.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const styles = readFileSync(join(__dirname, "../../styles.css"), "utf8");
+const editor = readFileSync(
+  join(__dirname, "../contracts/InvokeFileInteractiveEditor.tsx"),
+  "utf8"
+);
+
+test("contract studio content scrolls on short viewports", () => {
+  assert.match(styles, /html\[data-view="invokeFile"\] \.panel-shell/);
+  assert.match(
+    styles,
+    /\.contract-studio__content \{[\s\S]*overflow:\s*auto/
+  );
+  assert.doesNotMatch(
+    styles,
+    /grid-template-rows:\s*minmax\(320px,\s*1fr\)\s*minmax\(180px,\s*0\.55fr\)/
+  );
+});
+
+test("invocation results stay in the studio until dismissed", () => {
+  assert.match(editor, /dismissInvocationResult/);
+  assert.match(editor, /InvocationResultView/);
+  assert.match(editor, /showInvocationResult/);
+});
+
+test("invocation opens the Output channel to the results", () => {
+  const controller = readFileSync(
+    join(
+      __dirname,
+      "../../../extension/panelControllers/invokeFilePanelController.ts"
+    ),
+    "utf8"
+  );
+  const log = readFileSync(
+    join(__dirname, "../../../extension/util/log.ts"),
+    "utf8"
+  );
+  assert.match(log, /createOutputChannel\(\s*"Neo Express Invocation"/);
+  assert.match(log, /ensureInvocationChannel\(\)\.show\(/);
+  assert.match(controller, /Log\.showInvocation\(/);
+  assert.match(controller, /Log\.writeInvocation\(/);
+});

--- a/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.test.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.test.ts
@@ -1,7 +1,10 @@
 import { strict as assert } from "node:assert";
 import test from "node:test";
 
-import { getQuickStartActions } from "./quickStartActions";
+import {
+  describeQuickStartAction,
+  getQuickStartActions,
+} from "./quickStartActions";
 import QuickStartViewState from "../../../shared/viewState/quickStartViewState";
 
 const baseState: QuickStartViewState = {
@@ -25,12 +28,39 @@ test("offers NEP-6 wallet creation when none exist", () => {
   assert(actions.includes("createWallet"));
 });
 
+test("always offers new contract when a workspace is open", () => {
+  const empty = getQuickStartActions(baseState);
+  assert(empty.includes("createContract"));
+  const withContracts = getQuickStartActions({
+    ...baseState,
+    hasContracts: true,
+  });
+  assert(withContracts.includes("createContract"));
+});
+
 test("offers Neo Express wallet creation when an instance exists", () => {
   const actions = getQuickStartActions({
     ...baseState,
     hasNeoExpressInstance: true,
   });
   assert(actions.includes("createExpressWallet"));
+  assert(actions.includes("resetExpress"));
+});
+
+test("offers deploy when connected with workspace contracts", () => {
+  const actions = getQuickStartActions({
+    ...baseState,
+    connectionName: "default.neo-express",
+    hasContracts: true,
+    hasDeployedContract: true,
+    hasNeoExpressInstance: true,
+  });
+  assert(actions.includes("deployExpressContract"));
+  assert(actions.includes("invokeContract"));
+  assert.equal(
+    actions.filter((action) => action === "deployExpressContract").length,
+    1
+  );
 });
 
 test("offers transfer when Express and wallets are available", () => {
@@ -40,6 +70,7 @@ test("offers transfer when Express and wallets are available", () => {
     hasWallets: true,
   });
   assert(actions.includes("transfer"));
+  assert(actions.includes("transferNft"));
 });
 
 test("does not offer checkpoint actions when no single-node Express instance is present", () => {
@@ -50,6 +81,16 @@ test("does not offer checkpoint actions when no single-node Express instance is 
   });
   assert(!actions.includes("createCheckpoint"));
   assert(!actions.includes("restoreCheckpoint"));
+});
+
+test("every Quick Start action maps to a sidebar command", () => {
+  const actions = getQuickStartActions(baseState);
+  for (const action of actions) {
+    const item = describeQuickStartAction(action, baseState);
+    assert.equal(item.action, action);
+    assert.ok(item.label.length > 0);
+    assert.ok(item.command.startsWith("neo3-visual-devtracker.") || item.command === "vscode.openFolder");
+  }
 });
 
 test("offers checkpoint actions when a single-node Express instance is present", () => {

--- a/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/quickStartActions.ts
@@ -9,12 +9,155 @@ export type QuickStartAction =
   | "createContract"
   | "deployExpressContract"
   | "deployContract"
+  | "resetExpress"
   | "invokeContract"
   | "connect"
   | "createWallet"
   | "transfer"
+  | "transferNft"
   | "createCheckpoint"
   | "restoreCheckpoint";
+
+export type QuickStartActionItem = {
+  action: QuickStartAction;
+  label: string;
+  tooltip: string;
+  command: string;
+};
+
+export function describeQuickStartAction(
+  action: QuickStartAction,
+  viewState: QuickStartViewState
+): QuickStartActionItem {
+  switch (action) {
+    case "createExpressInstance":
+      return {
+        action,
+        label: "Create a new Neo Express instance",
+        tooltip:
+          "Neo Express can be used to create private blockchains that you can use to test and debug your smart contracts locally.",
+        command: "neo3-visual-devtracker.express.create",
+      };
+    case "startExpress":
+      return {
+        action,
+        label: "Start Neo Express",
+        tooltip:
+          "You are not currently running an instance of Neo Express. Running Neo Express will allow you to deploy, test and debug your contracts locally.",
+        command: "neo3-visual-devtracker.express.run",
+      };
+    case "createExpressWallet":
+      return {
+        action,
+        label: "Create a Neo Express wallet",
+        tooltip: "Create a wallet on the local Neo Express chain.",
+        command: "neo3-visual-devtracker.express.walletCreate",
+      };
+    case "createContract":
+      return {
+        action,
+        label: "New contract",
+        tooltip:
+          "Scaffold a C# (Blank, NEP-17, NEP-11, Oracle, Ownable), Python, or Java contract under contracts/.",
+        command: "neo3-visual-devtracker.neo.newContract",
+      };
+    case "deployExpressContract":
+      return {
+        action,
+        label: "Deploy a contract",
+        tooltip: `Deploy a workspace .nef to ${
+          viewState.connectionName || "this Neo Express instance"
+        }.`,
+        command: "neo3-visual-devtracker.express.contractDeploy",
+      };
+    case "deployContract":
+      return {
+        action,
+        label: "Deploy a contract",
+        tooltip: `Deploy a workspace .nef to ${
+          viewState.connectionName || "this chain"
+        }.`,
+        command: "neo3-visual-devtracker.neo.contractDeploy",
+      };
+    case "resetExpress":
+      return {
+        action,
+        label: "Reset Neo Express",
+        tooltip:
+          "Wipe the connected Neo Express chain and start a fresh genesis. Deployed contracts are removed.",
+        command: "neo3-visual-devtracker.express.reset",
+      };
+    case "invokeContract":
+      return {
+        action,
+        label: "Invoke a contract",
+        tooltip: "Your contract is deployed. Invoke it from Contract Studio.",
+        command: "neo3-visual-devtracker.neo.invokeContract",
+      };
+    case "connect":
+      return {
+        action,
+        label: "Connect to a blockchain",
+        tooltip:
+          "When you connect to a blockchain you will be able to see autocomplete suggestions within VS Code based on contracts deployed to the blockchain.",
+        command: "neo3-visual-devtracker.connect",
+      };
+    case "createWallet":
+      return {
+        action,
+        label: "Create a NEP-6 wallet",
+        tooltip:
+          "In order to deploy your contracts to TestNet or MainNet you will need a NEP-6 wallet.",
+        command: "neo3-visual-devtracker.neo.walletCreate",
+      };
+    case "transfer":
+      return {
+        action,
+        label: "Transfer NEO, GAS, or NEP-17",
+        tooltip:
+          "Transfer NEO, GAS, or a NEP-17 token between Neo Express wallets (neoxp transfer).",
+        command: "neo3-visual-devtracker.express.transfer",
+      };
+    case "transferNft":
+      return {
+        action,
+        label: "Transfer NFT (NEP-11)",
+        tooltip:
+          "Transfer an NFT token id between wallets (neoxp transfernft).",
+        command: "neo3-visual-devtracker.express.transferNft",
+      };
+    case "createCheckpoint":
+      return {
+        action,
+        label: "Create a checkpoint",
+        tooltip: "Save the current Neo Express chain state to a checkpoint file.",
+        command: "neo3-visual-devtracker.express.createCheckpoint",
+      };
+    case "restoreCheckpoint":
+      return {
+        action,
+        label: "Restore a checkpoint",
+        tooltip: "Restore a previously saved Neo Express checkpoint.",
+        command: "neo3-visual-devtracker.express.restoreCheckpoint",
+      };
+    case "createOrOpenWorkspace":
+      return {
+        action,
+        label: "Open or create a workspace folder",
+        tooltip:
+          "Create a new folder for your project and then open that folder in Visual Studio Code.",
+        command: "vscode.openFolder",
+      };
+    case "openExplorer":
+      return {
+        action,
+        label: "Open a blockchain explorer",
+        tooltip:
+          "You have access to a Neo blockchain explorer within Visual Studio Code.",
+        command: "neo3-visual-devtracker.tracker.openTracker",
+      };
+  }
+}
 
 export function getQuickStartActions(
   viewState: QuickStartViewState
@@ -27,20 +170,22 @@ export function getQuickStartActions(
         actions.push("startExpress");
       }
       actions.push("createExpressWallet");
+      actions.push("resetExpress");
     } else {
       actions.push("createExpressInstance");
     }
 
-    if (!viewState.hasContracts) {
-      actions.push("createContract");
-    }
+    actions.push("createContract");
 
     if (viewState.connectionName) {
-      if (viewState.neoExpressDeploymentRequired) {
+      if (viewState.hasNeoExpressInstance && viewState.hasContracts) {
+        actions.push("deployExpressContract");
+      } else if (viewState.neoExpressDeploymentRequired) {
         actions.push("deployExpressContract");
       } else if (viewState.neoDeploymentRequired) {
         actions.push("deployContract");
-      } else if (viewState.hasDeployedContract) {
+      }
+      if (viewState.hasDeployedContract) {
         actions.push("invokeContract");
       }
     } else {
@@ -51,6 +196,7 @@ export function getQuickStartActions(
       actions.push("createWallet");
     } else if (viewState.hasNeoExpressInstance) {
       actions.push("transfer");
+      actions.push("transferNft");
     }
 
     if (viewState.hasCheckpointCompatibleNeoExpressInstance) {

--- a/extentions/neo3-visual-tracker/src/panel/components/views/quickStartLayout.test.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/quickStartLayout.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const packageRoot = join(__dirname, "../../../..");
+const packageJson = JSON.parse(
+  readFileSync(join(packageRoot, "package.json"), "utf8")
+) as {
+  contributes?: {
+    views?: {
+      [container: string]: { id?: string; type?: string }[];
+    };
+  };
+};
+const indexSource = readFileSync(
+  join(packageRoot, "src/extension/index.ts"),
+  "utf8"
+);
+
+test("Quick Start is the first sidebar view so the last action is not clipped", () => {
+  const views =
+    packageJson.contributes?.views?.["neo3-visual-devtracker-mainView"] ?? [];
+  assert.equal(views[0]?.id, "neo3-visual-devtracker.views.quickStart");
+  const tree = readFileSync(
+    join(packageRoot, "src/extension/vscodeProviders/quickStartTreeDataProvider.ts"),
+    "utf8"
+  );
+  assert.match(tree, /if \(!item\.command\)/);
+});
+
+test("Quick Start is a tree view so it uses the main sidebar scrollbar", () => {
+  const views =
+    packageJson.contributes?.views?.["neo3-visual-devtracker-mainView"] ?? [];
+  const quickStart = views.find(
+    (view) => view.id === "neo3-visual-devtracker.views.quickStart"
+  );
+  assert.ok(quickStart, "Quick Start view is missing");
+  assert.notEqual(
+    quickStart.type,
+    "webview",
+    "Quick Start must not be a webview (those get a nested scrollbar)"
+  );
+  assert.match(
+    indexSource,
+    /registerTreeDataProvider\(\s*"neo3-visual-devtracker\.views\.quickStart"/
+  );
+  assert.doesNotMatch(indexSource, /registerWebviewViewProvider/);
+});

--- a/extentions/neo3-visual-tracker/src/panel/components/views/trackerLayout.test.ts
+++ b/extentions/neo3-visual-tracker/src/panel/components/views/trackerLayout.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const tracker = readFileSync(join(__dirname, "Tracker.tsx"), "utf8");
+const styles = readFileSync(join(__dirname, "../../styles.css"), "utf8");
+
+test("block explorer list scrolls inside the panel on small screens", () => {
+  assert.match(tracker, /className="tracker__blocks"/);
+  assert.doesNotMatch(tracker, /minHeight:\s*"100vh"/);
+  assert.match(styles, /\.tracker__blocks \{[\s\S]*overflow:\s*auto/);
+  assert.match(styles, /html\[data-view="tracker"\] \.panel-shell/);
+  assert.match(styles, /html\[data-view="tracker"\] \.panel-shell \{[\s\S]*margin:\s*0/);
+});

--- a/extentions/neo3-visual-tracker/src/panel/index.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/index.tsx
@@ -9,17 +9,9 @@ import ViewRouter from "./viewRouter";
 import "./index.html";
 
 function initialize() {
-  (window.document.querySelector("html") as HTMLElement).style.height = "100%";
-  (window.document.querySelector("#root") as HTMLElement).style.height = "100%";
-  window.document.body.style.height = "100%";
-  const negateVsCodeMargin: React.CSSProperties = {
-    margin: "0 -20px",
-    backgroundColor: "var(--vscode-sideBar-background)",
-    height: "100%",
-  };
   ReactDOM.render(
     <React.StrictMode>
-      <div style={negateVsCodeMargin}>
+      <div className="panel-shell">
         <ViewRouter />
       </div>
     </React.StrictMode>,

--- a/extentions/neo3-visual-tracker/src/panel/styles.css
+++ b/extentions/neo3-visual-tracker/src/panel/styles.css
@@ -20,6 +20,114 @@ body,
   margin: 0;
 }
 
+.panel-shell {
+  background-color: var(--vscode-sideBar-background);
+  box-sizing: border-box;
+  height: 100%;
+}
+
+html[data-view="invokeFile"],
+html[data-view="invokeFile"] body,
+html[data-view="invokeFile"] #root,
+html[data-view="invokeFile"] .panel-shell {
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+html[data-view="tracker"],
+html[data-view="tracker"] body,
+html[data-view="tracker"] #root,
+html[data-view="tracker"] .panel-shell {
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+html[data-view="tracker"] .panel-shell {
+  margin: 0;
+  padding: 0 var(--neo-space-3);
+}
+
+.tracker {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+}
+
+.tracker__blocks {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.tracker__blocks table {
+  height: auto;
+  min-width: 0;
+  table-layout: fixed;
+}
+
+.tracker__blocks th,
+.tracker__blocks td {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.tracker__blocks thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+/* Sidebar Quick Start: no inner scrollbar. The view container scrolls. */
+html[data-view="quickStart"],
+html[data-view="quickStart"] body,
+html[data-view="quickStart"] #root {
+  height: auto;
+  min-height: 0;
+  overflow: visible;
+}
+
+html[data-view="quickStart"] .panel-shell {
+  height: auto;
+  margin: 0;
+  overflow: visible;
+}
+
+.quick-start {
+  align-items: stretch;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--neo-space-3);
+  height: auto;
+  max-width: 100%;
+  overflow: visible;
+  padding: var(--neo-space-3) var(--neo-space-3) var(--neo-space-5);
+  text-align: center;
+}
+
+.quick-start .neo-button-wrap,
+.quick-start .neo-button {
+  width: 100%;
+}
+
+.quick-start .neo-button {
+  white-space: normal;
+}
+
+.quick-start > * {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.quick-start div {
+  overflow-wrap: anywhere;
+}
+
 body {
   background: var(--vscode-editor-background);
   color: var(--vscode-editor-foreground);
@@ -38,6 +146,10 @@ input,
 select,
 textarea {
   font: inherit;
+}
+
+select.neo-select {
+  appearance: auto;
 }
 
 button:focus-visible,
@@ -225,18 +337,20 @@ textarea:focus-visible,
 
 .contract-studio__content {
   min-height: 0;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .contract-studio__content > * {
-  height: 100%;
+  box-sizing: border-box;
+  min-height: 100%;
+  height: auto;
 }
 
 .contract-studio__interactive {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  min-height: 0;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  overflow: visible;
 }
 
 .execution-context {
@@ -305,9 +419,10 @@ textarea:focus-visible,
 
 .contract-studio__workspace {
   display: grid;
+  flex: 1 1 auto;
   grid-template-columns: minmax(420px, 1.4fr) minmax(300px, 0.8fr);
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .contract-studio__workspace--single {
@@ -316,7 +431,7 @@ textarea:focus-visible,
 
 .contract-studio__steps {
   min-width: 0;
-  overflow: auto;
+  overflow: visible;
   padding: var(--neo-space-4);
 }
 
@@ -324,7 +439,7 @@ textarea:focus-visible,
   background: var(--vscode-panel-background);
   border-left: 1px solid var(--neo-border);
   min-width: 0;
-  overflow: auto;
+  overflow: visible;
 }
 
 .invocation-step {
@@ -568,6 +683,74 @@ textarea:focus-visible,
   white-space: pre-wrap;
 }
 
+.invocation-result {
+  background: var(--vscode-sideBar-background);
+  border: 1px solid var(--neo-border);
+  border-radius: var(--neo-radius);
+  margin-bottom: var(--neo-space-4);
+  padding: var(--neo-space-3);
+}
+
+.invocation-result--success {
+  border-color: var(--neo-success);
+}
+
+.invocation-result--error {
+  border-color: var(--neo-danger);
+}
+
+.invocation-result__header {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--neo-space-2);
+  justify-content: space-between;
+  margin-bottom: var(--neo-space-2);
+}
+
+.invocation-result__title {
+  font-size: 12px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.invocation-result__meta {
+  color: var(--neo-muted);
+  font-size: 12px;
+}
+
+.invocation-result__body {
+  font-family: var(--vscode-editor-font-family);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+  max-height: 280px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.invocation-result__txids {
+  color: var(--neo-muted);
+  display: grid;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 12px;
+  gap: 2px;
+  margin-top: var(--neo-space-2);
+}
+
+.neo-dialog__body .invocation-result {
+  background: transparent;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.neo-dialog__body .invocation-result__body {
+  max-height: min(360px, 50vh);
+}
+
 @media (max-width: 900px) {
   .execution-context {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -575,12 +758,35 @@ textarea:focus-visible,
 
   .contract-studio__workspace {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(320px, 1fr) minmax(180px, 0.55fr);
+    grid-template-rows: auto auto;
   }
 
   .contract-studio__transactions {
     border-left: 0;
     border-top: 1px solid var(--neo-border);
+  }
+}
+
+@media (min-width: 901px) and (min-height: 560px) {
+  .contract-studio__content {
+    overflow: hidden;
+  }
+
+  .contract-studio__content > * {
+    height: 100%;
+  }
+
+  .contract-studio__interactive {
+    overflow: hidden;
+  }
+
+  .contract-studio__workspace {
+    overflow: hidden;
+  }
+
+  .contract-studio__steps,
+  .contract-studio__transactions {
+    overflow: auto;
   }
 }
 

--- a/extentions/neo3-visual-tracker/src/panel/viewRouter.tsx
+++ b/extentions/neo3-visual-tracker/src/panel/viewRouter.tsx
@@ -52,6 +52,14 @@ export default function ViewRouter() {
     window.addEventListener("message", (msg) => receiveMessage(msg.data));
     postMessage({ retrieveViewState: true });
   }, []);
+  useEffect(() => {
+    const html = document.documentElement;
+    if (view) {
+      html.dataset.view = view;
+    } else {
+      delete html.dataset.view;
+    }
+  }, [view]);
   let panelContent = <div></div>;
   if (!!view && !!viewState) {
     switch (view) {

--- a/extentions/neo3-visual-tracker/src/shared/autoCompleteData.ts
+++ b/extentions/neo3-visual-tracker/src/shared/autoCompleteData.ts
@@ -11,6 +11,8 @@ type AutoCompleteData = {
   contractPaths: { [contractHashOrName: string]: string[] };
   wellKnownAddresses: { [addressName: string]: string };
   addressNames: AddressNames;
+  /** Display name -> value passed to neoxp (wallet name or NEP-6 path). */
+  accountSigners?: { [addressName: string]: string };
 };
 
 export default AutoCompleteData;

--- a/extentions/neo3-visual-tracker/src/shared/expressWalletAddresses.test.ts
+++ b/extentions/neo3-visual-tracker/src/shared/expressWalletAddresses.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  contractsWithStandard,
+  isHiddenExpressConfig,
+  parseExpressWalletAddresses,
+  workspaceWalletDisplayName,
+} from "./expressWalletAddresses";
+
+test("parseExpressWalletAddresses includes genesis, node wallets, and user wallets", () => {
+  const addresses = parseExpressWalletAddresses({
+    wallets: [
+      {
+        name: "alice",
+        accounts: [
+          {
+            "script-hash": "Nalice",
+            "is-default": true,
+            label: null,
+          },
+        ],
+      },
+    ],
+    "consensus-nodes": [
+      {
+        wallet: {
+          name: "node1",
+          accounts: [
+            {
+              "script-hash": "Nnode1",
+              "is-default": true,
+              label: null,
+            },
+            {
+              "script-hash": "Ngenesis",
+              "is-default": false,
+              label: "Consensus MultiSigContract",
+            },
+          ],
+        },
+      },
+    ],
+  });
+  assert.deepEqual(addresses, {
+    alice: "Nalice",
+    node1: "Nnode1",
+    genesis: "Ngenesis",
+  });
+});
+
+test("workspaceWalletDisplayName uses the file name for Default account labels", () => {
+  assert.equal(
+    workspaceWalletDisplayName(
+      "/workspace/wallets/alice.neo-wallet.json",
+      "Default account"
+    ),
+    "alice"
+  );
+  assert.equal(
+    workspaceWalletDisplayName("/wallets/ops.json", "Cold storage"),
+    "Cold storage"
+  );
+});
+
+test("hides nested test neo-express files from the blockchain list", () => {
+  assert.equal(
+    isHiddenExpressConfig(
+      "/workspace/contracts/SampleToken/test/default.neo-express"
+    ),
+    true
+  );
+  assert.equal(
+    isHiddenExpressConfig("/workspace/default.neo-express"),
+    false
+  );
+});
+
+test("contractsWithStandard lists NEP-17 names and skips hashes", () => {
+  assert.deepEqual(
+    contractsWithStandard(
+      {
+        Nep17Contract: { supportedstandards: ["NEP-17"] },
+        "0xabc": { supportedstandards: ["NEP-17"] },
+        Nep11Contract: { supportedstandards: ["NEP-11"] },
+      },
+      "NEP-17"
+    ),
+    ["Nep17Contract"]
+  );
+});

--- a/extentions/neo3-visual-tracker/src/shared/expressWalletAddresses.ts
+++ b/extentions/neo3-visual-tracker/src/shared/expressWalletAddresses.ts
@@ -1,0 +1,104 @@
+export function isHiddenExpressConfig(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/").toLowerCase();
+  return (
+    normalized.includes("/test/") ||
+    normalized.includes("/tests/") ||
+    normalized.includes("/obj/") ||
+    normalized.includes("/bin/") ||
+    normalized.endsWith("tests.neo-express")
+  );
+}
+
+export function parseExpressWalletAddresses(config: {
+  wallets?: Array<{
+    name?: string;
+    accounts?: Array<{
+      label?: string | null;
+      "is-default"?: boolean;
+      "script-hash"?: string;
+    }>;
+  }>;
+  "consensus-nodes"?: Array<{
+    wallet?: {
+      name?: string;
+      accounts?: Array<{
+        label?: string | null;
+        "is-default"?: boolean;
+        "script-hash"?: string;
+      }>;
+    };
+  }>;
+}): { [name: string]: string } {
+  const result: { [name: string]: string } = {};
+  const add = (name: string | undefined, scriptHash: string | undefined) => {
+    if (!name || !scriptHash || result[name]) {
+      return;
+    }
+    result[name] = scriptHash;
+  };
+
+  for (const wallet of config.wallets ?? []) {
+    const accounts = wallet.accounts ?? [];
+    const defaultAccount =
+      accounts.find((account) => account["is-default"]) ?? accounts[0];
+    add(wallet.name, defaultAccount?.["script-hash"]);
+    for (const account of accounts) {
+      if (account.label) {
+        add(account.label, account["script-hash"]);
+      }
+    }
+  }
+
+  for (const node of config["consensus-nodes"] ?? []) {
+    const wallet = node.wallet;
+    const accounts = wallet?.accounts ?? [];
+    for (const account of accounts) {
+      if (account.label === "Consensus MultiSigContract") {
+        add("genesis", account["script-hash"]);
+      } else if (account["is-default"] || !account.label) {
+        add(wallet?.name, account["script-hash"]);
+      } else {
+        add(account.label, account["script-hash"]);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function workspaceWalletDisplayName(
+  filePath: string,
+  accountLabel?: string | null
+): string {
+  const slash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  const fileName = slash >= 0 ? filePath.slice(slash + 1) : filePath;
+  const base = fileName
+    .replace(/\.neo-wallet\.json$/i, "")
+    .replace(/\.json$/i, "");
+  if (accountLabel && accountLabel !== "Default account") {
+    return accountLabel;
+  }
+  return base || accountLabel || "wallet";
+}
+
+export function contractsWithStandard(
+  manifests: { [name: string]: { supportedstandards?: string[] } },
+  standard: string
+): string[] {
+  const needle = standard.replace("-", "").toUpperCase();
+  const names = new Set<string>();
+  for (const [name, manifest] of Object.entries(manifests)) {
+    if (name.startsWith("0x")) {
+      continue;
+    }
+    const standards = manifest.supportedstandards ?? [];
+    if (
+      standards.some(
+        (entry) => entry.replace("-", "").toUpperCase() === needle
+      )
+    ) {
+      names.add(name);
+    }
+  }
+  return [...names].sort((a, b) => a.localeCompare(b));
+}

--- a/extentions/neo3-visual-tracker/src/shared/invocationExecution.test.ts
+++ b/extentions/neo3-visual-tracker/src/shared/invocationExecution.test.ts
@@ -3,11 +3,13 @@ import test from "node:test";
 
 import {
   areInvocationStepsReady,
+  areInvocationStepsSafe,
   isLiveDebugWitnessScopeSupported,
   isWitnessScope,
   resolveSelectedAccount,
   toInvocationAccounts,
 } from "./invocationExecution";
+import AutoCompleteData from "./autoCompleteData";
 
 test("toInvocationAccounts returns stable alphabetic account options", () => {
   assert.deepEqual(
@@ -56,4 +58,45 @@ test("live debugging only supports CalledByEntry witness scope", () => {
   assert.equal(isLiveDebugWitnessScopeSupported("CalledByEntry"), true);
   assert.equal(isLiveDebugWitnessScopeSupported("Global"), false);
   assert.equal(isLiveDebugWitnessScopeSupported("None"), false);
+});
+
+test("areInvocationStepsSafe requires every method to be marked safe", () => {
+  const autoCompleteData = {
+    contractManifests: {
+      SuperTokenContract: {
+        abi: {
+          methods: [
+            { name: "getOwner", parameters: [], safe: true },
+            { name: "transfer", parameters: [], safe: false },
+          ],
+          events: [],
+        },
+      },
+    },
+    contractNames: {},
+    contractPaths: {},
+    wellKnownAddresses: {},
+    addressNames: {},
+  } as unknown as AutoCompleteData;
+  assert.equal(
+    areInvocationStepsSafe(
+      [{ contract: "#SuperTokenContract", operation: "getOwner" }],
+      autoCompleteData
+    ),
+    true
+  );
+  assert.equal(
+    areInvocationStepsSafe(
+      [{ contract: "#SuperTokenContract", operation: "transfer" }],
+      autoCompleteData
+    ),
+    false
+  );
+  assert.equal(
+    areInvocationStepsSafe(
+      [{ contract: "#Missing", operation: "getOwner" }],
+      autoCompleteData
+    ),
+    false
+  );
 });

--- a/extentions/neo3-visual-tracker/src/shared/invocationExecution.ts
+++ b/extentions/neo3-visual-tracker/src/shared/invocationExecution.ts
@@ -1,3 +1,9 @@
+import AutoCompleteData from "./autoCompleteData";
+import {
+  manifestMethods,
+  resolveContractManifest,
+} from "./resolveContractManifest";
+
 export type InvocationAccount = {
   address: string;
   name: string;
@@ -46,4 +52,19 @@ export function areInvocationStepsReady(
 
 export function isLiveDebugWitnessScopeSupported(scope: WitnessScope) {
   return scope === "CalledByEntry";
+}
+
+export function areInvocationStepsSafe(
+  steps: { contract?: string; operation?: string }[],
+  autoCompleteData: AutoCompleteData
+): boolean {
+  return (
+    steps.length > 0 &&
+    steps.every((step) => {
+      const method = manifestMethods(
+        resolveContractManifest(autoCompleteData, step.contract)
+      ).find((candidate) => candidate.name === step.operation);
+      return method?.safe === true;
+    })
+  );
 }

--- a/extentions/neo3-visual-tracker/src/shared/messages/invokeFileViewRequest.ts
+++ b/extentions/neo3-visual-tracker/src/shared/messages/invokeFileViewRequest.ts
@@ -4,6 +4,7 @@ type InvokeFileViewRequest = {
   connect?: boolean;
   debugStep?: { i: number };
   deleteStep?: { i: number };
+  dismissInvocationResult?: boolean;
   moveStep?: { from: number; to: number };
   runAll?: boolean;
   runStep?: { i: number };

--- a/extentions/neo3-visual-tracker/src/shared/neoExpressTx.test.ts
+++ b/extentions/neo3-visual-tracker/src/shared/neoExpressTx.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatInvokeMessage,
+  isContractOnChain,
+  isFailedTx,
+  isNodeStillRunningError,
+  looksLikeEncryptedWallet,
+  parseApplicationLogState,
+  parseGasBalance,
+  parseSubmittedTxids,
+} from "./neoExpressTx";
+
+test("looksLikeEncryptedWallet detects NEP-6 files", () => {
+  assert.equal(
+    looksLikeEncryptedWallet("/workspace/wallets/alice.neo-wallet.json"),
+    true
+  );
+  assert.equal(looksLikeEncryptedWallet("genesis"), false);
+  assert.equal(looksLikeEncryptedWallet("node1"), false);
+});
+
+test("parseGasBalance reads GAS from show balances output", () => {
+  assert.equal(
+    parseGasBalance(
+      "GAS (0xd2a4cff31913016155e38e474a2c06d08be276cf)\n  balance: 19.999"
+    ),
+    19.999
+  );
+  assert.equal(parseGasBalance("No balances for alice"), 0);
+  assert.equal(parseGasBalance("NEO\n  balance: 100"), null);
+});
+
+test("isFailedTx detects FAULT and insufficient GAS", () => {
+  assert.equal(isFailedTx('Tx FAULT: hash=0xabc exception="Insufficient GAS."'), true);
+  assert.equal(isFailedTx("Deployment of Token (0xabc) Transaction 0xdef submitted"), false);
+  assert.equal(
+    isFailedTx('Tx FAULT: exception="Contract Already Exists: 0xabc"'),
+    true
+  );
+});
+
+test("isNodeStillRunningError detects mutex / already-running CLI errors", () => {
+  assert.equal(
+    isNodeStillRunningError(
+      "System.InvalidOperationException: node NSkaz8cyADPr6w4Ff97rDYY1TabqEBmFTs currently running"
+    ),
+    true
+  );
+  assert.equal(isNodeStillRunningError("System.Exception: Node already running"), true);
+  assert.equal(isNodeStillRunningError("node 0 reset"), false);
+});
+
+test("isContractOnChain treats empty get output as not deployed", () => {
+  assert.equal(isContractOnChain("[]"), false);
+  assert.equal(isContractOnChain(""), false);
+  assert.equal(
+    isContractOnChain('[\n  {\n    "name": "Nep17Contract",\n    "hash": "0xabc"\n  }\n]'),
+    true
+  );
+});
+
+test("parseApplicationLogState reads vmstate from show transaction JSON", () => {
+  assert.equal(
+    parseApplicationLogState('{ "executions": [ { "vmstate": "FAULT" } ] }'),
+    "FAULT"
+  );
+  assert.equal(
+    parseApplicationLogState('{ "executions": [ { "vmstate": "HALT" } ] }'),
+    "HALT"
+  );
+  assert.equal(parseApplicationLogState("not json"), null);
+});
+
+test("parseSubmittedTxids extracts 32-byte transaction hashes", () => {
+  assert.deepEqual(
+    parseSubmittedTxids(
+      "Invocation Transaction 0xea42778535dd152aa7eca518a7c323ac98b11a74538af03e509c3684caa3db07 submitted"
+    ),
+    ["0xea42778535dd152aa7eca518a7c323ac98b11a74538af03e509c3684caa3db07"]
+  );
+  assert.deepEqual(parseSubmittedTxids("contract hash 0xd95198ef802d354260685d385a1579e0858e9239"), []);
+});
+
+test("formatInvokeMessage pretty-prints --results JSON", () => {
+  assert.equal(
+    formatInvokeMessage(
+      '{"state":"HALT","gasconsumed":"984060","exception":null,"stack":[{"type":"ByteString","value":"abc"}]}'
+    ),
+    [
+      "VM State: HALT",
+      "Gas Consumed: 984060",
+      "Result Stack:",
+      '[\n  {\n    "type": "ByteString",\n    "value": "abc"\n  }\n]',
+    ].join("\n")
+  );
+  assert.equal(
+    formatInvokeMessage("Invocation Transaction 0xabc submitted"),
+    "Invocation Transaction 0xabc submitted"
+  );
+});

--- a/extentions/neo3-visual-tracker/src/shared/neoExpressTx.ts
+++ b/extentions/neo3-visual-tracker/src/shared/neoExpressTx.ts
@@ -1,0 +1,83 @@
+export function looksLikeEncryptedWallet(account: string): boolean {
+  return /\.json$/i.test(account);
+}
+
+export function parseGasBalance(showBalancesOutput: string): number | null {
+  if (/no balances/i.test(showBalancesOutput)) {
+    return 0;
+  }
+  const match = showBalancesOutput.match(
+    /GAS\b[\s\S]*?balance:\s*([0-9]+(?:\.[0-9]+)?)/i
+  );
+  if (!match) {
+    return null;
+  }
+  return Number.parseFloat(match[1]);
+}
+
+export function isFailedTx(message: string): boolean {
+  return (
+    /\bFAULT\b/i.test(message) ||
+    /insufficient gas/i.test(message) ||
+    /contract already exists/i.test(message)
+  );
+}
+
+export function parseApplicationLogState(showTransactionOutput: string): string | null {
+  const match = showTransactionOutput.match(/"vmstate"\s*:\s*"(\w+)"/i);
+  return match ? match[1].toUpperCase() : null;
+}
+
+export function isNodeStillRunningError(message: string): boolean {
+  return /currently running/i.test(message) || /already running/i.test(message);
+}
+
+export function parseSubmittedTxids(message: string): string[] {
+  const matches = message.match(/0x[0-9a-f]{64}/gi) || [];
+  return [...new Set(matches.map((id) => id.toLowerCase()))];
+}
+
+export function formatInvokeMessage(message: string): string {
+  const cleaned = message.trim();
+  if (!cleaned) {
+    return "";
+  }
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    try {
+      const parsed = JSON.parse(cleaned.slice(start, end + 1));
+      if (parsed && typeof parsed === "object") {
+        const lines: string[] = [];
+        if (parsed.state) {
+          lines.push(`VM State: ${parsed.state}`);
+        }
+        if (parsed.gasconsumed) {
+          lines.push(`Gas Consumed: ${parsed.gasconsumed}`);
+        }
+        if (parsed.exception) {
+          lines.push(`Exception: ${parsed.exception}`);
+        }
+        if (Array.isArray(parsed.stack)) {
+          lines.push("Result Stack:");
+          lines.push(JSON.stringify(parsed.stack, null, 2));
+        }
+        if (lines.length) {
+          return lines.join("\n");
+        }
+        return JSON.stringify(parsed, null, 2);
+      }
+    } catch {
+      // Fall through and show the raw CLI output.
+    }
+  }
+  return cleaned;
+}
+
+export function isContractOnChain(contractGetOutput: string): boolean {
+  const text = contractGetOutput.trim();
+  if (!text || text === "[]") {
+    return false;
+  }
+  return /"name"\s*:/.test(text) || /hash:\s*0x/i.test(text);
+}

--- a/extentions/neo3-visual-tracker/src/shared/publicChainSeeds.test.ts
+++ b/extentions/neo3-visual-tracker/src/shared/publicChainSeeds.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAINNET_GENESIS,
+  TESTNET_GENESIS,
+  knownGenesisHashForSeed,
+} from "./publicChainSeeds";
+
+test("known seed URLs map to MainNet/TestNet without RPC", () => {
+  assert.equal(
+    knownGenesisHashForSeed("http://seed1.neo.org:10332"),
+    MAINNET_GENESIS
+  );
+  assert.equal(
+    knownGenesisHashForSeed("http://seed2t4.neo.org:20332"),
+    TESTNET_GENESIS
+  );
+  assert.equal(knownGenesisHashForSeed("http://127.0.0.1:50012"), undefined);
+});

--- a/extentions/neo3-visual-tracker/src/shared/publicChainSeeds.ts
+++ b/extentions/neo3-visual-tracker/src/shared/publicChainSeeds.ts
@@ -1,0 +1,15 @@
+export const MAINNET_GENESIS =
+  "0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15";
+export const TESTNET_GENESIS =
+  "0x9d3276785e7306daf59a3f3b9e31912c095598bbfb8a4476b821b0e59be4c57a";
+
+export function knownGenesisHashForSeed(rpcUrl: string): string | undefined {
+  const lower = rpcUrl.toLowerCase();
+  if (lower.includes("neo.org:10332")) {
+    return MAINNET_GENESIS;
+  }
+  if (lower.includes("neo.org:20332")) {
+    return TESTNET_GENESIS;
+  }
+  return undefined;
+}

--- a/extentions/neo3-visual-tracker/src/shared/recentTransaction.ts
+++ b/extentions/neo3-visual-tracker/src/shared/recentTransaction.ts
@@ -8,6 +8,7 @@ type RecentTransaction = {
   blockchain: string;
   log?: ApplicationLog;
   operation?: string;
+  output?: string;
   txid: string;
   state: TransactionStatus;
   submittedAt?: string;

--- a/extentions/neo3-visual-tracker/src/shared/resolveContractManifest.test.ts
+++ b/extentions/neo3-visual-tracker/src/shared/resolveContractManifest.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import AutoCompleteData from "./autoCompleteData";
+import {
+  manifestMethods,
+  resolveContractManifest,
+  stripContractPrefix,
+} from "./resolveContractManifest";
+
+function data(partial: Partial<AutoCompleteData>): AutoCompleteData {
+  return {
+    addressNames: {},
+    contractManifests: {},
+    contractNames: {},
+    contractPaths: {},
+    wellKnownAddresses: {},
+    ...partial,
+  };
+}
+
+test("stripContractPrefix removes hash alias", () => {
+  assert.equal(stripContractPrefix("#Foo"), "Foo");
+  assert.equal(stripContractPrefix("Foo"), "Foo");
+});
+
+test("resolveContractManifest finds workspace name and hash alias", () => {
+  const manifest = {
+    abi: { methods: [{ name: "GetNumber", parameters: [] }], events: [] },
+  } as unknown as AutoCompleteData["contractManifests"][string];
+  const autoComplete = data({
+    contractManifests: {
+      contracttestContract: manifest,
+      "0xabc": manifest,
+    },
+    contractNames: { "0xabc": "contracttestContract" },
+  });
+  assert.equal(
+    resolveContractManifest(autoComplete, "#contracttestContract"),
+    manifest
+  );
+  assert.equal(resolveContractManifest(autoComplete, "#0xabc"), manifest);
+});
+
+test("manifestMethods hides system methods", () => {
+  const methods = manifestMethods({
+    abi: {
+      methods: [
+        { name: "_deploy", parameters: [] },
+        { name: "GetNumber", parameters: [] },
+      ],
+    },
+  });
+  assert.deepEqual(
+    methods.map((m) => m.name),
+    ["GetNumber"]
+  );
+});
+
+test("resolveContractManifest finds a NEP-17 workspace contract by name", () => {
+  const manifest = {
+    abi: {
+      methods: [
+        { name: "_deploy", parameters: [] },
+        { name: "symbol", parameters: [] },
+        { name: "decimals", parameters: [] },
+        { name: "transfer", parameters: [{ name: "to", type: "Hash160" }] },
+        { name: "Mint", parameters: [{ name: "to", type: "Hash160" }] },
+      ],
+      events: [],
+    },
+  } as unknown as AutoCompleteData["contractManifests"][string];
+  const autoComplete = data({
+    contractManifests: { Nep17Contract: manifest },
+    contractPaths: {
+      Nep17Contract: ["/workspace/contracts/Nep17/src/bin/sc/Nep17Contract.nef"],
+    },
+  });
+  assert.equal(resolveContractManifest(autoComplete, "#Nep17Contract"), manifest);
+  assert.equal(resolveContractManifest(autoComplete, "nep17contract"), manifest);
+  assert.deepEqual(
+    manifestMethods(manifest).map((method) => method.name),
+    ["symbol", "decimals", "transfer", "Mint"]
+  );
+});
+
+test("resolveContractManifest finds a contract from its .nef path", () => {
+  const manifest = {
+    abi: { methods: [{ name: "GetResponse", parameters: [] }], events: [] },
+  } as unknown as AutoCompleteData["contractManifests"][string];
+  const autoComplete = data({
+    contractManifests: { OracleRequest: manifest },
+    contractPaths: {
+      OracleRequest: [
+        "/workspace/contracts/Oracle/src/bin/sc/OracleRequest.nef",
+      ],
+    },
+  });
+  assert.equal(
+    resolveContractManifest(autoComplete, "OracleRequest"),
+    manifest
+  );
+});

--- a/extentions/neo3-visual-tracker/src/shared/resolveContractManifest.ts
+++ b/extentions/neo3-visual-tracker/src/shared/resolveContractManifest.ts
@@ -1,0 +1,63 @@
+import AutoCompleteData from "./autoCompleteData";
+
+type ManifestLike = {
+  abi?: {
+    methods?: Array<{
+      name: string;
+      parameters?: Array<{ name: string; type: string }>;
+      returntype?: string;
+      safe?: boolean;
+    }>;
+  };
+};
+
+export function stripContractPrefix(contract?: string): string {
+  if (!contract) {
+    return "";
+  }
+  return contract.startsWith("#") ? contract.slice(1) : contract;
+}
+
+export function resolveContractManifest(
+  autoCompleteData: AutoCompleteData,
+  contract?: string
+): ManifestLike | undefined {
+  const name = stripContractPrefix(contract);
+  if (!name) {
+    return undefined;
+  }
+
+  const direct = autoCompleteData.contractManifests[name];
+  if (direct) {
+    return direct as ManifestLike;
+  }
+
+  const lower = name.toLowerCase();
+  for (const [key, manifest] of Object.entries(
+    autoCompleteData.contractManifests
+  )) {
+    if (key.toLowerCase() === lower) {
+      return manifest as ManifestLike;
+    }
+    const mappedName = autoCompleteData.contractNames[key];
+    if (mappedName && mappedName.toLowerCase() === lower) {
+      return manifest as ManifestLike;
+    }
+  }
+
+  for (const [key, paths] of Object.entries(autoCompleteData.contractPaths)) {
+    if (
+      key.toLowerCase() === lower ||
+      paths.some((p) => p.toLowerCase().includes(`/${lower}.`) || p.toLowerCase().includes(`\\${lower}.`))
+    ) {
+      return autoCompleteData.contractManifests[key] as ManifestLike;
+    }
+  }
+
+  return undefined;
+}
+
+export function manifestMethods(manifest?: ManifestLike) {
+  const methods = manifest?.abi?.methods ?? [];
+  return methods.filter((method) => method?.name && !method.name.startsWith("_"));
+}

--- a/extentions/neo3-visual-tracker/src/shared/viewState/invokeFileViewState.ts
+++ b/extentions/neo3-visual-tracker/src/shared/viewState/invokeFileViewState.ts
@@ -5,6 +5,14 @@ import {
 } from "../invocationExecution";
 import RecentTransaction from "../recentTransaction";
 
+export type InvocationResult = {
+  message: string;
+  operation?: string;
+  success: boolean;
+  submittedAt: string;
+  txids: string[];
+};
+
 type InvokeFileViewState = {
   view: "invokeFile";
   panelTitle: string;
@@ -25,9 +33,11 @@ type InvokeFileViewState = {
   isPartOfDiffView: boolean;
   isReadOnly: boolean;
   jsonMode: boolean;
+  lastInvocation: InvocationResult | null;
   recentTransactions: RecentTransaction[];
   selectedAccount: string | null;
   selectedTransactionId: string | null;
+  showInvocationResult: boolean;
   witnessScope: WitnessScope;
 };
 

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,11 @@
 [Neo-Express, Neo-WorkNet and Neo-Trace](#neo-express-neo-worknet-and-neo-trace)
 
 - [Overview](#overview)
+- [Getting started](#getting-started)
 - [Download Links](#download-links)
 - [Installation Guide](#installation-guide)
 - [Usage Guide](#usage-guide)
+- [Documentation](#documentation)
 - [New Features or issues](#new-features-or-issues)
 - [License](#license)
 
@@ -41,6 +43,27 @@ These tools provide developers with a complete local development environment for
   - Generate trace files for Neo Smart Contract Debugger
   - Support specifying blocks by index or hash and transactions by hash
   - Replay public-chain transactions from StateService-enabled RPC nodes
+
+## Getting started
+
+**[Full getting-started guide](docs/getting-started.md)** — install, create a chain, build a
+contract from the official templates, invoke it, and optionally use Visual Studio Code.
+
+```shell
+dotnet tool install Neo.Express -g
+dotnet build samples/examples/Nep17
+neoxp run -i samples/examples/Nep17/default.neo-express --seconds-per-block 1
+```
+
+In another terminal:
+
+```shell
+neoxp contract run -i samples/examples/Nep17/default.neo-express Nep17Contract symbol --results
+```
+
+C# starters (Blank, NEP-17, NEP-11, Oracle, Ownable) live in
+[`samples/examples/`](samples/examples/README.md). The VS Code **New contract** wizard offers
+the same templates.
 
 ## Download Links
 
@@ -114,23 +137,16 @@ brew install rocksdb
 
 ### Quick Start
 
-Get started with Neo-Express in just a few commands:
+See **[Getting started](docs/getting-started.md)** for the full walkthrough (CLI and VS Code).
 
 ```shell
-# Install Neo-Express
 dotnet tool install Neo.Express -g
-
-# Create a new blockchain
 neoxp create
-
-# Start the blockchain
-neoxp run
-
-# Check wallet balances
+neoxp run --seconds-per-block 1
 neoxp show balances genesis
 ```
 
-> **Tip:** While the blockchain is running it mints a new block every 3 seconds by
+> **Tip:** While the blockchain is running it mints a new block every 15 seconds by
 > default, so a transaction is not reflected in queries such as `show balances` until the
 > next block is produced. For faster local iteration, start the chain with a shorter block
 > time, for example `neoxp run --seconds-per-block 1`.
@@ -218,6 +234,23 @@ Please review the [Neo-WorkNet Command Reference](docs/worknet-command-reference
 Please review the [NeoTrace Command Reference](docs/trace-command-reference.md) for the full list of commands and options.
 
 > Note: Neo-Trace depends on the [StateService plugin module](https://github.com/neo-project/neo-modules/tree/master/src/StateService) running with `FullState` enabled. If a public seed node returns an `Old state not supported` error, use a JSON-RPC node with full-state StateService enabled. Neo-Trace does not include per-instruction storage snapshots from public-chain StateService replay. For local Neo-Express transactions with storage snapshots, use the `--trace` option on commands such as `neoxp run`, `neoxp contract invoke`, or `neoxp contract run` to write `.neo-trace` files locally.
+
+## Documentation
+
+| Doc | Topic |
+| --- | ----- |
+| [Getting started](docs/getting-started.md) | Install, first chain, first contract (CLI and VS Code) |
+| [Installation](docs/installation.md) | Global tools, release zips, Ubuntu/macOS |
+| [Quickstart](docs/quickstart.md) | Create, compile, deploy, invoke |
+| [Contract testing](docs/contract-testing.md) | `dotnet test` against a checkpoint |
+| [Samples](samples/README.md) | Simple sample and official C# templates |
+| [Command reference](docs/command-reference.md) | `neoxp` commands |
+| [Settings](docs/settings.md) | `.neo-express` settings |
+| [Invocation files](docs/Neo%20Express%20Invocation%20File.md) | `.neo-invoke.json` |
+| [Visual DevTracker](extentions/neo3-visual-tracker/README.md) | VS Code extension |
+| [Debugger](docs/debugger-command-reference.md) | VS Code `neo-contract` launch config |
+| [WorkNet](docs/worknet-command-reference.md) | Branch MainNet/TestNet |
+| [Trace](docs/trace-command-reference.md) | Public-chain traces |
 
 ## New Features or issues
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,32 @@
+# Samples
+
+Two layouts you can copy:
+
+| Path | What it shows |
+| ---- | ------------- |
+| [`src/`](src) + [`test/`](test) | Simple `SampleContract` (`TokenContract`) with `Neo.BuildTasks`, an Express batch, a checkpoint, and `dotnet test` |
+| [`examples/`](examples/README.md) | Official [Neo.SmartContract.Template](https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template) starters (Blank, NEP-17, NEP-11, Oracle, Ownable) wired for Express — no official unit-test projects |
+
+## Get started
+
+```shell
+dotnet build samples/examples/Blank
+dotnet test samples/test
+```
+
+The first example build restores local tools, creates `default.neo-express` if needed,
+compiles the `.nef`, resets the chain, and deploys with `genesis`. Then start the chain
+(global `neoxp`, or `cd samples` and `dotnet tool restore` first):
+
+```shell
+neoxp run -i samples/examples/Blank/default.neo-express --seconds-per-block 1
+```
+
+In another terminal:
+
+```shell
+neoxp contract run -i samples/examples/Blank/default.neo-express Contract MyMethod --results
+```
+
+Walkthrough: [docs/getting-started.md](../docs/getting-started.md).
+Checkpoint tests: [docs/contract-testing.md](../docs/contract-testing.md).

--- a/samples/examples/Blank/Contract.csproj
+++ b/samples/examples/Blank/Contract.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NeoContractName>Contract</NeoContractName>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/samples/examples/Blank/express.batch
+++ b/samples/examples/Blank/express.batch
@@ -1,0 +1,1 @@
+contract deploy ./bin/sc/Contract.nef genesis

--- a/samples/examples/Blank/src/Contract.cs
+++ b/samples/examples/Blank/src/Contract.cs
@@ -1,0 +1,78 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+
+namespace Blank;
+
+[DisplayName(nameof(Contract))]
+[ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+[ContractDescription("<Description Here>")]
+[ContractVersion("<Version String Here>")]
+[ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template")]
+[ContractPermission(Permission.Any, Method.Any)]
+public class Contract : SmartContract
+{
+    private const byte Prefix_Owner = 0xff;
+
+    [Safe]
+    public static UInt160 GetOwner()
+    {
+        return (UInt160)Storage.Get(new[] { Prefix_Owner });
+    }
+
+    private static bool IsOwner() =>
+        Runtime.CheckWitness(GetOwner());
+
+    public delegate void OnSetOwnerDelegate(UInt160 previousOwner, UInt160 newOwner);
+
+    [DisplayName("SetOwner")]
+    public static event OnSetOwnerDelegate OnSetOwner;
+
+    public static void SetOwner(UInt160 newOwner)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+
+        ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+        UInt160 previous = GetOwner();
+        Storage.Put(new[] { Prefix_Owner }, newOwner);
+        OnSetOwner(previous, newOwner);
+    }
+
+    [Safe]
+    public static bool Verify() => IsOwner();
+
+    public static string MyMethod()
+    {
+        return Storage.Get("Hello");
+    }
+
+    public static void _deploy(object data, bool update)
+    {
+        if (update)
+        {
+            return;
+        }
+
+        if (data is null) data = Runtime.Transaction.Sender;
+
+        UInt160 initialOwner = (UInt160)data;
+
+        ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exist");
+
+        Storage.Put(new[] { Prefix_Owner }, initialOwner);
+        OnSetOwner(null, initialOwner);
+        Storage.Put("Hello", "World");
+    }
+
+    public static void Update(ByteString nefFile, string manifest, object? data = null)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No authorization.");
+        ContractManagement.Update(nefFile, manifest, data);
+    }
+}

--- a/samples/examples/Directory.Build.props
+++ b/samples/examples/Directory.Build.props
@@ -1,0 +1,59 @@
+<Project>
+  <PropertyGroup>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TargetFramework>net10.0</TargetFramework>
+    <NeoTestVersion>3.10.1</NeoTestVersion>
+    <NeoExpressInputFile>default.neo-express</NeoExpressInputFile>
+    <NeoExpressDeployStamp>$(IntermediateOutputPath)$(NeoContractName).neoxp.deploy.touch</NeoExpressDeployStamp>
+    <DefaultItemExcludes>$(DefaultItemExcludes);src\obj\**;src\bin\**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Neo.SmartContract.Framework" Version="$(NeoTestVersion)" />
+    <PackageReference Include="Neo.BuildTasks" Version="$(NeoTestVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <Target Name="CreateNeoExpressInstance"
+          Condition="'$(NeoContractName)'!='' and !Exists('$(MSBuildProjectDirectory)\$(NeoExpressInputFile)')"
+          AfterTargets="ExecuteNeoCsc"
+          BeforeTargets="DeployContractToNeoExpress">
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="dotnet tool restore" />
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="dotnet tool run neoxp -- create -o $(NeoExpressInputFile)" />
+  </Target>
+  <!-- Deploy after compile with contract deploy so a running local neo-express instance works.
+       Offline batch reset cannot run while the chain is up. -->
+  <Target Name="DeployContractToNeoExpress"
+          AfterTargets="ExecuteNeoCsc"
+          DependsOnTargets="CreateNeoExpressInstance"
+          Condition="'$(NeoContractName)'!=''"
+          Inputs="$(MSBuildProjectDirectory)\bin\sc\$(NeoContractName).nef;$(MSBuildProjectDirectory)\$(NeoExpressInputFile)"
+          Outputs="$(NeoExpressDeployStamp)">
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="dotnet tool restore" />
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
+          IgnoreExitCode="true"
+          Command="dotnet tool run neoxp -- reset -f --input $(NeoExpressInputFile)">
+      <Output TaskParameter="ExitCode" PropertyName="_NeoResetExit" />
+    </Exec>
+    <PropertyGroup>
+      <_NeoChainOffline Condition="'$(_NeoResetExit)' == '0'">true</_NeoChainOffline>
+    </PropertyGroup>
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
+          Condition="'$(_NeoChainOffline)' == 'true'"
+          Command="dotnet tool run neoxp -- contract deploy &quot;bin/sc/$(NeoContractName).nef&quot; genesis --input $(NeoExpressInputFile)" />
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
+          Condition="'$(_NeoChainOffline)' != 'true'"
+          IgnoreExitCode="true"
+          Command="dotnet tool run neoxp -- contract deploy &quot;bin/sc/$(NeoContractName).nef&quot; genesis --input $(NeoExpressInputFile)" />
+    <Message Importance="high"
+             Condition="'$(_NeoChainOffline)' != 'true'"
+             Text="Neo Express is running. The contract is deployed if it was new; stop the chain and rebuild to replace it." />
+    <Touch Files="$(NeoExpressDeployStamp)" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(NeoExpressDeployStamp)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="CleanNeoExpressDeploy"
+          BeforeTargets="CoreClean;Rebuild"
+          Condition="'$(NeoContractName)'!=''">
+    <Delete Files="$(NeoExpressDeployStamp)" TreatErrorsAsWarnings="true" />
+  </Target>
+</Project>

--- a/samples/examples/Nep11/Nep11Contract.csproj
+++ b/samples/examples/Nep11/Nep11Contract.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NeoContractName>Nep11Contract</NeoContractName>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/samples/examples/Nep11/express.batch
+++ b/samples/examples/Nep11/express.batch
@@ -1,0 +1,1 @@
+contract deploy ./bin/sc/Nep11Contract.nef genesis

--- a/samples/examples/Nep11/src/Nep11Contract.cs
+++ b/samples/examples/Nep11/src/Nep11Contract.cs
@@ -1,0 +1,124 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+
+namespace Nep11;
+
+[DisplayName(nameof(Nep11Contract))]
+[ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+[ContractDescription("<Description Here>")]
+[ContractVersion("<Version String Here>")]
+[ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractnep11")]
+[ContractPermission(Permission.Any, Method.OnNEP11Payment)]
+[SupportedStandards(NepStandard.Nep11)]
+public class Nep11Contract : Nep11Token<TokenState>
+{
+    private const byte Prefix_Owner = 0xff;
+
+    [Safe]
+    public static UInt160 GetOwner()
+    {
+        return (UInt160)Storage.Get(new[] { Prefix_Owner });
+    }
+
+    private static bool IsOwner() =>
+        Runtime.CheckWitness(GetOwner());
+
+    public delegate void OnSetOwnerDelegate(UInt160? previousOwner, UInt160? newOwner);
+
+    [DisplayName("SetOwner")]
+    public static event OnSetOwnerDelegate OnSetOwner = null!;
+
+    public static void SetOwner(UInt160 newOwner)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+
+        ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+        UInt160? previousOwner = GetOwner();
+        ExecutionEngine.Assert(previousOwner != newOwner, "owner must change");
+
+        Storage.Put(new[] { Prefix_Owner }, newOwner);
+        OnSetOwner(previousOwner, newOwner);
+    }
+
+    public override string Symbol { [Safe] get => "EXAMPLE"; }
+
+    public static ByteString Mint(UInt160 to, string name, string description, string image)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+
+        ExecutionEngine.Assert(to.IsValid && to.NotZero, "recipient must be valid");
+
+        ByteString tokenId = NewTokenId();
+        Nep11Token<TokenState>.Mint(tokenId, new TokenState
+        {
+            Owner = to,
+            Name = name,
+            Description = description,
+            Image = image
+        });
+
+        return tokenId;
+    }
+
+    [Safe]
+    public override Map<string, object> Properties(ByteString tokenId)
+    {
+        if (tokenId.Length >= 64) throw new Exception("The argument \"tokenId\" should be 64 or less bytes long.");
+
+        var tokenMap = new LocalStorageMap(Prefix_Token);
+        var tokenKey = tokenMap[tokenId] ?? throw new Exception("The token with given \"tokenId\" does not exist.");
+        TokenState token = (TokenState)StdLib.Deserialize(tokenKey);
+
+        return new Map<string, object>()
+        {
+            ["name"] = token.Name,
+            ["description"] = token.Description,
+            ["image"] = token.Image
+        };
+    }
+
+    [Safe]
+    public static bool Verify() => IsOwner();
+
+    public static string MyMethod()
+    {
+        return Storage.Get("Hello");
+    }
+
+    public static void _deploy(object data, bool update)
+    {
+        if (update)
+        {
+            return;
+        }
+
+        if (data is null) data = Runtime.Transaction.Sender;
+        UInt160 initialOwner = (UInt160)data;
+
+        ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exists");
+
+        Storage.Put(new[] { Prefix_Owner }, initialOwner);
+        OnSetOwner(null, initialOwner);
+        Storage.Put("Hello", "World");
+    }
+
+    public static void Update(ByteString nefFile, string manifest, object? data = null)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No authorization.");
+        ContractManagement.Update(nefFile, manifest, data);
+    }
+}
+
+public class TokenState : Nep11TokenState
+{
+    public string Description = string.Empty;
+    public string Image = string.Empty;
+}

--- a/samples/examples/Nep17/Nep17Contract.csproj
+++ b/samples/examples/Nep17/Nep17Contract.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NeoContractName>Nep17Contract</NeoContractName>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/samples/examples/Nep17/express.batch
+++ b/samples/examples/Nep17/express.batch
@@ -1,0 +1,1 @@
+contract deploy ./bin/sc/Nep17Contract.nef genesis

--- a/samples/examples/Nep17/src/Nep17Contract.cs
+++ b/samples/examples/Nep17/src/Nep17Contract.cs
@@ -1,0 +1,98 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+using System.Numerics;
+
+namespace Nep17;
+
+[DisplayName(nameof(Nep17Contract))]
+[ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+[ContractDescription("<Description Here>")]
+[ContractVersion("<Version String Here>")]
+[ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractnep17")]
+[ContractPermission(Permission.Any, "onNEP17Payment")]
+[SupportedStandards(NepStandard.Nep17)]
+public class Nep17Contract : Nep17Token
+{
+    private const byte Prefix_Owner = 0xff;
+
+    [Safe]
+    public static UInt160 GetOwner()
+    {
+        return (UInt160)Storage.Get(new[] { Prefix_Owner });
+    }
+
+    private static bool IsOwner() =>
+        Runtime.CheckWitness(GetOwner());
+
+    public delegate void OnSetOwnerDelegate(UInt160 previousOwner, UInt160 newOwner);
+
+    [DisplayName("SetOwner")]
+    public static event OnSetOwnerDelegate OnSetOwner;
+
+    public static void SetOwner(UInt160 newOwner)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+
+        ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+        UInt160 previous = GetOwner();
+        Storage.Put(new[] { Prefix_Owner }, newOwner);
+        OnSetOwner(previous, newOwner);
+    }
+
+    public override string Symbol { [Safe] get => "EXAMPLE"; }
+
+    public override byte Decimals { [Safe] get => 8; }
+
+    public static new void Burn(UInt160 account, BigInteger amount)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+        Nep17Token.Burn(account, amount);
+    }
+
+    public static new void Mint(UInt160 to, BigInteger amount)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+        Nep17Token.Mint(to, amount);
+    }
+
+    [Safe]
+    public static bool Verify() => IsOwner();
+
+    public static string MyMethod()
+    {
+        return Storage.Get("Hello");
+    }
+
+    public static void _deploy(object data, bool update)
+    {
+        if (update)
+        {
+            return;
+        }
+
+        if (data is null) data = Runtime.Transaction.Sender;
+
+        UInt160 initialOwner = (UInt160)data;
+
+        ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exists");
+
+        Storage.Put(new[] { Prefix_Owner }, initialOwner);
+        OnSetOwner(null, initialOwner);
+        Storage.Put("Hello", "World");
+    }
+
+    public static void Update(ByteString nefFile, string manifest, object? data = null)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No authorization.");
+        ContractManagement.Update(nefFile, manifest, data);
+    }
+}

--- a/samples/examples/Oracle/OracleRequest.csproj
+++ b/samples/examples/Oracle/OracleRequest.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NeoContractName>OracleRequest</NeoContractName>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/samples/examples/Oracle/express.batch
+++ b/samples/examples/Oracle/express.batch
@@ -1,0 +1,1 @@
+contract deploy ./bin/sc/OracleRequest.nef genesis

--- a/samples/examples/Oracle/src/OracleRequest.cs
+++ b/samples/examples/Oracle/src/OracleRequest.cs
@@ -1,0 +1,46 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+
+namespace OracleContract;
+
+[DisplayName(nameof(OracleRequest))]
+[ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+[ContractDescription("<Description Here>")]
+[ContractVersion("<Version String Here>")]
+[ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractoracle")]
+public class OracleRequest : SmartContract
+{
+    [Safe]
+    public static string GetResponse()
+    {
+        return Storage.Get(Storage.CurrentReadOnlyContext, "Response");
+    }
+
+    public static void DoRequest()
+    {
+        var requestUrl = "https://api.jsonbin.io/v3/qs/6520ad3c12a5d3765988542a";
+        Neo.SmartContract.Framework.Native.Oracle.Request(
+            requestUrl,
+            "$.record.propertyName",
+            "onOracleResponse",
+            null,
+            Neo.SmartContract.Framework.Native.Oracle.MinimumResponseFee);
+    }
+
+    public static void onOracleResponse(string requestedUrl, object userData, OracleResponseCode oracleResponse, string jsonString)
+    {
+        if (Runtime.CallingScriptHash != Neo.SmartContract.Framework.Native.Oracle.Hash)
+            throw new InvalidOperationException("No Authorization!");
+        if (oracleResponse != OracleResponseCode.Success)
+            throw new Exception("Oracle response failure with code " + (byte)oracleResponse);
+
+        var jsonArrayValues = (object[])StdLib.JsonDeserialize(jsonString);
+        var jsonFirstValue = (string)jsonArrayValues[0];
+
+        Storage.Put(Storage.CurrentContext, "Response", jsonFirstValue);
+    }
+}

--- a/samples/examples/Ownable/Ownable.csproj
+++ b/samples/examples/Ownable/Ownable.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NeoContractName>Ownable</NeoContractName>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/samples/examples/Ownable/express.batch
+++ b/samples/examples/Ownable/express.batch
@@ -1,0 +1,1 @@
+contract deploy ./bin/sc/Ownable.nef genesis

--- a/samples/examples/Ownable/src/Ownable.cs
+++ b/samples/examples/Ownable/src/Ownable.cs
@@ -1,0 +1,81 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.ComponentModel;
+
+namespace OwnableContract;
+
+[DisplayName(nameof(Ownable))]
+[ContractAuthor("<Your Name Or Company Here>", "<Your Public Email Here>")]
+[ContractDescription("<Description Here>")]
+[ContractVersion("<Version String Here>")]
+[ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template/templates/neocontractowner")]
+public class Ownable : SmartContract
+{
+    private const byte Prefix_Owner = 0xff;
+
+    [Safe]
+    public static UInt160 GetOwner()
+    {
+        return (UInt160)Storage.Get(new[] { Prefix_Owner });
+    }
+
+    private static bool IsOwner() =>
+        Runtime.CheckWitness(GetOwner());
+
+    public delegate void OnSetOwnerDelegate(UInt160 previousOwner, UInt160 newOwner);
+
+    [DisplayName("SetOwner")]
+    public static event OnSetOwnerDelegate OnSetOwner;
+
+    public static void SetOwner(UInt160 newOwner)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No Authorization!");
+
+        ExecutionEngine.Assert(newOwner.IsValid && newOwner.NotZero, "owner must be valid");
+
+        UInt160 previous = GetOwner();
+        Storage.Put(new[] { Prefix_Owner }, newOwner);
+        OnSetOwner(previous, newOwner);
+    }
+
+    public static string MyMethod()
+    {
+        return Storage.Get(Storage.CurrentReadOnlyContext, "Hello");
+    }
+
+    public static void _deploy(object data, bool update)
+    {
+        if (update)
+        {
+            return;
+        }
+
+        if (data is null) data = Runtime.Transaction.Sender;
+
+        UInt160 initialOwner = (UInt160)data;
+
+        ExecutionEngine.Assert(initialOwner.IsValid && initialOwner.NotZero, "owner must exists");
+
+        Storage.Put(new[] { Prefix_Owner }, initialOwner);
+        OnSetOwner(null, initialOwner);
+        Storage.Put(Storage.CurrentContext, "Hello", "World");
+    }
+
+    public static void Update(ByteString nefFile, string manifest, object? data = null)
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No authorization.");
+        ContractManagement.Update(nefFile, manifest, data);
+    }
+
+    public static void Destroy()
+    {
+        if (!IsOwner())
+            throw new InvalidOperationException("No authorization.");
+        ContractManagement.Destroy();
+    }
+}

--- a/samples/examples/README.md
+++ b/samples/examples/README.md
@@ -1,0 +1,69 @@
+# Official contract templates for Neo Express
+
+These folders are the official
+[Neo.SmartContract.Template](https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template)
+starters, laid out for Neo Express and `Neo.BuildTasks`. Official unit-test projects are not
+included.
+
+Walkthrough: [docs/getting-started.md](../../docs/getting-started.md).
+
+## Templates
+
+| Folder | `dotnet new` short name | Contract |
+| ------ | ----------------------- | -------- |
+| `Blank` | `neocontract` | Owner + `MyMethod` |
+| `Nep17` | `neocontractnep17` | NEP-17 token |
+| `Nep11` | `neocontractnep11` | NEP-11 NFT |
+| `Oracle` | `neocontractoracle` | Oracle request/response |
+| `Ownable` | `neocontractowner` | Owner + `Destroy` |
+
+## Layout
+
+```
+*.csproj              # `dotnet build` here compiles and deploys
+src/*.cs
+express.batch         # optional offline reset+deploy (`neoxp batch`)
+default.neo-express   # created on first `dotnet build` if missing
+```
+
+Shared `Directory.Build.props` sets `Neo.SmartContract.Framework`, `Neo.BuildTasks`,
+`NeoExpressBatchFile`, and creates the chain file on first build.
+
+Local tools (`neoxp`, `nccs`) come from [`samples/.config/dotnet-tools.json`](../.config/dotnet-tools.json).
+
+## Build, deploy, invoke
+
+From the repository root:
+
+From an example folder:
+
+```shell
+cd samples/examples/Nep17
+dotnet build
+```
+
+Or from the repo:
+
+```shell
+dotnet build samples/examples/Nep17
+dotnet build samples/examples/examples.sln
+```
+
+The first build creates `default.neo-express` if needed, compiles `bin/sc/*.nef`, and
+deploys with `genesis`. If Neo Express is already running (VS Code **Start Neo Express**),
+the build still deploys (`contract deploy --force`). It does not require stopping the chain.
+
+Then:
+
+```shell
+neoxp run -i default.neo-express --seconds-per-block 1
+neoxp contract run -i default.neo-express Nep17Contract symbol --results
+```
+
+`dotnet clean` / `dotnet rebuild` delete the deploy stamp so the next build deploys again.
+
+## VS Code
+
+Open the example folder (or the repo) with Neo N3 Visual DevTracker. **New contract**
+offers the same C# starters (plus the existing storage example). After a build, start the
+chain from **Blockchains** and invoke from **Smart contracts**.

--- a/samples/examples/examples.sln
+++ b/samples/examples/examples.sln
@@ -1,0 +1,43 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contract", "Blank\Contract.csproj", "{A1B2C3D4-E5F6-7890-ABCD-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nep17Contract", "Nep17\Nep17Contract.csproj", "{A1B2C3D4-E5F6-7890-ABCD-000000000002}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nep11Contract", "Nep11\Nep11Contract.csproj", "{A1B2C3D4-E5F6-7890-ABCD-000000000003}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OracleRequest", "Oracle\OracleRequest.csproj", "{A1B2C3D4-E5F6-7890-ABCD-000000000004}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ownable", "Ownable\Ownable.csproj", "{A1B2C3D4-E5F6-7890-ABCD-000000000005}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000003}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000003}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000003}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000004}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000004}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000004}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000004}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000005}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000005}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000005}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-000000000005}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/samples/express.batch
+++ b/samples/express.batch
@@ -1,2 +1,2 @@
-contract deploy ./src/bin/sc/contract.nef genesis
+contract deploy ./src/bin/sc/SampleContract.nef genesis
 checkpoint create ./checkpoints/contract-deployed -f

--- a/samples/invoke-files/TestContract.neo-invoke.json
+++ b/samples/invoke-files/TestContract.neo-invoke.json
@@ -1,0 +1,6 @@
+[
+  {
+    "contract": "#TestContract",
+    "operation": "symbol"
+  }
+]

--- a/samples/invoke-files/contract-1.neo-invoke.json
+++ b/samples/invoke-files/contract-1.neo-invoke.json
@@ -1,0 +1,7 @@
+[
+  {
+    "contract": "#contract",
+    "operation": "symbol",
+    "args": []
+  }
+]

--- a/samples/invoke-files/contract.neo-invoke.json
+++ b/samples/invoke-files/contract.neo-invoke.json
@@ -1,0 +1,6 @@
+[
+  {
+    "contract": "#contract",
+    "operation": "symbol"
+  }
+]

--- a/samples/nuget.config
+++ b/samples/nuget.config
@@ -4,6 +4,5 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="ngd-ent-artifacts" value="https://pkgs.dev.azure.com/ngdenterprise/Build/_packaging/public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/samples/src/checkpoints/.gitignore
+++ b/samples/src/checkpoints/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/samples/src/contract.cs
+++ b/samples/src/contract.cs
@@ -10,7 +10,7 @@
 
 using Neo.SmartContract.Framework;
 
-public class TestContract : TokenContract
+public class SampleContract : TokenContract
 {
     public override byte Decimals => 0;
     public override string Symbol => "TEST";

--- a/samples/src/contract.csproj
+++ b/samples/src/contract.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NeoContractName>$(AssemblyName)</NeoContractName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NeoContractName>SampleContract</NeoContractName>
     <NeoExpressBatchFile>../express.batch</NeoExpressBatchFile>
+    <NeoExpressBatchInputFile>../default.neo-express</NeoExpressBatchInputFile>
     <Nullable>enable</Nullable>
     <TargetFramework>net10.0</TargetFramework>
     <NeoTestVersion>3.10.1</NeoTestVersion>

--- a/samples/test/contract-test.csproj
+++ b/samples/test/contract-test.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <RootNamespace>ContractTests</RootNamespace>
@@ -10,12 +11,12 @@
     <NeoContractReference Include="..\src\contract.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Neo.Assertions" Version="$(NeoTestVersion)" />
     <PackageReference Include="Neo.BuildTasks" Version="$(NeoTestVersion)" PrivateAssets="all" />
     <PackageReference Include="Neo.Test.Harness" Version="$(NeoTestVersion)" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/test/contract-tests.cs
+++ b/samples/test/contract-tests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace ContractTests
 {
-    [CheckpointPath("checkpoints/contract-deployed.neoxp-checkpoint")]
+    [CheckpointPath("src/checkpoints/contract-deployed.neoxp-checkpoint")]
     public class ContractDeployedTests : IClassFixture<CheckpointFixture<ContractDeployedTests>>
     {
         readonly CheckpointFixture fixture;
@@ -31,7 +31,7 @@ namespace ContractTests
             using var snapshot = fixture.GetSnapshot();
             using var engine = new TestApplicationEngine(snapshot, settings);
 
-            var state = engine.ExecuteScript<contract>(c => c.symbol());
+            var state = engine.ExecuteScript<SampleContract>(c => c.symbol());
 
             engine.State.Should().Be(VMState.HALT);
             engine.ResultStack.Should().HaveCount(1);
@@ -45,7 +45,7 @@ namespace ContractTests
             using var snapshot = fixture.GetSnapshot();
             using var engine = new TestApplicationEngine(snapshot, settings);
 
-            var state = engine.ExecuteScript<contract>(c => c.decimals());
+            var state = engine.ExecuteScript<SampleContract>(c => c.decimals());
 
             engine.State.Should().Be(VMState.HALT);
             engine.ResultStack.Should().HaveCount(1);

--- a/src/bctklib/ContractParameterParser.cs
+++ b/src/bctklib/ContractParameterParser.cs
@@ -183,7 +183,8 @@ namespace Neo.BlockchainToolkit
                     ? value
                     : UInt160.TryParse(contract, out var uint160)
                         ? uint160
-                        : throw new InvalidOperationException($"contract \"{contract}\" not found");
+                        : throw new InvalidOperationException(
+                        $"contract \"{contract}\" not found. Deploy it first (`neoxp contract deploy <file.nef> genesis`) or use a name/hash from `neoxp contract list`. A leading '#' is not a file path.");
 
                 var operation = json.Value<string>("operation")
                     ?? throw new JsonException("missing operation field");

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -39,6 +39,8 @@ namespace Neo.BuildTasks
 
         public ITaskItem? WorkingDirectory { get; set; }
 
+        internal void SetResolvedToolType(DotNetToolType value) => toolType = value;
+
         protected DotNetToolTask(IProcessRunner? processRunner = null)
         {
             this.processRunner = processRunner ?? new ProcessRunner();
@@ -118,21 +120,27 @@ namespace Neo.BuildTasks
             return false;
         }
 
-        internal bool TryExecute(string command, string arguments, ITaskItem? directory, out IReadOnlyCollection<string> output)
+        protected ProcessResults LastProcessResults { get; private set; }
+
+        internal bool TryExecute(string command, string arguments, ITaskItem? directory, out IReadOnlyCollection<string> output, bool logFailure = true)
         {
             var results = processRunner.Run(command, arguments, directory?.ItemSpec ?? "");
+            LastProcessResults = results;
 
             if (results.ExitCode != 0)
             {
-                Log.LogError("{0} returned {1}", Command, results.ExitCode);
+                if (logFailure)
+                {
+                    Log.LogError("{0} returned {1}", Command, results.ExitCode);
 
-                foreach (var err in results.Error)
-                {
-                    Log.LogError(err);
-                }
-                foreach (var @out in results.Output)
-                {
-                    Log.LogWarning(@out);
+                    foreach (var err in results.Error)
+                    {
+                        Log.LogError(err);
+                    }
+                    foreach (var @out in results.Output)
+                    {
+                        Log.LogWarning(@out);
+                    }
                 }
 
                 output = Array.Empty<string>();

--- a/src/build-tasks/NeoExpressBatch.cs
+++ b/src/build-tasks/NeoExpressBatch.cs
@@ -10,6 +10,9 @@
 
 using Microsoft.Build.Framework;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Neo.BuildTasks
@@ -18,6 +21,7 @@ namespace Neo.BuildTasks
     {
         const string PACKAGE_ID = "Neo.Express";
         const string COMMAND = "neoxp";
+        const string RunningChainMessage = "Cannot run batch command while blockchain is running";
 
         protected override string Command => COMMAND;
         protected override string PackageId => PACKAGE_ID;
@@ -34,6 +38,56 @@ namespace Neo.BuildTasks
         public bool Trace { get; set; }
 
         public bool StackTrace { get; set; }
+
+        public override bool Execute()
+        {
+            if (BatchFile is null)
+                throw new Exception("Missing BatchFile Property");
+
+            var directory = WorkingDirectory;
+            if (!FindTool(PackageId, directory, out var resolvedType, out var version))
+            {
+                Log.LogError("tool package {0} not found", PackageId);
+                return false;
+            }
+
+            SetResolvedToolType(resolvedType);
+            ToolVersion = version.ToString();
+            Log.LogMessage(MessageImportance.High, "Found {0} tool package {1} version {2}",
+                resolvedType, PackageId, version);
+
+            var command = resolvedType == DotNetToolType.Global ? Command : "dotnet";
+            var batchArguments = resolvedType == DotNetToolType.Global
+                ? GetArguments()
+                : Command + " " + GetArguments();
+            CommandLine = $"{command} {batchArguments}";
+            Log.LogMessage(MessageImportance.High, "Running {0} {1}", command, batchArguments);
+
+            if (TryExecute(command, batchArguments, directory, out var output, logFailure: false))
+            {
+                ExecutionSuccess(output);
+                return true;
+            }
+
+            if (IsChainRunningFailure(LastProcessResults))
+            {
+                Log.LogMessage(MessageImportance.High,
+                    "Neo Express is running; deploying contracts from {0} without resetting the chain.",
+                    BatchFile.ItemSpec);
+                return DeployContractsWhileRunning(command, resolvedType, directory);
+            }
+
+            Log.LogError("{0} returned {1}", Command, LastProcessResults.ExitCode);
+            foreach (var err in LastProcessResults.Error)
+            {
+                Log.LogError(err);
+            }
+            foreach (var @out in LastProcessResults.Output)
+            {
+                Log.LogWarning(@out);
+            }
+            return false;
+        }
 
         protected override string GetArguments()
         {
@@ -63,6 +117,83 @@ namespace Neo.BuildTasks
             { builder.Append(" --stack-trace"); }
 
             return builder.ToString();
+        }
+
+        internal static bool IsChainRunningFailure(ProcessResults results)
+        {
+            return results.Error.Concat(results.Output)
+                .Any(line => line.IndexOf(RunningChainMessage, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        internal static IReadOnlyList<(string NefFile, string Account)> ParseDeployCommands(string batchText)
+        {
+            var deploys = new List<(string, string)>();
+            using var reader = new StringReader(batchText);
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length == 0 || trimmed.StartsWith("#") || trimmed.StartsWith("//"))
+                    continue;
+                var parts = trimmed.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 4
+                    && parts[0].Equals("contract", StringComparison.OrdinalIgnoreCase)
+                    && parts[1].Equals("deploy", StringComparison.OrdinalIgnoreCase))
+                {
+                    deploys.Add((parts[2], parts[3]));
+                }
+            }
+            return deploys;
+        }
+
+        bool DeployContractsWhileRunning(string command, DotNetToolType resolvedType, ITaskItem? directory)
+        {
+            var batchPath = BatchFile!.ItemSpec;
+            if (!Path.IsPathRooted(batchPath) && directory is not null && !string.IsNullOrEmpty(directory.ItemSpec))
+            {
+                batchPath = Path.Combine(directory.ItemSpec, batchPath);
+            }
+            if (!File.Exists(batchPath))
+            {
+                Log.LogError("Batch file \"{0}\" could not be found", batchPath);
+                return false;
+            }
+
+            var deploys = ParseDeployCommands(File.ReadAllText(batchPath));
+            if (deploys.Count == 0)
+            {
+                Log.LogError("Neo Express is running, and {0} has no 'contract deploy' lines to apply.", batchPath);
+                return false;
+            }
+
+            foreach (var (nefFile, account) in deploys)
+            {
+                var builder = new StringBuilder();
+                if (resolvedType != DotNetToolType.Global)
+                {
+                    builder.Append(Command);
+                    builder.Append(' ');
+                }
+                builder.AppendFormat("contract deploy \"{0}\" {1} --force", nefFile, account);
+                if (InputFile is not null)
+                {
+                    builder.AppendFormat(" --input \"{0}\"", InputFile.ItemSpec);
+                }
+                if (Trace)
+                {
+                    builder.Append(" --trace");
+                }
+
+                var arguments = builder.ToString();
+                Log.LogMessage(MessageImportance.High, "Running {0} {1}", command, arguments);
+                if (!TryExecute(command, arguments, directory, out var output))
+                {
+                    return false;
+                }
+                ExecutionSuccess(output);
+            }
+
+            return true;
         }
     }
 }

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -34,6 +34,7 @@
       <NeoCscOutput Include="$(NeoCscManifestPath)" />
       <NeoCscOutput Include="$(NeoCscDebugInfoPath)" Condition="'$(NeoCscDebugInfo)'=='true'" />
       <NeoCscOutput Include="$(NeoCscAssemblyPath)" Condition="'$(NeoContractAssembly)'=='true'"/>
+      <FileWrites Include="@(NeoCscOutput)" />
     </ItemGroup>
   </Target>
 
@@ -69,16 +70,26 @@
 
   <Target Name="ConfigureNeoExpressBatch">
     <PropertyGroup>
-      <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
+      <!-- Use the batch file name only so a relative NeoExpressBatchFile (../express.batch)
+           does not place the stamp outside IntermediateOutputPath, where Clean would miss it. -->
+      <NeoExpressBatchFileName>$([System.IO.Path]::GetFileName($(NeoExpressBatchFile)))</NeoExpressBatchFileName>
+      <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFileName).neoxp.touch'))</NeoExpressTouchFile>
       <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
+      <NeoExpressNormalizedInputFile Condition="'$(NeoExpressBatchInputFile)'!=''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchInputFile)))</NeoExpressNormalizedInputFile>
+      <!-- Older builds stamped obj/$(Configuration)/$(batch).neoxp.touch when NeoExpressBatchFile was a relative path. -->
+      <NeoExpressLegacyTouchFile Condition="'$(BaseIntermediateOutputPath)'!='' and '$(Configuration)'!='' and '$(NeoExpressBatchFileName)'!=''">$([MSBuild]::NormalizePath($(BaseIntermediateOutputPath), '$(Configuration)\$(NeoExpressBatchFileName).neoxp.touch'))</NeoExpressLegacyTouchFile>
     </PropertyGroup>
+    <ItemGroup>
+      <FileWrites Include="$(NeoExpressTouchFile)" Condition="'$(NeoExpressTouchFile)'!=''" />
+    </ItemGroup>
   </Target>
 
   <Target Name="ExecuteNeoExpressBatch"
     AfterTargets="Build" 
     DependsOnTargets="ConfigureNeoExpressBatch;ExecuteNeoCsc"
     Condition="'$(NeoExpressBatchFile)'!=''"
-    Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
+    Inputs="@(NeoCscOutput);$(NeoExpressNormalizedBatchFile);$(NeoExpressNormalizedInputFile)"
+    Outputs="$(NeoExpressTouchFile)">
 
     <PropertyGroup>
       <NeoExpressBatchReset>true</NeoExpressBatchReset>
@@ -172,7 +183,8 @@
 
   </Target>
 
-  <Target Name="CleanNeoCsc" 
+  <Target Name="CleanNeoCsc"
+    BeforeTargets="CoreClean;Rebuild"
     DependsOnTargets="ConfigureNeoCsc"
     Condition="'$(NeoContractName)'!=''">
 
@@ -181,10 +193,11 @@
   </Target>
 
   <Target Name="CleanNeoExpressBatch"
+    BeforeTargets="CoreClean;Rebuild"
     DependsOnTargets="ConfigureNeoExpressBatch"
     Condition="'$(NeoExpressBatchFile)'!=''">
 
-     <Delete Files="$(NeoExpressTouchFile)" TreatErrorsAsWarnings="true"/>
+    <Delete Files="$(NeoExpressTouchFile);$(NeoExpressLegacyTouchFile)" TreatErrorsAsWarnings="true"/>
 
   </Target>
 

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -171,7 +171,8 @@ namespace NeoExpress.Commands
                                     cmd.Model.Password,
                                     cmd.Model.WitnessScope,
                                     cmd.Model.Data,
-                                    cmd.Model.Force).ConfigureAwait(false);
+                                    cmd.Model.Force,
+                                    1m).ConfigureAwait(false);
                                 break;
                             }
                         case CommandLineApplication<BatchFileCommands.Contract.Download> cmd:

--- a/src/neoxp/Commands/ContractCommand.Deploy.cs
+++ b/src/neoxp/Commands/ContractCommand.Deploy.cs
@@ -47,6 +47,9 @@ namespace NeoExpress.Commands
             [Option(Description = "Password to use for NEP-2/NEP-6 account")]
             internal string Password { get; init; } = string.Empty;
 
+            [Option("--gas|-g", CommandOptionType.SingleValue, Description = "Additional GAS to apply to the deployment (covers fee-estimation shortfall)")]
+            internal decimal AdditionalGas { get; init; } = 1;
+
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
@@ -66,7 +69,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    await txExec.ContractDeployAsync(Contract, Account, password, WitnessScope, Data, Force).ConfigureAwait(false);
+                    await txExec.ContractDeployAsync(Contract, Account, password, WitnessScope, Data, Force, AdditionalGas).ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)

--- a/src/neoxp/ExpressChainManager.cs
+++ b/src/neoxp/ExpressChainManager.cs
@@ -23,6 +23,7 @@ using Nito.Disposables;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using System.Net;
+using System.Threading;
 
 namespace NeoExpress
 {
@@ -158,10 +159,23 @@ namespace NeoExpress
         private static bool IsNodeRunning(ExpressConsensusNode node)
         {
             // Check to see if there's a neo-express blockchain currently running by
-            // attempting to open a mutex with the multisig account address for a name
+            // attempting to open a mutex with the consensus account script hash for a name.
+            // An abandoned mutex means the previous process died without releasing it.
 
             var account = node.Wallet.Accounts.Single(a => a.IsDefault);
-            return Mutex.TryOpenExisting(GLOBAL_PREFIX + account.ScriptHash, out var _);
+            try
+            {
+                if (Mutex.TryOpenExisting(GLOBAL_PREFIX + account.ScriptHash, out var mutex))
+                {
+                    mutex.Dispose();
+                    return true;
+                }
+                return false;
+            }
+            catch (AbandonedMutexException)
+            {
+                return false;
+            }
         }
 
         public bool IsRunning(ExpressConsensusNode? node = null)

--- a/src/neoxp/Extensions/ExpressNodeExtensions.cs
+++ b/src/neoxp/Extensions/ExpressNodeExtensions.cs
@@ -271,6 +271,16 @@ namespace NeoExpress
             return await expressNode.ExecuteAsync(sender, senderHash, WitnessScope.CalledByEntry, script).ConfigureAwait(false);
         }
 
+        public static bool HasUpdateMethod(ContractManifest? manifest)
+        {
+            if (manifest?.Abi is null)
+            {
+                return false;
+            }
+            return manifest.Abi.GetMethod("update", 2) is not null
+                || manifest.Abi.GetMethod("update", 3) is not null;
+        }
+
         public static async Task<UInt256> UpdateAsync(this IExpressNode expressNode,
                                                       UInt160 contractHash,
                                                       NefFile nefFile,
@@ -281,6 +291,9 @@ namespace NeoExpress
                                                       object? data = null)
         {
             CheckNefFile(nefFile);
+            // Native ContractManagement.Update only succeeds when the calling
+            // script is the contract itself. Invoke the contract's update method,
+            // which must call ContractManagement.Update internally.
             using var sb = new ScriptBuilder();
             if (data == null)
                 sb.EmitDynamicCall(contractHash,
@@ -303,7 +316,8 @@ namespace NeoExpress
                                                       Wallet wallet,
                                                       UInt160 accountHash,
                                                       WitnessScope witnessScope,
-                                                      ContractParameter? data)
+                                                      ContractParameter? data,
+                                                      decimal additionalGas = 1m)
         {
             CheckNefFile(nefFile);
 
@@ -314,7 +328,42 @@ namespace NeoExpress
                 nefFile.ToArray(),
                 manifest.ToJson().ToString(),
                 data);
-            return await expressNode.ExecuteAsync(wallet, accountHash, witnessScope, sb.ToArray()).ConfigureAwait(false);
+            // RPC fee estimation is slightly below actual _deploy consumption (observed 480 datoshi).
+            return await expressNode.ExecuteAsync(wallet, accountHash, witnessScope, sb.ToArray(), additionalGas).ConfigureAwait(false);
+        }
+
+        public static async Task EnsureTransactionSucceededAsync(this IExpressNode expressNode, UInt256 txHash, TimeSpan? timeout = null)
+        {
+            timeout ??= TimeSpan.FromSeconds(30);
+            var stopwatch = Stopwatch.StartNew();
+            Exception? lastError = null;
+            while (stopwatch.Elapsed < timeout)
+            {
+                try
+                {
+                    var (_, log) = await expressNode.GetTransactionAsync(txHash).ConfigureAwait(false);
+                    if (log?.Executions is { Count: > 0 })
+                    {
+                        var fault = log.Executions.FirstOrDefault(execution => execution.VMState == VMState.FAULT);
+                        if (fault is not null)
+                        {
+                            throw new Exception($"Transaction {txHash} FAULT");
+                        }
+                        if (log.Executions.Any(execution => execution.VMState == VMState.HALT))
+                        {
+                            return;
+                        }
+                    }
+                }
+                catch (Exception ex) when (!ex.Message.Contains("FAULT", StringComparison.OrdinalIgnoreCase))
+                {
+                    lastError = ex;
+                }
+                await Task.Delay(400).ConfigureAwait(false);
+            }
+
+            var suffix = lastError is null ? string.Empty : $" {lastError.Message}";
+            throw new TimeoutException($"Transaction {txHash} was not confirmed within {timeout.Value.TotalSeconds:0} seconds.{suffix}");
         }
 
         static void CheckNefFile(NefFile nefFile)

--- a/src/neoxp/Node/NodeUtility.cs
+++ b/src/neoxp/Node/NodeUtility.cs
@@ -34,6 +34,14 @@ namespace NeoExpress.Node
     {
         internal static string ContractNotFoundMessage(UInt160 scriptHash) => $"Contract {scriptHash} not found";
 
+        // RPC invokescript / Wallet.MakeTransaction report slightly less GAS than persist-time
+        // execution consumes. Contract deploy was observed 480 datoshi short, which FAULTs the
+        // submitted transaction with "Insufficient GAS." Always pad the estimate; --gas is extra.
+        internal const long InvokeEstimatePadDatoshi = 10_000_000L; // 0.1 GAS
+
+        internal static long SystemFeeBuffer(decimal additionalGas)
+            => AdditionalGasSystemFee(additionalGas) + InvokeEstimatePadDatoshi;
+
         // Convert an --additional-gas amount to the system-fee delta (in GAS datoshi),
         // with clear errors instead of the raw exceptions the bare conversion throws: an
         // ArgumentException for more than GAS.Decimals fractional digits, and an

--- a/src/neoxp/Node/OfflineNode.cs
+++ b/src/neoxp/Node/OfflineNode.cs
@@ -192,7 +192,7 @@ namespace NeoExpress.Node
             const long maxSafeGas = long.MaxValue / 10_000;
             var maxGas = balance.Amount > maxSafeGas ? maxSafeGas : (long)balance.Amount;
             var tx = wallet.MakeTransaction(neoSystem.StoreView, script, accountHash, new[] { signer }, maxGas: maxGas);
-            tx.SystemFee += NodeUtility.AdditionalGasSystemFee(additionalGas);
+            tx.SystemFee += NodeUtility.SystemFeeBuffer(additionalGas);
 
             var context = new ContractParametersContext(neoSystem.StoreView, tx, ProtocolSettings.Network);
             var account = wallet.GetAccount(accountHash)

--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -92,7 +92,7 @@ namespace NeoExpress.Node
             var signers = new[] { new Signer { Account = accountHash, Scopes = witnessScope } };
             var tm = await TransactionManager.MakeTransactionAsync(rpcClient, script, signers).ConfigureAwait(false);
 
-            tm.Tx.SystemFee += NodeUtility.AdditionalGasSystemFee(additionalGas);
+            tm.Tx.SystemFee += NodeUtility.SystemFeeBuffer(additionalGas);
 
             var account = wallet.GetAccount(accountHash)
                 ?? throw new Exception($"Account {accountHash} not found in wallet {wallet.Name}");

--- a/src/neoxp/TransactionExecutor.cs
+++ b/src/neoxp/TransactionExecutor.cs
@@ -91,10 +91,11 @@ namespace NeoExpress
             var txHash = await expressNode
                 .UpdateAsync(scriptHash, nefFile, manifest, wallet, accountHash, witnessScope, data)
                 .ConfigureAwait(false);
+            await expressNode.EnsureTransactionSucceededAsync(txHash).ConfigureAwait(false);
             await writer.WriteTxHashAsync(txHash, "Update", json).ConfigureAwait(false);
         }
 
-        public async Task ContractDeployAsync(string contract, string accountName, string password, WitnessScope witnessScope, string data, bool force)
+        public async Task ContractDeployAsync(string contract, string accountName, string password, WitnessScope witnessScope, string data, bool force, decimal additionalGas = 1m)
         {
             if (!chainManager.TryGetSigningAccount(accountName, password, out var wallet, out var accountHash))
             {
@@ -102,11 +103,34 @@ namespace NeoExpress
             }
 
             var (nefFile, manifest) = await fileSystem.LoadContractAsync(contract).ConfigureAwait(false);
+            var contractHash = Neo.SmartContract.Helper.GetContractHash(accountHash, nefFile.CheckSum, manifest.Name);
+            var existing = await expressNode.ListContractsAsync(manifest.Name).ConfigureAwait(false);
+            if (existing.Any(candidate => candidate.hash == contractHash))
+            {
+                var onChainManifest = existing.First(candidate => candidate.hash == contractHash).manifest;
+                if (!ExpressNodeExtensions.HasUpdateMethod(onChainManifest))
+                {
+                    throw new Exception(
+                        $"Contract {manifest.Name} ({contractHash}) is already deployed and has no update method. " +
+                        "Restore a checkpoint or reset the chain to remove it, then deploy again.");
+                }
+                if (!force)
+                {
+                    throw new Exception($"Contract named {manifest.Name} already deployed. Use --force to update the existing contract.");
+                }
+
+                var updateTxHash = await expressNode
+                    .UpdateAsync(contractHash, nefFile, manifest, wallet, accountHash, witnessScope,
+                        string.IsNullOrEmpty(data) ? null : data)
+                    .ConfigureAwait(false);
+                await expressNode.EnsureTransactionSucceededAsync(updateTxHash).ConfigureAwait(false);
+                await WriteDeployResultAsync(manifest.Name, contractHash, updateTxHash, "Update").ConfigureAwait(false);
+                return;
+            }
 
             if (!force)
             {
-                var contracts = await expressNode.ListContractsAsync(manifest.Name).ConfigureAwait(false);
-                if (contracts.Count > 0)
+                if (existing.Count > 0)
                 {
                     throw new Exception($"Contract named {manifest.Name} already deployed. Use --force to deploy contract with conflicting name.");
                 }
@@ -194,25 +218,31 @@ namespace NeoExpress
             }
 
             var txHash = await expressNode
-                .DeployAsync(nefFile, manifest, wallet, accountHash, witnessScope, dataParam)
+                .DeployAsync(nefFile, manifest, wallet, accountHash, witnessScope, dataParam, additionalGas)
                 .ConfigureAwait(false);
+            await expressNode.EnsureTransactionSucceededAsync(txHash).ConfigureAwait(false);
+            await WriteDeployResultAsync(manifest.Name, contractHash, txHash, "Deployment").ConfigureAwait(false);
+        }
 
-            var contractHash = Neo.SmartContract.Helper.GetContractHash(accountHash, nefFile.CheckSum, manifest.Name);
+        private async Task WriteDeployResultAsync(string name, UInt160 contractHash, UInt256 txHash, string action)
+        {
             if (json)
             {
                 using var jsonWriter = new JsonTextWriter(writer) { Formatting = Formatting.Indented };
                 await jsonWriter.WriteStartObjectAsync().ConfigureAwait(false);
                 await jsonWriter.WritePropertyNameAsync("contract-name").ConfigureAwait(false);
-                await jsonWriter.WriteValueAsync(manifest.Name).ConfigureAwait(false);
+                await jsonWriter.WriteValueAsync(name).ConfigureAwait(false);
                 await jsonWriter.WritePropertyNameAsync("contract-hash").ConfigureAwait(false);
                 await jsonWriter.WriteValueAsync($"{contractHash}").ConfigureAwait(false);
                 await jsonWriter.WritePropertyNameAsync("tx-hash").ConfigureAwait(false);
                 await jsonWriter.WriteValueAsync($"{txHash}").ConfigureAwait(false);
+                await jsonWriter.WritePropertyNameAsync("action").ConfigureAwait(false);
+                await jsonWriter.WriteValueAsync(action).ConfigureAwait(false);
                 await jsonWriter.WriteEndObjectAsync().ConfigureAwait(false);
             }
             else
             {
-                await writer.WriteLineAsync($"Deployment of {manifest.Name} ({contractHash}) Transaction {txHash} submitted").ConfigureAwait(false);
+                await writer.WriteLineAsync($"{action} of {name} ({contractHash}) Transaction {txHash} submitted").ConfigureAwait(false);
             }
         }
 

--- a/test/test-build-tasks/TestNeoBuildTasksTargets.cs
+++ b/test/test-build-tasks/TestNeoBuildTasksTargets.cs
@@ -1,0 +1,113 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestNeoBuildTasksTargets.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestNeoBuildTasksTargets
+    {
+        static string FindTargetsPath()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                var candidate = Path.Combine(dir.FullName, "src", "build-tasks", "build", "Neo.BuildTasks.targets");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+                dir = dir.Parent;
+            }
+
+            throw new FileNotFoundException("Could not find Neo.BuildTasks.targets");
+        }
+
+        [Fact]
+        public void express_batch_stamp_stays_inside_intermediate_output()
+        {
+            var text = File.ReadAllText(FindTargetsPath());
+            Assert.Contains("GetFileName($(NeoExpressBatchFile))", text);
+            Assert.Contains("FileWrites Include=\"$(NeoExpressTouchFile)\"", text);
+            Assert.Contains("FileWrites Include=\"@(NeoCscOutput)\"", text);
+            Assert.Contains("BeforeTargets=\"CoreClean;Rebuild\"", text);
+            Assert.Contains("NeoExpressLegacyTouchFile", text);
+        }
+
+        [Fact]
+        public void express_batch_incremental_inputs_do_not_include_the_stamp()
+        {
+            var text = File.ReadAllText(FindTargetsPath());
+            Assert.Contains("Inputs=\"@(NeoCscOutput);$(NeoExpressNormalizedBatchFile);$(NeoExpressNormalizedInputFile)\"", text);
+            Assert.Contains("Outputs=\"$(NeoExpressTouchFile)\"", text);
+            Assert.DoesNotContain("Inputs=\"@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)\"", text);
+        }
+
+        [Fact]
+        public void clean_deletes_express_batch_stamp_for_relative_batch_paths()
+        {
+            var targetsPath = FindTargetsPath();
+            var temp = Directory.CreateTempSubdirectory("neoxp-buildtasks-");
+            try
+            {
+                var projectDir = Path.Combine(temp.FullName, "src");
+                Directory.CreateDirectory(projectDir);
+                var intermediate = Path.Combine(projectDir, "obj", "Debug", "net10.0");
+                var legacyDir = Path.Combine(projectDir, "obj", "Debug");
+                Directory.CreateDirectory(intermediate);
+                Directory.CreateDirectory(legacyDir);
+
+                var stamp = Path.Combine(intermediate, "express.batch.neoxp.touch");
+                var legacyStamp = Path.Combine(legacyDir, "express.batch.neoxp.touch");
+                File.WriteAllText(stamp, "stamp");
+                File.WriteAllText(legacyStamp, "legacy");
+
+                var projectPath = Path.Combine(projectDir, "clean.proj");
+                File.WriteAllText(projectPath, $"""
+                    <Project>
+                      <PropertyGroup>
+                        <Configuration>Debug</Configuration>
+                        <BaseIntermediateOutputPath>{Path.Combine(projectDir, "obj") + Path.DirectorySeparatorChar}</BaseIntermediateOutputPath>
+                        <IntermediateOutputPath>{intermediate + Path.DirectorySeparatorChar}</IntermediateOutputPath>
+                        <NeoExpressBatchFile>../express.batch</NeoExpressBatchFile>
+                        <NeoBuildTasksAssembly>{Path.Combine(temp.FullName, "missing.dll")}</NeoBuildTasksAssembly>
+                      </PropertyGroup>
+                      <Import Project="{targetsPath}" />
+                    </Project>
+                    """);
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    Arguments = $"msbuild \"{projectPath}\" -nologo -t:CleanNeoExpressBatch -v:q",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start msbuild");
+                var stdout = process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                Assert.True(process.ExitCode == 0, stdout + Environment.NewLine + stderr);
+                Assert.False(File.Exists(stamp), "Current NeoExpressTouchFile should be deleted on Clean");
+                Assert.False(File.Exists(legacyStamp), "Legacy obj/Configuration stamp should be deleted on Clean");
+            }
+            finally
+            {
+                try { temp.Delete(true); } catch { }
+            }
+        }
+    }
+}

--- a/test/test-build-tasks/TestNeoBuildTasksTargets.cs
+++ b/test/test-build-tasks/TestNeoBuildTasksTargets.cs
@@ -106,7 +106,9 @@ namespace build_tasks
             }
             finally
             {
-                try { temp.Delete(true); } catch { }
+                try
+                { temp.Delete(true); }
+                catch { }
             }
         }
     }

--- a/test/test-build-tasks/TestNeoExpressBatch.cs
+++ b/test/test-build-tasks/TestNeoExpressBatch.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestNeoExpressBatch.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.BuildTasks;
+using System.Collections.Generic;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestNeoExpressBatch
+    {
+        [Fact]
+        public void parse_deploy_commands_skips_comments_and_other_lines()
+        {
+            var batch = """
+                # setup
+                transfer 1 gas genesis node1
+                contract deploy ./bin/sc/Contract.nef genesis
+                contract deploy ./bin/sc/Nep17Contract.nef owner
+                checkpoint create ./checkpoints/deployed -f
+                // done
+                """;
+
+            var deploys = NeoExpressBatch.ParseDeployCommands(batch);
+            Assert.Equal(2, deploys.Count);
+            Assert.Equal("./bin/sc/Contract.nef", deploys[0].NefFile);
+            Assert.Equal("genesis", deploys[0].Account);
+            Assert.Equal("./bin/sc/Nep17Contract.nef", deploys[1].NefFile);
+            Assert.Equal("owner", deploys[1].Account);
+        }
+
+        [Fact]
+        public void chain_running_failure_is_detected_from_stderr()
+        {
+            var results = new ProcessResults(
+                1,
+                new List<string>(),
+                new List<string> { "Cannot run batch command while blockchain is running" });
+            Assert.True(NeoExpressBatch.IsChainRunningFailure(results));
+        }
+
+        [Fact]
+        public void unrelated_batch_failure_is_not_treated_as_running_chain()
+        {
+            var results = new ProcessResults(
+                1,
+                new List<string> { "Batch file missing" },
+                new List<string>());
+            Assert.False(NeoExpressBatch.IsChainRunningFailure(results));
+        }
+    }
+}

--- a/test/test.workflowvalidation/AdditionalGasTests.cs
+++ b/test/test.workflowvalidation/AdditionalGasTests.cs
@@ -24,6 +24,13 @@ public class AdditionalGasTests
         NodeUtility.AdditionalGasSystemFee(1.5m).Should().Be(150_000_000L);
     }
 
+    [Fact]
+    public void SystemFeeBuffer_pads_invokescript_estimates_and_adds_requested_gas()
+    {
+        NodeUtility.SystemFeeBuffer(0m).Should().Be(NodeUtility.InvokeEstimatePadDatoshi);
+        NodeUtility.SystemFeeBuffer(1m).Should().Be(100_000_000L + NodeUtility.InvokeEstimatePadDatoshi);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]

--- a/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
+++ b/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
@@ -267,7 +267,10 @@ public class ExpressNodeExtensionsTests
             return Task.FromResult<Block>(null!);
         }
 
-        public Task<(Transaction tx, RpcApplicationLog? appLog)> GetTransactionAsync(UInt256 txHash) => throw new NotSupportedException();
+        public RpcApplicationLog? TransactionLog { get; set; }
+
+        public Task<(Transaction tx, RpcApplicationLog? appLog)> GetTransactionAsync(UInt256 txHash)
+            => Task.FromResult<(Transaction tx, RpcApplicationLog? appLog)>((null!, TransactionLog));
 
         public Task<uint> GetTransactionHeightAsync(UInt256 txHash) => throw new NotSupportedException();
 


### PR DESCRIPTION
## Summary

This updates Visual DevTracker, the C# samples, and `neoxp` so a local Neo Express workspace can be created, built, deployed, and invoked from VS Code without the UX bugs we hit on current 3.10 / .NET 10.

### Samples and wizard
- Official [Neo.SmartContract.Template](https://github.com/neo-project/neo-devpack-dotnet/tree/master-n3/src/Neo.SmartContract.Template) starters (Blank, NEP-17, NEP-11, Oracle, Ownable) live under `samples/examples/` with `Neo.BuildTasks`.
- `dotnet build` in an example folder creates `default.neo-express` if missing, compiles the `.nef`, and deploys as `genesis` while Express is running.
- The **New contract** wizard overlays those same official C# starters (plus the existing Storage scaffold). Official unit-test projects are not copied.

### Visual DevTracker
- Quick Start is a tree view (sidebar scrollbar, no nested webview bar). **Deploy a contract** stays; **Redeploy** is removed.
- Contract Studio: contract/method dropdowns, scroll on short panes, persistent invocation results, Output channel **Neo Express Invocation**.
- Wallets: genesis + `node1` + NEP-6 accounts. Deploy as genesis uses `--password` when needed.
- Reset stops leftover node processes (including after F5 reload), does not hang on failed start, and clears the status bar.
- F5 uses a repo-built `src/neoxp/bin/.../neoxp.dll` when present, instead of an older global `neoxp` that lacks `--gas`.

### `neoxp` / BuildTasks
- Deploy system fee is padded (invokescript underestimates persist-time `_deploy` cost by a few hundred datoshi → `Insufficient GAS` FAULT). Default `--gas 1` plus a 0.1 GAS estimate pad.
- After deploy/update, wait for the application log; FAULT is an error, not “Transaction submitted”.
- `deploy --force` on the **same hash** calls the contract `update` method (which must call `ContractManagement.Update`). No `update` method → error telling you to reset or restore a checkpoint.
- Clean/rebuild deletes the batch stamp so the next build resets and redeploys.

### Docs
- New [docs/getting-started.md](docs/getting-started.md) (CLI and VS Code).
- Debugger command reference and sample README updates.

## How to test locally

### Prerequisites
- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (`dotnet --list-sdks` lists a 10.x).
- Node.js 20+ (for the extension).
- VS Code 1.104+.
- RocksDB on Ubuntu (`librocksdb-dev`); on macOS `brew install rocksdb`. Do not install .NET via Snap.

### 1. Build this branch’s `neoxp` (do not rely on an old global tool)

```shell
git clone https://github.com/cschuchardt88/neo-express.git
cd neo-express
git checkout fix/vscode-extensions-and-samples
dotnet build src/neoxp/neoxp.csproj
```

Optional — install this build as a global tool so PATH matches F5:

```shell
dotnet pack src/neoxp/neoxp.csproj -c Release -o nupkgs
dotnet tool uninstall Neo.Express -g   # if an older 3.10.1 is installed
dotnet tool install Neo.Express -g --add-source ./nupkgs --prerelease
neoxp contract deploy --help   # should list --gas / -g
```

If you skip the pack/install step, F5 still picks `src/neoxp/bin/Debug/net10.0/neoxp.dll` automatically (DevTracker log: `using repo build:`).

### 2. Automated tests

```shell
dotnet test test/test.workflowvalidation/test.workflowvalidation.csproj
dotnet test test/test-build-tasks/test-build-tasks.csproj

cd extentions/neo3-visual-tracker
npm install
npm test
npm run compile
```

Expect Visual DevTracker tests to pass (`npm test`).

### 3. CLI sample: compile + deploy on build

Terminal A:

```shell
cd samples
dotnet tool restore
dotnet tool run neoxp -- create -f -o examples/Nep17/default.neo-express
dotnet tool run neoxp -- run -i examples/Nep17/default.neo-express --seconds-per-block 1
```

Terminal B (repo root):

```shell
dotnet build samples/examples/Nep17
dotnet tool run --project samples neoxp -- contract run -i samples/examples/Nep17/default.neo-express Nep17Contract symbol --results
```

`dotnet rebuild samples/examples/Nep17` should reset the chain and redeploy (batch stamp is cleared).

### 4. VS Code — Extension Development Host (F5)

```shell
cd extentions/neo3-visual-tracker
npm install
npm run compile
```

**Option A — F5**  
Open `extentions/neo3-visual-tracker` as the VS Code folder, then **Run and Debug → Launch Visual DevTracker**. In the Extension Development Host, **File → Open Folder** on a test workspace (empty folder, or `samples/examples/Nep17`).

**Option B — CLI**

```shell
code --extensionDevelopmentPath="<repo>/extentions/neo3-visual-tracker" "<your-workspace>"
```

Use a **fresh folder** as `<your-workspace>` so you are not mixing leftover `default.neo-express` files from earlier runs.

### 5. Manual UI checklist (Extension Development Host)

1. Neo N3 activity bar → **Quick Start** is the first view and uses the **sidebar** scrollbar (no inner webview bar).
2. **Create a new Neo Express instance** (or start an existing `default.neo-express`). Confirm **genesis** and **node1** appear under **Wallets**.
3. **New contract** → C# → **Ownable** (or NEP-17). Files land under `contracts/<name>/`. Wait for restore/build.
4. **Start Neo Express** if it is not running. Connect to `default.neo-express`.
5. Quick Start still shows **Deploy a contract** (not Redeploy). Deploy as **genesis**.
6. Confirm the contract appears under **Smart contracts** (not FAULT / Insufficient GAS in the Express terminal).
7. Rocket on the workspace contract → Contract Studio. Shrink the editor (terminal open) and **scroll** to Method + **Run invocation**.
8. Run a `[Safe]` method such as `getOwner`. Results stay in a dialog/card and in Output → **Neo Express Invocation**.
9. **Reset Neo Express**: node stops, chain wipes, node restarts. Status bar must not stick on “Restarting node…”. Deploy again after reset.
10. Contract Studio on a short pane must remain scrollable; last Quick Start item must not sit under the status bar.

### 6. Known local gotchas
- A **global** `neoxp` 3.10.1.x without `--gas` will reject `-g`. This branch prefers the repo DLL and only passes `-g` when `contract deploy --help` lists `--gas`.
- After reset, the same contract hash cannot be deployed again. Use **Reset** (or restore a checkpoint), then **Deploy**. Updating requires an on-chain `update` method that calls `ContractManagement.Update`.
- Keep only one `default.neo-express` in the test workspace. Nested `test/*.neo-express` files are hidden from the Blockchains view.

## Test plan (reviewers)
- [ ] `dotnet test` on `test.workflowvalidation` and `test-build-tasks`
- [ ] `npm test` / `npm run compile` in `extentions/neo3-visual-tracker`
- [ ] `dotnet build samples/examples/Nep17` while Express is running
- [ ] F5 DevTracker: create/start chain, new Ownable contract, deploy genesis, invoke `getOwner`, reset, deploy again
