### PR TITLE
fix: show transaction for unconfirmed online txs

### DIFF
--- a/src/neoxp/Node/OnlineNode.cs
+++ b/src/neoxp/Node/OnlineNode.cs
@@ -242,9 +242,21 @@ namespace NeoExpress.Node
         {
             var hash = txHash.ToString();
             var response = await rpcClient.GetRawTransactionAsync(hash).ConfigureAwait(false);
-            var log = await rpcClient.GetApplicationLogAsync(hash).ConfigureAwait(false);
+            RpcApplicationLog? log = null;
+            try
+            {
+                log = await rpcClient.GetApplicationLogAsync(hash).ConfigureAwait(false);
+            }
+            catch (RpcException ex) when (IsMissingApplicationLog(ex))
+            {
+                // Mempool / unconfirmed txs have no application log yet.
+            }
+
             return (response.Transaction, log);
         }
+
+        internal static bool IsMissingApplicationLog(RpcException ex)
+            => ex.HResult == -100;
 
         public Task<uint> GetTransactionHeightAsync(UInt256 txHash)
         {

--- a/test/test.workflowvalidation/OnlineNodeTests.cs
+++ b/test/test.workflowvalidation/OnlineNodeTests.cs
@@ -105,6 +105,15 @@ public class OnlineNodeTests
     }
 
     [Fact]
+    public void IsMissingApplicationLog_matches_unknown_transaction_rpc()
+    {
+        OnlineNode.IsMissingApplicationLog(new RpcException(-100, "Unknown transaction/blockhash"))
+            .Should().BeTrue();
+        OnlineNode.IsMissingApplicationLog(new RpcException(-500, "timeout"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
     public void CreatePolicyFailException_explains_default_max_block_system_fee_when_system_fee_is_high()
     {
         var rpcException = new RpcException(OnlineNode.RpcPolicyFailedCode, "Policy check failed");


### PR DESCRIPTION
## Summary

On a running node, `show tx` always called `getapplicationlog`. That RPC throws `-100 Unknown transaction/blockhash` for mempool txs, so unconfirmed hashes failed even though `getrawtransaction` succeeded.

Catch that error and return `(tx, null)`, matching `OfflineNode.GetTransaction`.

Independent of #836–#839.