### PR TITLE
fix: default contract download RPC URI to mainnet

### DIFF
--- a/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
+++ b/src/neoxp/Commands/BatchCommand.BatchFileCommands.cs
@@ -137,7 +137,7 @@ namespace NeoExpress.Commands
                     internal string Contract { get; init; } = string.Empty;
 
                     [Argument(1, Description = "URL of Neo JSON-RPC Node\nSpecify MainNet (default), TestNet or JSON-RPC URL")]
-                    internal string RpcUri { get; } = string.Empty;
+                    internal string RpcUri { get; } = "mainnet";
 
                     [Option(Description = "Block height to get contract state for\nZero gets the latest")]
                     internal uint Height { get; } = 0;

--- a/src/neoxp/Commands/ContractCommand.Download.cs
+++ b/src/neoxp/Commands/ContractCommand.Download.cs
@@ -39,7 +39,7 @@ namespace NeoExpress.Commands
             internal string Contract { get; init; } = string.Empty;
 
             [Argument(1, Description = "URL of Neo JSON-RPC Node\nSpecify MainNet (default), TestNet or JSON-RPC URL")]
-            internal string RpcUri { get; } = string.Empty;
+            internal string RpcUri { get; } = "mainnet";
 
             [Option(Description = "Path to neo-express data file")]
             internal string Input { get; init; } = string.Empty;
@@ -51,8 +51,12 @@ namespace NeoExpress.Commands
                 Description = "Replace contract and storage if it already exists\nDefaults to None if option unspecified, All if option value unspecified")]
             internal (bool hasValue, OverwriteForce value) Force { get; init; }
 
+            internal static string NormalizeRpcUri(string rpcUri)
+                => string.IsNullOrWhiteSpace(rpcUri) ? "mainnet" : rpcUri;
+
             internal static async Task ExecuteAsync(IExpressNode expressNode, string contract, string rpcUri, uint height, OverwriteForce force, TextWriter writer)
             {
+                rpcUri = NormalizeRpcUri(rpcUri);
                 var (state, storage) = await NodeUtility.DownloadContractStateAsync(contract, rpcUri, height)
                     .ConfigureAwait(false);
                 var storageCount = storage.Count == 1 ? "1 storage record" : $"{storage.Count} storage records";

--- a/test/test.workflowvalidation/ContractDownloadRpcUriTests.cs
+++ b/test/test.workflowvalidation/ContractDownloadRpcUriTests.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractDownloadRpcUriTests.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or https://opensource.org/license/MIT for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using FluentAssertions;
+using NeoExpress.Commands;
+using Xunit;
+
+namespace test.workflowvalidation;
+
+public class ContractDownloadRpcUriTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeRpcUri_defaults_empty_to_mainnet(string? value)
+    {
+        ContractCommand.Download.NormalizeRpcUri(value!).Should().Be("mainnet");
+    }
+
+    [Fact]
+    public void NormalizeRpcUri_keeps_an_explicit_uri()
+    {
+        ContractCommand.Download.NormalizeRpcUri("testnet").Should().Be("testnet");
+        ContractCommand.Download.NormalizeRpcUri("http://localhost:10332").Should().Be("http://localhost:10332");
+    }
+}


### PR DESCRIPTION
## Summary

`contract download` help says MainNet is the default, but `RpcUri` was `\"\"`, so `TryParseRpcUri` failed unless a URI was passed.

Default to `mainnet` (and treat blank the same way) for CLI and batch.

Independent of #836–#839.