### PR TITLE
fix: reject invalid hashes in show transaction

### DIFF
--- a/src/neoxp/Commands/ShowCommand.Transaction.cs
+++ b/src/neoxp/Commands/ShowCommand.Transaction.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using McMaster.Extensions.CommandLineUtils;
+using Neo;
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations;
 
@@ -30,6 +31,9 @@ namespace NeoExpress.Commands
             [Required]
             internal string TransactionHash { get; init; } = string.Empty;
 
+            internal static bool TryParseTransactionHash(string value, out UInt256 hash)
+                => UInt256.TryParse(value, out hash!);
+
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
 
@@ -39,7 +43,9 @@ namespace NeoExpress.Commands
                 {
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     using var expressNode = chainManager.GetExpressNode();
-                    var (tx, log) = await expressNode.GetTransactionAsync(Neo.UInt256.Parse(TransactionHash));
+                    if (!TryParseTransactionHash(TransactionHash, out var hash))
+                        throw new Exception($"Invalid transaction hash \"{TransactionHash}\".");
+                    var (tx, log) = await expressNode.GetTransactionAsync(hash);
 
                     using var writer = new JsonTextWriter(console.Out) { Formatting = Formatting.Indented };
                     await writer.WriteStartObjectAsync();

--- a/test/test.workflowvalidation/ShowTransactionHashTests.cs
+++ b/test/test.workflowvalidation/ShowTransactionHashTests.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ShowTransactionHashTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using Neo;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ShowTransactionHashTests
+{
+    [Fact]
+    public void TryParseTransactionHash_accepts_a_valid_hash()
+    {
+        var hex = new string('0', 64);
+        ShowCommand.Transaction.TryParseTransactionHash(hex, out var hash).Should().BeTrue();
+        hash.Should().Be(UInt256.Zero);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-hash")]
+    [InlineData("0xzz")]
+    public void TryParseTransactionHash_rejects_invalid_input(string value)
+    {
+        ShowCommand.Transaction.TryParseTransactionHash(value, out _).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`neoxp show transaction` used `UInt256.Parse`, which throws `FormatException` on garbage input.

Use `TryParse` and report `Invalid transaction hash \"...\"`.

Independent of #836–#839.