### PR TITLE
fix: treat a null Wallets list as empty

### DIFF
--- a/src/bctklib/ExpressChainExtensions.cs
+++ b/src/bctklib/ExpressChainExtensions.cs
@@ -454,6 +454,12 @@ namespace Neo.BlockchainToolkit
 
         public static bool TryGetWallet(this ExpressChain chain, string name, [MaybeNullWhen(false)] out ExpressWallet wallet)
         {
+            if (chain.Wallets is null)
+            {
+                wallet = null;
+                return false;
+            }
+
             for (int i = 0; i < chain.Wallets.Count; i++)
             {
                 if (string.Equals(name, chain.Wallets[i].Name, StringComparison.OrdinalIgnoreCase))

--- a/src/neoxp/Extensions/ExpressChainExtensions.cs
+++ b/src/neoxp/Extensions/ExpressChainExtensions.cs
@@ -77,7 +77,7 @@ namespace NeoExpress
             // if the name is a valid Neo Express account name, no password is needed
             if (chain.IsReservedName(name))
                 return password;
-            if (chain.Wallets.Any(w => name.Equals(w.Name, StringComparison.OrdinalIgnoreCase)))
+            if (chain.Wallets is not null && chain.Wallets.Any(w => name.Equals(w.Name, StringComparison.OrdinalIgnoreCase)))
                 return password;
 
             // if a password is needed but not provided, prompt the user

--- a/test/test.bctklib/TryGetWalletNullTests.cs
+++ b/test/test.bctklib/TryGetWalletNullTests.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TryGetWalletNullTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit;
+using Neo.BlockchainToolkit.Models;
+using Xunit;
+
+namespace test.bctklib;
+
+public class TryGetWalletNullTests
+{
+    [Fact]
+    public void TryGetWallet_returns_false_when_wallets_is_null()
+    {
+        var chain = new ExpressChain { Wallets = null! };
+
+        chain.TryGetWallet("alice", out var wallet).Should().BeFalse();
+        wallet.Should().BeNull();
+    }
+}

--- a/test/test.workflowvalidation/ResolvePasswordNullWalletsTests.cs
+++ b/test/test.workflowvalidation/ResolvePasswordNullWalletsTests.cs
@@ -1,0 +1,27 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ResolvePasswordNullWalletsTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo.BlockchainToolkit.Models;
+using NeoExpress;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ResolvePasswordNullWalletsTests
+{
+    [Fact]
+    public void ResolvePassword_does_not_throw_when_wallets_is_null()
+    {
+        var chain = new ExpressChain { Wallets = null! };
+
+        chain.ResolvePassword("unknown", "secret").Should().Be("secret");
+    }
+}


### PR DESCRIPTION
## Summary

A `.neo-express` file can deserialize "wallets": null`. `TryGetWallet` and `ResolvePassword` then throw `NullReferenceException`.

Treat a null list as empty so wallet lookup and password resolution fail cleanly (wallet not found / prompt or provided password).

Independent of #836–#839.