### PR TITLE
fix: parse contract update data with the chain contract resolver

### DIFF
--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -244,8 +244,10 @@ namespace NeoExpress.Commands
                             }
                         case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:
                             {
-                                var parser = await txExec.ExpressNode.GetContractParameterParserAsync(chainManager.Chain).ConfigureAwait(false);
-                                var data = ContractCommand.Update.ParseUpdateData(cmd.Model.Data, s => parser.ParseParameter(s));
+                                var data = await ContractCommand.Update.ParseUpdateDataAsync(
+                                    cmd.Model.Data,
+                                    txExec.ExpressNode,
+                                    chainManager.Chain).ConfigureAwait(false);
                                 await txExec.ContractUpdateAsync(
                                     cmd.Model.Contract,
                                     root.Resolve(cmd.Model.NefFile),

--- a/src/neoxp/Commands/BatchCommand.cs
+++ b/src/neoxp/Commands/BatchCommand.cs
@@ -244,7 +244,8 @@ namespace NeoExpress.Commands
                             }
                         case CommandLineApplication<BatchFileCommands.Contract.Update> cmd:
                             {
-                                var data = ContractCommand.Update.ParseUpdateData(cmd.Model.Data, txExec.ContractParameterParser);
+                                var parser = await txExec.ExpressNode.GetContractParameterParserAsync(chainManager.Chain).ConfigureAwait(false);
+                                var data = ContractCommand.Update.ParseUpdateData(cmd.Model.Data, s => parser.ParseParameter(s));
                                 await txExec.ContractUpdateAsync(
                                     cmd.Model.Contract,
                                     root.Resolve(cmd.Model.NefFile),

--- a/src/neoxp/Commands/ContractCommand.Update.cs
+++ b/src/neoxp/Commands/ContractCommand.Update.cs
@@ -8,6 +8,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.BlockchainToolkit.Models;
 using Neo.Network.P2P.Payloads;
 using System.ComponentModel.DataAnnotations;
 
@@ -67,8 +68,7 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    var parser = await txExec.ExpressNode.GetContractParameterParserAsync(chainManager.Chain).ConfigureAwait(false);
-                    var data = ParseUpdateData(Data, s => parser.ParseParameter(s));
+                    var data = await ParseUpdateDataAsync(Data, txExec.ExpressNode, chainManager.Chain).ConfigureAwait(false);
                     await txExec.ContractUpdateAsync(Contract, NefFile, Account, password, WitnessScope, data).ConfigureAwait(false);
                     return 0;
                 }
@@ -81,6 +81,15 @@ namespace NeoExpress.Commands
 
             internal static object? ParseUpdateData(string data, Func<string, object> parseData)
                 => string.IsNullOrEmpty(data) ? null : parseData(data);
+
+            internal static async Task<object?> ParseUpdateDataAsync(string data, IExpressNode expressNode, ExpressChain chain)
+            {
+                if (string.IsNullOrEmpty(data))
+                    return null;
+
+                var parser = await expressNode.GetContractParameterParserAsync(chain).ConfigureAwait(false);
+                return parser.ParseParameter(data);
+            }
         }
     }
 }

--- a/src/neoxp/Commands/ContractCommand.Update.cs
+++ b/src/neoxp/Commands/ContractCommand.Update.cs
@@ -67,7 +67,8 @@ namespace NeoExpress.Commands
                     var (chainManager, _) = chainManagerFactory.LoadChain(Input);
                     var password = chainManager.Chain.ResolvePassword(Account, Password);
                     using var txExec = txExecutorFactory.Create(chainManager, Trace, Json);
-                    var data = ParseUpdateData(Data, txExec.ContractParameterParser);
+                    var parser = await txExec.ExpressNode.GetContractParameterParserAsync(chainManager.Chain).ConfigureAwait(false);
+                    var data = ParseUpdateData(Data, s => parser.ParseParameter(s));
                     await txExec.ContractUpdateAsync(Contract, NefFile, Account, password, WitnessScope, data).ConfigureAwait(false);
                     return 0;
                 }

--- a/test/test.workflowvalidation/ContractUpdateCommandTests.cs
+++ b/test/test.workflowvalidation/ContractUpdateCommandTests.cs
@@ -31,4 +31,18 @@ public class ContractUpdateCommandTests
 
         data.Should().Be(2);
     }
+
+    [Fact]
+    public void ParseUpdateData_forwards_the_json_to_the_parser()
+    {
+        string? seen = null;
+        var data = ContractCommand.Update.ParseUpdateData("{\"type\":\"Hash160\",\"value\":\"0x00\"}", value =>
+        {
+            seen = value;
+            return value;
+        });
+
+        seen.Should().Be("{\"type\":\"Hash160\",\"value\":\"0x00\"}");
+        data.Should().Be(seen);
+    }
 }

--- a/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
+++ b/test/test.workflowvalidation/ExpressNodeExtensionsTests.cs
@@ -126,6 +126,49 @@ public class ExpressNodeExtensionsTests
     }
 
     [Fact]
+    public async Task Contract_update_data_uses_the_chain_parser()
+    {
+        var manifest = ContractManifest.Parse("""
+        {
+          "name":"SampleContract",
+          "groups":[],
+          "features":{},
+          "supportedstandards":[],
+          "abi":{
+            "methods":[{"name":"dummy","parameters":[],"returntype":"Void","offset":0,"safe":false}],
+            "events":[]
+          },
+          "permissions":[],
+          "trusts":[],
+          "extra":{}
+        }
+        """);
+        var hash = UInt160.Parse("0x0101010101010101010101010101010101010101");
+        var node = new StubExpressNode(ProtocolSettings.Default);
+        node.Contracts.Add((hash, manifest));
+
+        var data = await ContractCommand.Update.ParseUpdateDataAsync(
+            "#SampleContract",
+            node,
+            new ExpressChain());
+
+        data.Should().BeOfType<ContractParameter>()
+            .Which.Value.Should().Be(hash);
+        node.ContractsRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Contract_update_data_skips_the_chain_parser_when_omitted()
+    {
+        var node = new StubExpressNode(ProtocolSettings.Default);
+
+        var data = await ContractCommand.Update.ParseUpdateDataAsync(string.Empty, node, new ExpressChain());
+
+        data.Should().BeNull();
+        node.ContractsRequested.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task TransferNFT_uses_raw_token_bytes()
     {
         var node = new StubExpressNode(ProtocolSettings.Default);
@@ -216,6 +259,8 @@ public class ExpressNodeExtensionsTests
 
         public List<(UInt160 hash, ContractManifest manifest)> Contracts { get; } = new();
 
+        public bool ContractsRequested { get; private set; }
+
         public Script? CapturedScript { get; private set; }
 
         public UInt256? RequestedBlockHash { get; private set; }
@@ -274,8 +319,11 @@ public class ExpressNodeExtensionsTests
         public Task<IReadOnlyList<(TokenContract contract, BigInteger balance)>> ListBalancesAsync(UInt160 address) =>
             Task.FromResult<IReadOnlyList<(TokenContract contract, BigInteger balance)>>(SysArray.Empty<(TokenContract contract, BigInteger balance)>());
 
-        public Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync() =>
-            Task.FromResult<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>>(Contracts);
+        public Task<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>> ListContractsAsync()
+        {
+            ContractsRequested = true;
+            return Task.FromResult<IReadOnlyList<(UInt160 hash, ContractManifest manifest)>>(Contracts);
+        }
 
         public Task<IReadOnlyList<string>> ListNftTokenIdsAsync(UInt160 address, UInt160 assetHash) =>
             Task.FromResult<IReadOnlyList<string>>(SysArray.Empty<string>());


### PR DESCRIPTION
## Summary

`contract update --data` and batch `contract update` used `TransactionExecutor.ContractParameterParser`, which only resolves account names — not deployed contract names.

Use `GetContractParameterParserAsync` so `--data` JSON can refer to contracts by name, matching invoke/run.

Independent of #836–#839.